### PR TITLE
atom.io lazy evaluation

### DIFF
--- a/.changeset/metal-gifts-agree.md
+++ b/.changeset/metal-gifts-agree.md
@@ -1,0 +1,5 @@
+---
+"atom.io": minor
+---
+
+🚀 major performance improvement: selectors no longer eagerly evaluate by default

--- a/packages/atom.io/src/atom.ts
+++ b/packages/atom.io/src/atom.ts
@@ -4,7 +4,7 @@ import * as Rx from "rxjs"
 import type { Serializable } from "~/packages/anvl/src/json"
 import { stringifyJson } from "~/packages/anvl/src/json"
 
-import type { AtomToken, Observe } from "."
+import type { AtomToken, ObserveState } from "."
 import { subscribe, setState } from "."
 import { deposit } from "./internal"
 import type { Store } from "./internal/store"
@@ -39,7 +39,7 @@ export const atom = <T>(
   store.valueMap = HAMT.set(options.key, options.default, store.valueMap)
   const token = deposit(newAtom)
   const setSelf = (next) => setState(token, next, store)
-  const onSet = (observe: Observe<T>) => subscribe(token, observe, store)
+  const onSet = (observe: ObserveState<T>) => subscribe(token, observe, store)
   setSelf(options.default)
   options.effects?.forEach((effect) => effect({ setSelf, onSet }))
   return token

--- a/packages/atom.io/src/index.ts
+++ b/packages/atom.io/src/index.ts
@@ -49,11 +49,11 @@ export const setState = <T, New extends T>(
   finishAction(store)
 }
 
-export type Observe<T> = (change: { newValue: T; oldValue: T }) => void
+export type ObserveState<T> = (change: { newValue: T; oldValue: T }) => void
 
 export const subscribe = <T>(
   token: ReadonlyValueToken<T> | StateToken<T>,
-  observe: Observe<T>,
+  observe: ObserveState<T>,
   store: Store = IMPLICIT.STORE
 ): (() => void) => {
   const state = withdraw<T>(token, store)

--- a/packages/atom.io/src/index.ts
+++ b/packages/atom.io/src/index.ts
@@ -39,11 +39,12 @@ export const getState = <T>(
 }
 
 export const setState = <T, New extends T>(
-  state: StateToken<T>,
+  token: StateToken<T>,
   value: New | ((oldValue: T) => New),
   store: Store = IMPLICIT.STORE
 ): void => {
   startAction(store)
+  const state = withdraw(token, store)
   setState__INTERNAL(state, value, store)
   finishAction(store)
 }

--- a/packages/atom.io/src/index.ts
+++ b/packages/atom.io/src/index.ts
@@ -59,11 +59,18 @@ export const subscribe = <T>(
 ): (() => void) => {
   const state = withdraw<T>(token, store)
   const subscription = state.subject.subscribe(observe)
+  store.config.logger?.info(`👀 subscribe to "${state.key}"`)
   const dependencySubscriptions = subscribeToRootAtoms(state, store)
   const unsubscribe =
     dependencySubscriptions === null
-      ? () => subscription.unsubscribe()
+      ? () => {
+          store.config.logger?.info(`🙈 unsubscribe from "${state.key}"`)
+          subscription.unsubscribe()
+        }
       : () => {
+          store.config.logger?.info(
+            `🙈 unsubscribe from "${state.key}" and its dependencies`
+          )
           subscription.unsubscribe()
           for (const dependencySubscription of dependencySubscriptions) {
             dependencySubscription.unsubscribe()

--- a/packages/atom.io/src/internal/get.ts
+++ b/packages/atom.io/src/internal/get.ts
@@ -95,11 +95,11 @@ export const getState__INTERNAL = <T>(
   store: Store = IMPLICIT.STORE
 ): T => {
   if (HAMT.has(state.key, store.valueMap)) {
-    store.config.logger?.info(`   💬 read "${state.key}"`)
+    store.config.logger?.info(`>> read "${state.key}"`)
     return getCachedState(state, store)
   }
   if (`get` in state) {
-    store.config.logger?.info(`   🧮 calc "${state.key}"`)
+    store.config.logger?.info(`-> calc "${state.key}"`)
     return getSelectorState(state)
   }
   store.config.logger?.error(

--- a/packages/atom.io/src/internal/get.ts
+++ b/packages/atom.io/src/internal/get.ts
@@ -68,7 +68,8 @@ export function deposit<T>(
 
 export const getState__INTERNAL = <T>(
   state: Atom<T> | ReadonlySelector<T> | Selector<T>,
-  store: Store = IMPLICIT.STORE
+  store: Store = IMPLICIT.STORE,
+  path: string[] = []
 ): T => {
   if (HAMT.has(state.key, store.valueMap)) {
     return getCachedState(state, store)

--- a/packages/atom.io/src/internal/get.ts
+++ b/packages/atom.io/src/internal/get.ts
@@ -1,3 +1,4 @@
+import { pipe } from "fp-ts/function"
 import HAMT from "hamt_plus"
 
 import type { Atom, ReadonlySelector, Selector } from "."
@@ -14,6 +15,17 @@ export const getCachedState = <T>(
   state: Atom<T> | ReadonlySelector<T> | Selector<T>,
   store: Store = IMPLICIT.STORE
 ): T => {
+  const path = []
+  if (`default` in state) {
+    const atomKey = state.key
+    store.selectorAtoms = pipe(store.selectorAtoms, (oldValue) => {
+      let newValue = oldValue
+      for (const selectorKey of path) {
+        newValue = newValue.set(selectorKey, atomKey)
+      }
+      return newValue
+    })
+  }
   const value = HAMT.get(state.key, store.valueMap)
   return value
 }
@@ -21,6 +33,18 @@ export const getCachedState = <T>(
 export const getSelectorState = <T>(
   selector: ReadonlySelector<T> | Selector<T>
 ): T => selector.get()
+
+export function lookup(
+  key: string,
+  store: Store
+): AtomToken<unknown> | ReadonlyValueToken<unknown> | SelectorToken<unknown> {
+  const type = HAMT.has(key, store.atoms)
+    ? `atom`
+    : HAMT.has(key, store.selectors)
+    ? `selector`
+    : `readonly_selector`
+  return { key, type }
+}
 
 export function withdraw<T>(token: AtomToken<T>, store: Store): Atom<T>
 export function withdraw<T>(token: SelectorToken<T>, store: Store): Selector<T>
@@ -68,13 +92,14 @@ export function deposit<T>(
 
 export const getState__INTERNAL = <T>(
   state: Atom<T> | ReadonlySelector<T> | Selector<T>,
-  store: Store = IMPLICIT.STORE,
-  path: string[] = []
+  store: Store = IMPLICIT.STORE
 ): T => {
   if (HAMT.has(state.key, store.valueMap)) {
+    store.config.logger?.info(`   💬 read "${state.key}"`)
     return getCachedState(state, store)
   }
   if (`get` in state) {
+    store.config.logger?.info(`   🧮 calc "${state.key}"`)
     return getSelectorState(state)
   }
   store.config.logger?.error(

--- a/packages/atom.io/src/internal/index.ts
+++ b/packages/atom.io/src/internal/index.ts
@@ -2,7 +2,9 @@ import type * as Rx from "rxjs"
 
 export * from "./get"
 export * from "./set"
+export * from "./selector-internal"
 export * from "./store"
+export * from "./subscribe-internal"
 export * from "./operation"
 export * from "./transaction-internal"
 

--- a/packages/atom.io/src/internal/operation.ts
+++ b/packages/atom.io/src/internal/operation.ts
@@ -10,11 +10,11 @@ export const startAction = (store: Store): void => {
     done: new Set(),
     prev: store.valueMap,
   }
-  store.config.logger?.info(`☐`, `operation start`)
+  store.config.logger?.info(`⭕`, `operation start`)
 }
 export const finishAction = (store: Store): void => {
   store.operation = { open: false }
-  store.config.logger?.info(`☑️`, `operation done`)
+  store.config.logger?.info(`🔴`, `operation done`)
 }
 
 export const isDone = (key: string, store: Store = IMPLICIT.STORE): boolean => {

--- a/packages/atom.io/src/internal/operation.ts
+++ b/packages/atom.io/src/internal/operation.ts
@@ -35,7 +35,7 @@ export const markDone = (key: string, store: Store = IMPLICIT.STORE): void => {
   }
   store.operation.done.add(key)
 }
-export const recall = <T>(
+export const recallState = <T>(
   state: Atom<T> | ReadonlySelector<T> | Selector<T>,
   store: Store = IMPLICIT.STORE
 ): T => {

--- a/packages/atom.io/src/internal/selector-internal.ts
+++ b/packages/atom.io/src/internal/selector-internal.ts
@@ -1,0 +1,114 @@
+import type { Store } from "."
+import {
+  lookup,
+  IMPLICIT,
+  getState__INTERNAL,
+  setState__INTERNAL,
+  withdraw,
+} from "."
+import type {
+  AtomToken,
+  ReadonlyValueToken,
+  SelectorToken,
+  StateToken,
+} from ".."
+import type { Transactors } from "../transaction"
+
+export const lookupSelectorSources = (
+  key: string,
+  store: Store
+): (
+  | AtomToken<unknown>
+  | ReadonlyValueToken<unknown>
+  | SelectorToken<unknown>
+)[] =>
+  store.selectorGraph
+    .getRelations(key)
+    .filter(({ source }) => source !== key)
+    .map(({ source }) => lookup(source, store))
+
+export const traceSelectorRoots = (
+  selectorKey: string,
+  dependency: ReadonlyValueToken<unknown> | StateToken<unknown>,
+  store: Store
+): AtomToken<unknown>[] => {
+  const roots: AtomToken<unknown>[] = []
+
+  const sources = lookupSelectorSources(dependency.key, store)
+  let depth = 0
+  while (sources.length > 0) {
+    ++depth
+    if (depth > 999) {
+      throw new Error(
+        `Maximum selector dependency depth exceeded in selector "${selectorKey}".`
+      )
+    }
+    /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+    const source = sources.shift()!
+    if (source.type !== `atom`) {
+      sources.push(...lookupSelectorSources(source.key, store))
+    } else {
+      roots.push(source)
+    }
+  }
+
+  return roots
+}
+
+export const updateSelectorAtoms = (
+  selectorKey: string,
+  dependency: ReadonlyValueToken<unknown> | StateToken<unknown>,
+  store: Store
+): void => {
+  if (dependency.type === `atom`) {
+    store.selectorAtoms = store.selectorAtoms.set(selectorKey, dependency.key)
+    store.config.logger?.info(
+      `   || adding root for "${selectorKey}": ${dependency.key}`
+    )
+    return
+  }
+  const roots = traceSelectorRoots(selectorKey, dependency, store)
+  store.config.logger?.info(`   || adding roots for "${selectorKey}":`, roots)
+  for (const root of roots) {
+    store.selectorAtoms = store.selectorAtoms.set(selectorKey, root.key)
+  }
+}
+
+export const registerSelector = (
+  selectorKey: string,
+  store: Store = IMPLICIT.STORE
+): Transactors => ({
+  get: (dependency) => {
+    const alreadyRegistered = store.selectorGraph
+      .getRelations(selectorKey)
+      .some(({ source }) => source === dependency.key)
+
+    const dependencyState = withdraw(dependency, store)
+    const dependencyValue = getState__INTERNAL(dependencyState, store)
+
+    if (alreadyRegistered) {
+      store.config.logger?.info(
+        `   || ${selectorKey} <- ${dependency.key} =`,
+        dependencyValue
+      )
+    } else {
+      store.config.logger?.info(
+        `🔌 registerSelector "${selectorKey}" <- "${dependency.key}" =`,
+        dependencyValue
+      )
+      store.selectorGraph = store.selectorGraph.set(
+        selectorKey,
+        dependency.key,
+        {
+          source: dependency.key,
+        }
+      )
+    }
+    updateSelectorAtoms(selectorKey, dependency, store)
+    return dependencyValue
+  },
+  set: (stateToken, newValue) => {
+    const state = withdraw(stateToken, store)
+    setState__INTERNAL(state, newValue, store)
+  },
+})

--- a/packages/atom.io/src/internal/set.ts
+++ b/packages/atom.io/src/internal/set.ts
@@ -3,11 +3,10 @@ import HAMT from "hamt_plus"
 import { become } from "~/packages/anvl/src/function"
 
 import type { Atom, Selector } from "."
-import { withdraw, getState__INTERNAL } from "./get"
+import { getState__INTERNAL } from "./get"
 import { isDone, recall, markDone } from "./operation"
 import type { Store } from "./store"
 import { IMPLICIT } from "./store"
-import type { StateToken } from ".."
 
 export const propagateDown = <T>(
   state: Atom<T> | Selector<T>,
@@ -28,7 +27,7 @@ export const propagateDown = <T>(
       store.config.logger?.info(`   || ${stateKey} already done`)
       return
     }
-    store.config.logger?.info(`-> bumping ${stateKey}`)
+    store.config.logger?.info(`-> bumping "${stateKey}"`)
     const state =
       HAMT.get(stateKey, store.selectors) ??
       HAMT.get(stateKey, store.readonlySelectors)
@@ -40,7 +39,7 @@ export const propagateDown = <T>(
     }
     store.valueMap = HAMT.remove(stateKey, store.valueMap)
     const newValue = getState__INTERNAL(state, store)
-    store.config.logger?.info(`   <- ${stateKey} became ${newValue}`)
+    store.config.logger?.info(`   <- ${stateKey} became`, newValue)
     const oldValue = recall(state, store)
     state.subject.next({ newValue, oldValue })
     markDone(stateKey, store)

--- a/packages/atom.io/src/internal/set.ts
+++ b/packages/atom.io/src/internal/set.ts
@@ -80,28 +80,17 @@ export const setSelectorState = <T>(
   const oldValue = getState__INTERNAL(selector, store)
   const newValue = become(next)(oldValue)
 
-  store.config.logger?.info(
-    `->`,
-    `setting selector`,
-    `"${selector.key}"`,
-    `to`,
-    newValue
-  )
-  store.config.logger?.info(
-    `   ||`,
-    `propagating change made to`,
-    `"${selector.key}"`
-  )
+  store.config.logger?.info(`-> setting selector "${selector.key}" to`, newValue)
+  store.config.logger?.info(`   || propagating change made to "${selector.key}"`)
 
   selector.set(newValue)
   propagateDown(selector, store)
 }
 export const setState__INTERNAL = <T>(
-  token: StateToken<T>,
+  state: Atom<T> | Selector<T>,
   value: T | ((oldValue: T) => T),
   store: Store = IMPLICIT.STORE
 ): void => {
-  const state = withdraw<T>(token, store)
   if (`set` in state) {
     setSelectorState(state, value, store)
   } else {

--- a/packages/atom.io/src/internal/set.ts
+++ b/packages/atom.io/src/internal/set.ts
@@ -9,11 +9,10 @@ import type { Store } from "./store"
 import { IMPLICIT } from "./store"
 
 export const evictDownStream = <T>(
-  state: Atom<T> | Selector<T>,
+  state: Atom<T>,
   store: Store = IMPLICIT.STORE
 ): void => {
-  const stateRelations = store.selectorGraph.getRelations(state.key)
-  const downstream = stateRelations.filter(({ source }) => source === state.key)
+  const downstream = store.selectorAtoms.getRelations(state.key)
   const downstreamKeys = downstream.map(({ id }) => id)
   store.config.logger?.info(
     `   || ${downstreamKeys.length} downstream:`,
@@ -40,7 +39,6 @@ export const evictDownStream = <T>(
     store.config.logger?.info(`   xx evicted "${stateKey}"`)
 
     markDone(stateKey, store)
-    if (`set` in state) evictDownStream(state, store)
   })
 }
 
@@ -72,7 +70,6 @@ export const setSelectorState = <T>(
   store.config.logger?.info(`   || propagating change made to "${selector.key}"`)
 
   selector.set(newValue)
-  evictDownStream(selector, store)
 }
 export const setState__INTERNAL = <T>(
   state: Atom<T> | Selector<T>,

--- a/packages/atom.io/src/internal/store.ts
+++ b/packages/atom.io/src/internal/store.ts
@@ -8,6 +8,7 @@ import type { Atom, ReadonlySelector, Selector } from "."
 export interface Store {
   valueMap: Hamt<any, string>
   selectorGraph: Join<{ source: string }>
+  selectorAtoms: Join
   selectors: Hamt<Selector<any>, string>
   readonlySelectors: Hamt<ReadonlySelector<any>, string>
   atoms: Hamt<Atom<any>, string>
@@ -45,6 +46,7 @@ export const createStore = (name: string): Store =>
   ({
     valueMap: HAMT.make<any, string>(),
     selectorGraph: new Join({ relationType: `n:n` }),
+    selectorAtoms: new Join({ relationType: `n:n` }),
     atoms: HAMT.make<Atom<any>, string>(),
     selectors: HAMT.make<Selector<any>, string>(),
     readonlySelectors: HAMT.make<ReadonlySelector<any>, string>(),

--- a/packages/atom.io/src/internal/subscribe-internal.ts
+++ b/packages/atom.io/src/internal/subscribe-internal.ts
@@ -1,0 +1,33 @@
+import type { Atom, ReadonlySelector, Selector } from "."
+import { getState__INTERNAL, withdraw } from "./get"
+import { recallState } from "./operation"
+import { traceAllSelectorAtoms } from "./selector-internal"
+import type { Store } from "./store"
+import { IMPLICIT } from "./store"
+import { __INTERNAL__ } from ".."
+
+export const subscribeToRootAtoms = <T>(
+  state: Atom<T> | ReadonlySelector<T> | Selector<T>,
+  store: Store = IMPLICIT.STORE
+): { unsubscribe: () => void }[] | null => {
+  const dependencySubscriptions =
+    `default` in state
+      ? null
+      : traceAllSelectorAtoms(state.key, store).map((atomToken) => {
+          const atom = withdraw(atomToken, store)
+          return atom.subject.subscribe((atomChange) => {
+            store.config.logger?.info(
+              `   !! atom changed: "${atomToken.key}" (`,
+              atomChange.oldValue,
+              `->`,
+              atomChange.newValue,
+              `) re-evaluating "${state.key}"`
+            )
+            const oldValue = recallState(state, store)
+            const newValue = getState__INTERNAL(state, store)
+            store.config.logger?.info(`   <- ${state.key} became`, newValue)
+            state.subject.next({ newValue, oldValue })
+          })
+        })
+  return dependencySubscriptions
+}

--- a/packages/atom.io/src/internal/subscribe-internal.ts
+++ b/packages/atom.io/src/internal/subscribe-internal.ts
@@ -17,7 +17,7 @@ export const subscribeToRootAtoms = <T>(
           const atom = withdraw(atomToken, store)
           return atom.subject.subscribe((atomChange) => {
             store.config.logger?.info(
-              `   !! atom changed: "${atomToken.key}" (`,
+              `📢 atom changed: "${atomToken.key}" (`,
               atomChange.oldValue,
               `->`,
               atomChange.newValue,

--- a/packages/atom.io/src/selector.ts
+++ b/packages/atom.io/src/selector.ts
@@ -5,18 +5,9 @@ import { become } from "~/packages/anvl/src/function"
 import type { Serializable } from "~/packages/anvl/src/json"
 import { stringifyJson } from "~/packages/anvl/src/json"
 
-import type { AtomToken, ReadonlyValueToken, SelectorToken, StateToken } from "."
+import type { ReadonlyValueToken, SelectorToken } from "."
 import type { Selector, Store } from "./internal"
-import {
-  lookup,
-  IMPLICIT,
-  getState__INTERNAL,
-  setState__INTERNAL,
-  withdraw,
-  markDone,
-  deposit,
-} from "./internal"
-import { registerSelector } from "./internal/selector-internal"
+import { IMPLICIT, markDone, deposit, registerSelector } from "./internal"
 import type { ReadonlyTransactors, Transactors } from "./transaction"
 
 export type SelectorOptions<T> = {

--- a/packages/atom.io/test/atom-selector.test.ts
+++ b/packages/atom.io/test/atom-selector.test.ts
@@ -95,12 +95,16 @@ describe(`selector`, () => {
     const doublePlusOne = selector<number>({
       key: `doublePlusOne`,
       get: ({ get }) => get(double) + 1,
+      set: ({ set }, newValue) => set(double, newValue - 1),
     })
     setState(double, 20)
     expect(getState(count)).toBe(10)
     expect(getState(double)).toBe(20)
     expect(getState(triple)).toBe(30)
     expect(getState(doublePlusOne)).toBe(21)
+
+    setState(doublePlusOne, 43)
+    expect(getState(count)).toBe(21)
   })
   it(`may depend on more than one atom or selector`, () => {
     const firstNameState = atom<string>({

--- a/packages/atom.io/test/lazy.test.ts
+++ b/packages/atom.io/test/lazy.test.ts
@@ -1,0 +1,73 @@
+import { vitest } from "vitest"
+
+import * as UTIL from "./-util"
+import {
+  __INTERNAL__,
+  atom,
+  configure,
+  selector,
+  setState,
+  subscribe,
+} from "../src"
+import { withdraw } from "../src/internal"
+
+const loggers = [UTIL.silence, console] as const
+const choose = 1
+const logger = loggers[choose]
+
+configure({ logger })
+
+beforeEach(() => {
+  __INTERNAL__.clearStore()
+  vitest.spyOn(logger, `error`)
+  vitest.spyOn(logger, `warn`)
+  vitest.spyOn(logger, `info`)
+  vitest.spyOn(UTIL, `stdout`)
+})
+
+describe(`lazy propagation system`, () => {
+  test(`on subscribe, selectors in turn subscribe to their root atoms`, () => {
+    const a = atom({
+      key: `a`,
+      default: 0,
+    })
+    const s = selector({
+      key: `s`,
+      get: ({ get }) => get(a) * 10,
+    })
+    const s0 = selector({
+      key: `s0`,
+      get: ({ get }) => get(s) * 10,
+    })
+    subscribe(s, UTIL.stdout)
+    subscribe(s0, UTIL.stdout)
+    const myAtom = withdraw(a, __INTERNAL__.IMPLICIT.STORE)
+    const mySelector = withdraw(s, __INTERNAL__.IMPLICIT.STORE)
+    const mySelector0 = withdraw(s0, __INTERNAL__.IMPLICIT.STORE)
+    expect(myAtom.subject.observers.length).toBe(2)
+    expect(mySelector.subject.observers.length).toBe(1)
+    expect(mySelector0.subject.observers.length).toBe(1)
+    setState(a, 1)
+    expect(UTIL.stdout).not.toHaveBeenCalledWith({ newValue: 1, oldValue: 0 })
+    expect(UTIL.stdout).toHaveBeenCalledWith({ newValue: 10, oldValue: 0 })
+    expect(UTIL.stdout).toHaveBeenCalledWith({ newValue: 100, oldValue: 0 })
+  })
+  test(`subscriptions are cleaned up when in a domino effect`, () => {
+    const a = atom({
+      key: `a`,
+      default: 0,
+    })
+    const s = selector({
+      key: `s`,
+      get: ({ get }) => get(a) * 10,
+    })
+    const unsubscribe = subscribe(s, UTIL.stdout)
+    const myAtom = withdraw(a, __INTERNAL__.IMPLICIT.STORE)
+    const mySelector = withdraw(s, __INTERNAL__.IMPLICIT.STORE)
+    expect(myAtom.subject.observers.length).toBe(1)
+    expect(mySelector.subject.observers.length).toBe(1)
+    unsubscribe()
+    expect(myAtom.subject.observers.length).toBe(0)
+    expect(mySelector.subject.observers.length).toBe(0)
+  })
+})


### PR DESCRIPTION
- ♻️ internal refactors
- ✨ track selectorAtoms
- 🎨 arrange for readability
- 🚀 don't preemptively compute, just evict and notify
- 🐛 use selectorAtoms not selectorGraph in propagateDown
- ✅ test subscription system
- ✅ test deferred selector evaluation
- 🦋
