### PR TITLE
atom.io optimize and organize

### DIFF
--- a/.changeset/brave-islands-study.md
+++ b/.changeset/brave-islands-study.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+💥 Remove unused `isDefault` function.

--- a/.changeset/good-mails-build.md
+++ b/.changeset/good-mails-build.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 Selectors are no longer computed twice!

--- a/.changeset/lovely-elephants-call.md
+++ b/.changeset/lovely-elephants-call.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🥅 Automatically catch and log errors from rejected promises set into state.

--- a/.changeset/spotty-hornets-cry.md
+++ b/.changeset/spotty-hornets-cry.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+`atom.io/internal`: withdraw may return undefined now, not null.

--- a/.changeset/young-suns-beam.md
+++ b/.changeset/young-suns-beam.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+`atom.io/internal`: openOperation no longer throws, but may return a string signaling the rejection of the action, due to an operation currently being open.

--- a/packages/atom.io/__tests__/async-state.test.ts
+++ b/packages/atom.io/__tests__/async-state.test.ts
@@ -13,8 +13,7 @@ beforeEach(() => {
 
 describe(`async atom`, async () => {
 	it(`hits the subscriber twice`, async () => {
-		type Loadable<T> = Promise<T> | T
-		const count = AtomIO.atom<Loadable<number>>({
+		const count = AtomIO.atom<Internal.Loadable<number>>({
 			key: `count`,
 			default: 0,
 		})
@@ -29,6 +28,24 @@ describe(`async atom`, async () => {
 		const countValueAwaited = await AtomIO.getState(count)
 		expect(countValueAwaited).toBe(1)
 		expect(Utils.stdout).toHaveBeenCalledTimes(2)
+	})
+	it(`handles a rejected promise`, async () => {
+		const count = AtomIO.atom<Internal.Loadable<number>>({
+			key: `count`,
+			default: 0,
+		})
+		AtomIO.subscribe(count, ({ newValue, oldValue }) => {
+			Utils.stdout(`count`, { newValue, oldValue })
+		})
+		const getNumber = async (): Promise<number> => {
+			throw new Error(`😤`)
+		}
+		AtomIO.setState(count, getNumber())
+		const countValueInitial = AtomIO.getState(count)
+		expect(countValueInitial).toBeInstanceOf(Promise)
+		expect(countValueInitial).toBeInstanceOf(Internal.Future)
+
+		expect(Utils.stdout).toHaveBeenCalledTimes(1)
 	})
 })
 

--- a/packages/atom.io/__tests__/atom-selector.test.ts
+++ b/packages/atom.io/__tests__/atom-selector.test.ts
@@ -3,7 +3,6 @@ import { vitest } from "vitest"
 import {
 	atom,
 	getState,
-	isDefault,
 	selector,
 	setLogLevel,
 	setState,
@@ -61,11 +60,9 @@ describe(`atom`, () => {
 			default: () => ({ 0: 0, 1: 0, 2: 0 }),
 		})
 		expect(getState(stats)).toStrictEqual({ 0: 0, 1: 0, 2: 0 })
-		expect(isDefault(stats)).toBe(true)
 
 		setState(stats, { 0: 1, 1: 0, 2: 0 })
 		expect(getState(stats)).toStrictEqual({ 0: 1, 1: 0, 2: 0 })
-		expect(isDefault(stats)).toBe(false)
 	})
 })
 
@@ -184,10 +181,8 @@ describe(`selector`, () => {
 			get: ({ get }) => get(count) * 2,
 		})
 		expect(getState(double)).toBe(0)
-		expect(isDefault(double)).toBe(true)
 
 		setState(count, 1)
 		expect(getState(double)).toBe(2)
-		expect(isDefault(double)).toBe(false)
 	})
 })

--- a/packages/atom.io/__tests__/react-useStore.test.tsx
+++ b/packages/atom.io/__tests__/react-useStore.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render } from "@testing-library/react"
 import * as AR from "atom.io/react"
 import type { FC } from "react"
 
-import { atom, isDefault } from "atom.io"
+import { atom } from "atom.io"
 import { Observer } from "./__util__/Observer"
 
 export const onChange = [() => undefined, console.log][0]
