### PR TITLE
atom.io future error suppression

### DIFF
--- a/.changeset/grumpy-foxes-agree.md
+++ b/.changeset/grumpy-foxes-agree.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🔇 Remove annoying error message that would notify any time a async selector was canceled.

--- a/packages/atom.io/__tests__/future-internal.test.ts
+++ b/packages/atom.io/__tests__/future-internal.test.ts
@@ -1,7 +1,6 @@
 import { Future, Subject, cacheValue, evictCachedValue } from "atom.io/internal"
 import { vitest } from "vitest"
 
-import { c } from "vitest/dist/reporters-5f784f42"
 import type { StateUpdate } from "../src"
 import * as UTIL from "./__util__"
 

--- a/packages/atom.io/internal/src/caching.ts
+++ b/packages/atom.io/internal/src/caching.ts
@@ -27,10 +27,12 @@ export const cacheValue = (
 				subject.next({ newValue: value, oldValue: value })
 			})
 			.catch((error) => {
-				store.config.logger?.error(
-					`Promised value for "${key}" rejected:`,
-					error,
-				)
+				if (error !== `canceled`) {
+					store.config.logger?.error(
+						`Promised value for "${key}" rejected:`,
+						error,
+					)
+				}
 			})
 	} else {
 		target(store).valueMap.set(key, value)


### PR DESCRIPTION
- 🔇 don't logger error when async arrivals are canceled
- 🦋