@@ -16,11 +16,9 @@ describe(`single atom`, () => {
 		const Letter: FC = () => {
 			const setLetter = AR.useI(letterState)
 			const letter = AR.useO(letterState)
-			const isDefaultLetter = isDefault(letterState)
 			return (
 				<>
 					<div data-testid={letter}>{letter}</div>
-					<div data-testid={isDefaultLetter}>{isDefaultLetter}</div>
 					<button
 						type="button"
 						onClick={() => setLetter(`B`)}
@@ -40,11 +38,9 @@ describe(`single atom`, () => {
 
 	it(`accepts user input with externally managed state`, () => {
 		const { getByTestId } = scenario()
-		expect(getByTestId(`true`)).toBeTruthy()
 		const changeStateButton = getByTestId(`changeStateButton`)
 		fireEvent.click(changeStateButton)
 		const option = getByTestId(`B`)
 		expect(option).toBeTruthy()
-		expect(getByTestId(`false`)).toBeTruthy()
 	})
 })

--- a/packages/atom.io/internal/src/caching.ts
+++ b/packages/atom.io/internal/src/caching.ts
@@ -18,10 +18,17 @@ export const cacheValue = (
 	if (value instanceof Promise) {
 		const future = new Future(value)
 		target(store).valueMap.set(key, future)
-		future.then((value) => {
-			cacheValue(key, value, subject, store)
-			subject.next({ newValue: value, oldValue: value })
-		})
+		future
+			.then((value) => {
+				cacheValue(key, value, subject, store)
+				subject.next({ newValue: value, oldValue: value })
+			})
+			.catch((error) => {
+				store.config.logger?.error(
+					`Promised value for "${key}" rejected:`,
+					error,
+				)
+			})
 	} else {
 		target(store).valueMap.set(key, value)
 	}

--- a/packages/atom.io/internal/src/caching.ts
+++ b/packages/atom.io/internal/src/caching.ts
@@ -1,4 +1,4 @@
-import type { StateUpdate } from "../../src"
+import type { StateUpdate } from "atom.io"
 import { Future } from "./future"
 import type { Store } from "./store"
 import { IMPLICIT } from "./store"

--- a/packages/atom.io/internal/src/future.ts
+++ b/packages/atom.io/internal/src/future.ts
@@ -1,7 +1,5 @@
-import { E } from "vitest/dist/reporters-5f784f42"
-
-export type Eventual<T> = Promise<T> | T
-export type Fated<T, E extends Error = Error> = Eventual<E | T>
+export type Loadable<T> = Promise<T> | T
+export type Fated<T, E extends Error = Error> = Loadable<E | T>
 
 /**
  * A Promise that can be canceled.

--- a/packages/atom.io/internal/src/mutable/create-mutable-atom-family.ts
+++ b/packages/atom.io/internal/src/mutable/create-mutable-atom-family.ts
@@ -1,4 +1,4 @@
-import type * as AtomIO from "atom.io"
+import type { MutableAtomFamily, MutableAtomFamilyOptions } from "atom.io"
 import type { Json } from "atom.io/json"
 import { selectJsonFamily } from "atom.io/json"
 
@@ -12,13 +12,13 @@ export function createMutableAtomFamily<
 	SerializableCore extends Json.Serializable,
 	Key extends string,
 >(
-	options: AtomIO.MutableAtomFamilyOptions<Core, SerializableCore, Key>,
+	options: MutableAtomFamilyOptions<Core, SerializableCore, Key>,
 	store: Store = IMPLICIT.STORE,
-): AtomIO.MutableAtomFamily<Core, SerializableCore, Key> {
+): MutableAtomFamily<Core, SerializableCore, Key> {
 	const coreFamily = Object.assign(
 		createAtomFamily<Core, Key>(options, store),
 		options,
-	) as AtomIO.MutableAtomFamily<Core, SerializableCore, Key>
+	) as MutableAtomFamily<Core, SerializableCore, Key>
 	selectJsonFamily(coreFamily, options)
 	new FamilyTracker(coreFamily, store)
 	return coreFamily

--- a/packages/atom.io/internal/src/mutable/create-mutable-atom.ts
+++ b/packages/atom.io/internal/src/mutable/create-mutable-atom.ts
@@ -1,4 +1,5 @@
-import * as AtomIO from "atom.io"
+import type { MutableAtomOptions, MutableAtomToken } from "atom.io"
+import { subscribe } from "atom.io"
 import type { Json } from "atom.io/json"
 import { selectJson } from "atom.io/json"
 
@@ -13,16 +14,16 @@ export function createMutableAtom<
 	Core extends Transceiver<any>,
 	SerializableCore extends Json.Serializable,
 >(
-	options: AtomIO.MutableAtomOptions<Core, SerializableCore>,
+	options: MutableAtomOptions<Core, SerializableCore>,
 	store: Store = IMPLICIT.STORE,
-): AtomIO.MutableAtomToken<Core, SerializableCore> {
+): MutableAtomToken<Core, SerializableCore> {
 	store.config.logger?.info(
 		`🔧 creating mutable atom "${options.key}" in store "${store.config.name}"`,
 	)
 	const coreState = createAtom<Core>(options, undefined, store)
 	new Tracker(coreState, store)
 	const jsonState = selectJson(coreState, options, store)
-	AtomIO.subscribe(
+	subscribe(
 		jsonState,
 		() => {
 			store.config.logger?.info(
@@ -45,5 +46,5 @@ export function createMutableAtom<
 				: store.transactionStatus.key
 		}`,
 	)
-	return coreState as AtomIO.MutableAtomToken<Core, SerializableCore>
+	return coreState as MutableAtomToken<Core, SerializableCore>
 }

--- a/packages/atom.io/internal/src/mutable/is-atom-token-mutable.ts
+++ b/packages/atom.io/internal/src/mutable/is-atom-token-mutable.ts
@@ -1,7 +1,7 @@
-import type * as AtomIO from "atom.io"
+import type { AtomToken, MutableAtomToken } from "atom.io"
 
 export function isAtomTokenMutable(
-	token: AtomIO.AtomToken<any>,
-): token is AtomIO.MutableAtomToken<any, any> {
+	token: AtomToken<any>,
+): token is MutableAtomToken<any, any> {
 	return token.key.endsWith(`::mutable`)
 }

--- a/packages/atom.io/internal/src/mutable/tracker-family.ts
+++ b/packages/atom.io/internal/src/mutable/tracker-family.ts
@@ -1,4 +1,4 @@
-import type * as AtomIO from "atom.io"
+import type { AtomFamily } from "atom.io"
 import type { Json } from "atom.io/json"
 import { parseJson } from "atom.io/json"
 
@@ -16,14 +16,14 @@ export class FamilyTracker<
 		? Signal
 		: never
 
-	public readonly findLatestUpdateState: AtomIO.AtomFamily<
+	public readonly findLatestUpdateState: AtomFamily<
 		typeof this.Update | null,
 		FamilyMemberKey
 	>
-	public readonly findMutableState: AtomIO.AtomFamily<Core, FamilyMemberKey>
+	public readonly findMutableState: AtomFamily<Core, FamilyMemberKey>
 
 	public constructor(
-		findMutableState: AtomIO.AtomFamily<Core, FamilyMemberKey>,
+		findMutableState: AtomFamily<Core, FamilyMemberKey>,
 		store: Store = IMPLICIT.STORE,
 	) {
 		this.findLatestUpdateState = createAtomFamily<

--- a/packages/atom.io/internal/src/operation.ts
+++ b/packages/atom.io/internal/src/operation.ts
@@ -16,13 +16,16 @@ export type OperationProgress =
 			token: StateToken<any>
 	  }
 
-export const openOperation = (token: StateToken<any>, store: Store): void => {
+export const openOperation = (
+	token: StateToken<any>,
+	store: Store,
+): `rejection` | undefined => {
 	const core = target(store)
 	if (core.operation.open) {
 		store.config.logger?.error(
 			`❌ failed to setState to "${token.key}" during a setState for "${core.operation.token.key}"`,
 		)
-		throw Symbol(`violation`)
+		return `rejection`
 	}
 	core.operation = {
 		open: true,

--- a/packages/atom.io/internal/src/selector/create-read-write-selector.ts
+++ b/packages/atom.io/internal/src/selector/create-read-write-selector.ts
@@ -26,14 +26,14 @@ export const createReadWriteSelector = <T>(
 
 	const setSelf = (next: T | ((oldValue: T) => T)): void => {
 		const oldValue = getSelf()
+		const newValue = become(next)(oldValue)
 		store.config.logger?.info(
 			`   <- "${options.key}" went (`,
 			oldValue,
 			`->`,
-			next,
+			newValue,
 			`)`,
 		)
-		const newValue = become(next)(oldValue)
 		cacheValue(options.key, newValue, subject, store)
 		markDone(options.key, store)
 		if (store.transactionStatus.phase === `idle`) {

--- a/packages/atom.io/internal/src/selector/register-selector.ts
+++ b/packages/atom.io/internal/src/selector/register-selector.ts
@@ -18,7 +18,7 @@ export const registerSelector = (
 			.some(([_, { source }]) => source === dependency.key)
 
 		const dependencyState = withdraw(dependency, store)
-		if (dependencyState === null) {
+		if (dependencyState === undefined) {
 			throw new Error(
 				`State "${dependency.key}" not found in this store. Did you forget to initialize with the "atom" or "selector" function?`,
 			)
@@ -51,7 +51,7 @@ export const registerSelector = (
 	},
 	set: (stateToken, newValue) => {
 		const state = withdraw(stateToken, store)
-		if (state === null) {
+		if (state === undefined) {
 			throw new Error(
 				`State "${stateToken.key}" not found in this store. Did you forget to initialize with the "atom" or "selector" function?`,
 			)

--- a/packages/atom.io/internal/src/set-state/set-atom.ts
+++ b/packages/atom.io/internal/src/set-state/set-atom.ts
@@ -11,7 +11,7 @@ import { emitUpdate } from "./emit-update"
 import { evictDownStream } from "./evict-downstream"
 import { stowUpdate } from "./stow-update"
 
-export const setAtomState = <T>(
+export const setAtom = <T>(
 	atom: Atom<T>,
 	next: T | ((oldValue: T) => T),
 	store: Store = IMPLICIT.STORE,

--- a/packages/atom.io/internal/src/set-state/set-selector-state.ts
+++ b/packages/atom.io/internal/src/set-state/set-selector-state.ts
@@ -1,19 +1,8 @@
-import { getState__INTERNAL } from "../get-state-internal"
 import type { Selector } from "../selector"
-import type { Store } from "../store"
-import { IMPLICIT } from "../store"
-import { become } from "./become"
 
 export const setSelectorState = <T>(
 	selector: Selector<T>,
 	next: T | ((oldValue: T) => T),
-	store: Store = IMPLICIT.STORE,
 ): void => {
-	const oldValue = getState__INTERNAL(selector, store)
-	const newValue = become(next)(oldValue)
-
-	store.config.logger?.info(`<< setting selector "${selector.key}" to`, newValue)
-	store.config.logger?.info(`   || propagating change made to "${selector.key}"`)
-
-	selector.set(newValue)
+	selector.set(next)
 }

--- a/packages/atom.io/internal/src/set-state/set-state-internal.ts
+++ b/packages/atom.io/internal/src/set-state/set-state-internal.ts
@@ -2,17 +2,16 @@ import type { Atom } from "../atom"
 import type { Selector } from "../selector"
 import type { Store } from "../store"
 import { IMPLICIT } from "../store"
-import { setAtomState } from "./set-atom-state"
-import { setSelectorState } from "./set-selector-state"
+import { setAtom } from "./set-atom"
 
 export const setState__INTERNAL = <T>(
 	state: Atom<T> | Selector<T>,
 	value: T | ((oldValue: T) => T),
 	store: Store = IMPLICIT.STORE,
 ): void => {
-	if (`set` in state) {
-		setSelectorState(state, value, store)
+	if (state.type === `selector`) {
+		state.set(value)
 	} else {
-		setAtomState(state, value, store)
+		setAtom(state, value, store)
 	}
 }

--- a/packages/atom.io/internal/src/store/withdraw-new-family-member.ts
+++ b/packages/atom.io/internal/src/store/withdraw-new-family-member.ts
@@ -11,23 +11,23 @@ import { target } from "../transaction"
 export function withdrawNewFamilyMember<T>(
 	token: AtomToken<T>,
 	store: Store,
-): Atom<T> | null
+): Atom<T> | undefined
 export function withdrawNewFamilyMember<T>(
 	token: SelectorToken<T>,
 	store: Store,
-): Selector<T> | null
+): Selector<T> | undefined
 export function withdrawNewFamilyMember<T>(
 	token: ReadonlySelectorToken<T>,
 	store: Store,
-): ReadonlySelector<T> | null
+): ReadonlySelector<T> | undefined
 export function withdrawNewFamilyMember<T>(
 	token: StateToken<T>,
 	store: Store,
-): Atom<T> | Selector<T> | null
+): Atom<T> | Selector<T> | undefined
 export function withdrawNewFamilyMember<T>(
 	token: ReadonlySelectorToken<T> | StateToken<T>,
 	store: Store,
-): Atom<T> | ReadonlySelector<T> | Selector<T> | null
+): Atom<T> | ReadonlySelector<T> | Selector<T> | undefined
 export function withdrawNewFamilyMember<T>(
 	token:
 		| AtomToken<T>
@@ -35,7 +35,7 @@ export function withdrawNewFamilyMember<T>(
 		| SelectorToken<T>
 		| StateToken<T>,
 	store: Store,
-): Atom<T> | ReadonlySelector<T> | Selector<T> | null {
+): Atom<T> | ReadonlySelector<T> | Selector<T> | undefined {
 	store.config.logger?.info(
 		`👪 creating new family member "${token.key}" in store "${store.config.name}"`,
 	)
@@ -49,5 +49,5 @@ export function withdrawNewFamilyMember<T>(
 			return state
 		}
 	}
-	return null
+	return undefined
 }

--- a/packages/atom.io/internal/src/store/withdraw.ts
+++ b/packages/atom.io/internal/src/store/withdraw.ts
@@ -16,28 +16,34 @@ import type { Transaction } from "../transaction"
 import { target } from "../transaction"
 import type { Store } from "./store"
 
-export function withdraw<T>(token: AtomToken<T>, store: Store): Atom<T> | null
+export function withdraw<T>(
+	token: AtomToken<T>,
+	store: Store,
+): Atom<T> | undefined
 export function withdraw<T>(
 	token: SelectorToken<T>,
 	store: Store,
-): Selector<T> | null
+): Selector<T> | undefined
 export function withdraw<T>(
 	token: StateToken<T>,
 	store: Store,
-): Atom<T> | Selector<T> | null
+): Atom<T> | Selector<T> | undefined
 export function withdraw<T>(
 	token: ReadonlySelectorToken<T>,
 	store: Store,
-): ReadonlySelector<T> | null
+): ReadonlySelector<T> | undefined
 export function withdraw<T>(
 	token: TransactionToken<T>,
 	store: Store,
-): Transaction<T extends ƒn ? T : never> | null
+): Transaction<T extends ƒn ? T : never> | undefined
 export function withdraw<T>(
 	token: ReadonlySelectorToken<T> | StateToken<T>,
 	store: Store,
-): Atom<T> | ReadonlySelector<T> | Selector<T> | null
-export function withdraw<T>(token: TimelineToken, store: Store): Timeline | null
+): Atom<T> | ReadonlySelector<T> | Selector<T> | undefined
+export function withdraw<T>(
+	token: TimelineToken,
+	store: Store,
+): Timeline | undefined
 export function withdraw<T>(
 	token:
 		| ReadonlySelectorToken<T>
@@ -51,7 +57,7 @@ export function withdraw<T>(
 	| Selector<T>
 	| Timeline
 	| Transaction<T extends ƒn ? T : never>
-	| null {
+	| undefined {
 	let core = target(store)
 	let state =
 		core.atoms.get(token.key) ??
@@ -109,5 +115,5 @@ export function withdraw<T>(
 			return state
 		}
 	}
-	return null
+	return undefined
 }

--- a/packages/atom.io/internal/src/subscribe/subscribe-to-root-atoms.ts
+++ b/packages/atom.io/internal/src/subscribe/subscribe-to-root-atoms.ts
@@ -14,7 +14,7 @@ export const subscribeToRootAtoms = <T>(
 			? null
 			: traceAllSelectorAtoms(state.key, store).map((atomToken) => {
 					const atom = withdraw(atomToken, store)
-					if (atom === null) {
+					if (atom === undefined) {
 						throw new Error(
 							`Atom "${atomToken.key}", a dependency of selector "${state.key}", not found in store "${store.config.name}".`,
 						)

--- a/packages/atom.io/internal/src/timeline/add-atom-to-timeline.ts
+++ b/packages/atom.io/internal/src/timeline/add-atom-to-timeline.ts
@@ -15,7 +15,7 @@ export const addAtomToTimeline = (
 	store: Store = IMPLICIT.STORE,
 ): void => {
 	const atom = withdraw(atomToken, store)
-	if (atom === null) {
+	if (atom === undefined) {
 		throw new Error(
 			`Cannot subscribe to atom "${atomToken.key}" because it has not been initialized in store "${store.config.name}"`,
 		)
@@ -67,7 +67,7 @@ export const addAtomToTimeline = (
 					{ key: currentTransactionKey, type: `transaction` },
 					store,
 				)
-				if (currentTransaction === null) {
+				if (currentTransaction === undefined) {
 					throw new Error(
 						`Transaction "${currentTransactionKey}" not found in store "${store.config.name}". This is surprising, because we are in the application phase of "${currentTransactionKey}".`,
 					)

--- a/packages/atom.io/internal/src/transaction/apply-transaction.ts
+++ b/packages/atom.io/internal/src/transaction/apply-transaction.ts
@@ -48,7 +48,7 @@ export const applyTransaction = <ƒ extends ƒn>(
 		{ key: store.transactionStatus.key, type: `transaction` },
 		store,
 	)
-	if (myTransaction === null) {
+	if (myTransaction === undefined) {
 		throw new Error(
 			`Transaction "${store.transactionStatus.key}" not found. Absurd. How is this running?`,
 		)

--- a/packages/atom.io/internal/src/transaction/redo-transaction.ts
+++ b/packages/atom.io/internal/src/transaction/redo-transaction.ts
@@ -12,7 +12,7 @@ export const redoTransactionUpdate = <ƒ extends ƒn>(
 	for (const { key, newValue } of update.atomUpdates) {
 		const token: AtomToken<unknown> = { key, type: `atom` }
 		const state = withdraw(token, store)
-		if (state === null) {
+		if (state === undefined) {
 			throw new Error(
 				`State "${token.key}" not found in this store. This is surprising, because we are navigating the history of the store.`,
 			)

--- a/packages/atom.io/internal/src/transaction/undo-transaction.ts
+++ b/packages/atom.io/internal/src/transaction/undo-transaction.ts
@@ -12,7 +12,7 @@ export const undoTransactionUpdate = <ƒ extends ƒn>(
 	for (const { key, oldValue } of update.atomUpdates) {
 		const token: AtomToken<unknown> = { key, type: `atom` }
 		const state = withdraw(token, store)
-		if (state === null) {
+		if (state === undefined) {
 			throw new Error(
 				`State "${token.key}" not found in this store. This is surprising, because we are navigating the history of the store.`,
 			)

--- a/packages/atom.io/src/get-set.ts
+++ b/packages/atom.io/src/get-set.ts
@@ -1,0 +1,49 @@
+import * as Internal from "atom.io/internal"
+import type { ReadonlySelectorToken, StateToken } from "."
+
+export const capitalize = (str: string): string =>
+	str[0].toUpperCase() + str.slice(1)
+
+export const getState = <T>(
+	token: ReadonlySelectorToken<T> | StateToken<T>,
+	store: Internal.Store = Internal.IMPLICIT.STORE,
+): T => {
+	const state =
+		Internal.withdraw(token, store) ??
+		Internal.withdrawNewFamilyMember(token, store)
+	if (state === null) {
+		throw new Error(
+			`${capitalize(token.type)} "${token.key}" not found in store "${
+				store.config.name
+			}".`,
+		)
+	}
+	return Internal.getState__INTERNAL(state, store)
+}
+
+export const setState = <T, New extends T>(
+	token: StateToken<T>,
+	value: New | ((oldValue: T) => New),
+	store: Internal.Store = Internal.IMPLICIT.STORE,
+): void => {
+	try {
+		Internal.openOperation(token, store)
+	} catch (thrown) {
+		if (!(typeof thrown === `symbol`)) {
+			throw thrown
+		}
+		return
+	}
+	const state =
+		Internal.withdraw(token, store) ??
+		Internal.withdrawNewFamilyMember(token, store)
+	if (state === null) {
+		throw new Error(
+			`${capitalize(token.type)} "${token.key}" not found in store "${
+				store.config.name
+			}".`,
+		)
+	}
+	Internal.setState__INTERNAL(state, value, store)
+	Internal.closeOperation(store)
+}

--- a/packages/atom.io/src/get-set.ts
+++ b/packages/atom.io/src/get-set.ts
@@ -1,9 +1,6 @@
 import * as Internal from "atom.io/internal"
 import type { ReadonlySelectorToken, StateToken } from "."
 
-export const capitalize = (str: string): string =>
-	str[0].toUpperCase() + str.slice(1)
-
 export const getState = <T>(
 	token: ReadonlySelectorToken<T> | StateToken<T>,
 	store: Internal.Store = Internal.IMPLICIT.STORE,
@@ -12,11 +9,7 @@ export const getState = <T>(
 		Internal.withdraw(token, store) ??
 		Internal.withdrawNewFamilyMember(token, store)
 	if (state === undefined) {
-		throw new Error(
-			`${capitalize(token.type)} "${token.key}" not found in store "${
-				store.config.name
-			}".`,
-		)
+		throw new NotFoundError(token, store)
 	}
 	return Internal.getState__INTERNAL(state, store)
 }
@@ -34,12 +27,22 @@ export const setState = <T, New extends T>(
 		Internal.withdraw(token, store) ??
 		Internal.withdrawNewFamilyMember(token, store)
 	if (state === undefined) {
-		throw new Error(
+		throw new NotFoundError(token, store)
+	}
+	Internal.setState__INTERNAL(state, value, store)
+	Internal.closeOperation(store)
+}
+
+const capitalize = (str: string) => str[0].toUpperCase() + str.slice(1)
+export class NotFoundError extends Error {
+	public constructor(
+		token: ReadonlySelectorToken<any> | StateToken<any>,
+		store: Internal.Store,
+	) {
+		super(
 			`${capitalize(token.type)} "${token.key}" not found in store "${
 				store.config.name
 			}".`,
 		)
 	}
-	Internal.setState__INTERNAL(state, value, store)
-	Internal.closeOperation(store)
 }

--- a/packages/atom.io/src/get-set.ts
+++ b/packages/atom.io/src/get-set.ts
@@ -26,12 +26,8 @@ export const setState = <T, New extends T>(
 	value: New | ((oldValue: T) => New),
 	store: Internal.Store = Internal.IMPLICIT.STORE,
 ): void => {
-	try {
-		Internal.openOperation(token, store)
-	} catch (thrown) {
-		if (!(typeof thrown === `symbol`)) {
-			throw thrown
-		}
+	const rejection = Internal.openOperation(token, store)
+	if (rejection) {
 		return
 	}
 	const state =

--- a/packages/atom.io/src/get-set.ts
+++ b/packages/atom.io/src/get-set.ts
@@ -11,7 +11,7 @@ export const getState = <T>(
 	const state =
 		Internal.withdraw(token, store) ??
 		Internal.withdrawNewFamilyMember(token, store)
-	if (state === null) {
+	if (state === undefined) {
 		throw new Error(
 			`${capitalize(token.type)} "${token.key}" not found in store "${
 				store.config.name
@@ -37,7 +37,7 @@ export const setState = <T, New extends T>(
 	const state =
 		Internal.withdraw(token, store) ??
 		Internal.withdrawNewFamilyMember(token, store)
-	if (state === null) {
+	if (state === undefined) {
 		throw new Error(
 			`${capitalize(token.type)} "${token.key}" not found in store "${
 				store.config.name

--- a/packages/atom.io/src/index.ts
+++ b/packages/atom.io/src/index.ts
@@ -46,11 +46,3 @@ export type FamilyMetadata = {
 	key: string
 	subKey: string
 }
-
-export const isDefault = (
-	token: ReadonlySelectorToken<unknown> | StateToken<unknown>,
-	store: Store = IO.IMPLICIT.STORE,
-): boolean =>
-	token.type === `atom`
-		? IO.isAtomDefault(token.key, store)
-		: IO.isSelectorDefault(token.key, store)

--- a/packages/atom.io/src/index.ts
+++ b/packages/atom.io/src/index.ts
@@ -1,5 +1,4 @@
-import * as IO from "atom.io/internal"
-import type { Store, Transceiver } from "atom.io/internal"
+import type { Transceiver } from "atom.io/internal"
 import type { Json } from "atom.io/json"
 
 export * from "./atom"
@@ -7,7 +6,6 @@ export * from "./get-set"
 export * from "./logger"
 export * from "./selector"
 export * from "./silo"
-export { subscribe } from "./subscribe"
 export * from "./subscribe"
 export * from "./timeline"
 export * from "./transaction"
@@ -42,7 +40,4 @@ export type ReadonlySelectorToken<_> = {
 	__brand?: _
 }
 
-export type FamilyMetadata = {
-	key: string
-	subKey: string
-}
+export type FamilyMetadata = { key: string; subKey: string }

--- a/packages/atom.io/src/index.ts
+++ b/packages/atom.io/src/index.ts
@@ -3,6 +3,7 @@ import type { Store, Transceiver } from "atom.io/internal"
 import type { Json } from "atom.io/json"
 
 export * from "./atom"
+export * from "./get-set"
 export * from "./logger"
 export * from "./selector"
 export * from "./silo"
@@ -44,51 +45,6 @@ export type ReadonlySelectorToken<_> = {
 export type FamilyMetadata = {
 	key: string
 	subKey: string
-}
-
-export const capitalize = (str: string): string =>
-	str[0].toUpperCase() + str.slice(1)
-
-export const getState = <T>(
-	token: ReadonlySelectorToken<T> | StateToken<T>,
-	store: Store = IO.IMPLICIT.STORE,
-): T => {
-	const state =
-		IO.withdraw(token, store) ?? IO.withdrawNewFamilyMember(token, store)
-	if (state === null) {
-		throw new Error(
-			`${capitalize(token.type)} "${token.key}" not found in store "${
-				store.config.name
-			}".`,
-		)
-	}
-	return IO.getState__INTERNAL(state, store)
-}
-
-export const setState = <T, New extends T>(
-	token: StateToken<T>,
-	value: New | ((oldValue: T) => New),
-	store: Store = IO.IMPLICIT.STORE,
-): void => {
-	try {
-		IO.openOperation(token, store)
-	} catch (thrown) {
-		if (!(typeof thrown === `symbol`)) {
-			throw thrown
-		}
-		return
-	}
-	const state =
-		IO.withdraw(token, store) ?? IO.withdrawNewFamilyMember(token, store)
-	if (state === null) {
-		throw new Error(
-			`${capitalize(token.type)} "${token.key}" not found in store "${
-				store.config.name
-			}".`,
-		)
-	}
-	IO.setState__INTERNAL(state, value, store)
-	IO.closeOperation(store)
 }
 
 export const isDefault = (

--- a/packages/atom.io/src/subscribe.ts
+++ b/packages/atom.io/src/subscribe.ts
@@ -26,7 +26,7 @@ export function subscribe<T>(
 	store: Store = IMPLICIT.STORE,
 ): () => void {
 	const state = withdraw<T>(token, store)
-	if (state === null) {
+	if (state === undefined) {
 		throw new Error(
 			`State "${token.key}" not found in this store. Did you forget to initialize with the "atom" or "selector" function?`,
 		)
@@ -66,7 +66,7 @@ export const subscribeToTransaction = <ƒ extends ƒn>(
 	store = IMPLICIT.STORE,
 ): (() => void) => {
 	const tx = withdraw(token, store)
-	if (tx === null) {
+	if (tx === undefined) {
 		throw new Error(
 			`Cannot subscribe to transaction "${token.key}": transaction not found in store "${store.config.name}".`,
 		)
@@ -86,7 +86,7 @@ export const subscribeToTimeline = (
 	store = IMPLICIT.STORE,
 ): (() => void) => {
 	const tl = withdraw(token, store)
-	if (tl === null) {
+	if (tl === undefined) {
 		throw new Error(
 			`Cannot subscribe to timeline "${token.key}": timeline not found in store "${store.config.name}".`,
 		)


### PR DESCRIPTION
- 🚀 don't compute selectors twice
- 🚚 move get and set state out of index
- 💥 remove isDefault
- ♻️  withdraw may return null instead of undefined
