### PR TITLE
1047 atomio refactor build to use multiple entrypoints

### DIFF
--- a/.changeset/red-lemons-burn.md
+++ b/.changeset/red-lemons-burn.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🚀 Improve bundle size and source mapping.

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 node_modules
 package-lock.json
 projects
+metafile-*

--- a/apps/atom.io.fyi/package.json
+++ b/apps/atom.io.fyi/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "concurrently \"npm:dev:*\"",
 		"dev:exhibits": "tsx scripts/wrap-exhibits.node watch",
-		"dev:next": "next -p 5400",
+		"dev:next": "next dev -p 5400",
 		"build": "pnpm build:exhibits && pnpm build:next",
 		"build:exhibits": "tsx scripts/wrap-exhibits.node once",
 		"build:next": "next build",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
 	"license": "GPL-3.0",
 	"private": true,
 	"packageManager": "pnpm@8.11.0",
-	"engines": { "pnpm": "8.11.0" },
+	"engines": {
+		"pnpm": "8.11.0"
+	},
 	"scripts": {
 		"dev": "tsc --watch",
 		"lint": "turbo run lint",
@@ -25,6 +27,8 @@
 		"nuke": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' + && rm pnpm-lock.yaml"
 	},
 	"devDependencies": {
+		"@biomejs/biome": "1.4.1",
+		"@biomejs/cli-darwin-arm64": "1.4.1",
 		"@changesets/cli": "2.27.1",
 		"c8": "8.0.1",
 		"cross-env": "7.0.3",
@@ -32,8 +36,6 @@
 		"hamt_plus": "1.0.2",
 		"io-ts": "2.2.21",
 		"json-schema-to-zod": "2.0.12",
-		"@biomejs/biome": "1.4.1",
-		"@biomejs/cli-darwin-arm64": "1.4.1",
 		"tsx": "4.6.2",
 		"turbo": "1.11.1",
 		"typescript": "5.3.3",

--- a/packages/atom.io/__scripts__/constants.ts
+++ b/packages/atom.io/__scripts__/constants.ts
@@ -1,0 +1,11 @@
+import fs from "fs"
+import path from "path"
+import url from "url"
+
+const FILEPATH = url.fileURLToPath(import.meta.url)
+const DIRNAME = path.dirname(FILEPATH)
+
+export const ATOM_IO_ROOT = path.resolve(DIRNAME, `..`)
+export const EXCLUDE_LIST = [`node_modules`, `src`, `dist`, `coverage`]
+export const PACKAGE_JSON_PATH = path.join(ATOM_IO_ROOT, `package.json`)
+export const TSCONFIG_JSON_PATH = path.join(ATOM_IO_ROOT, `tsconfig.prod.json`)

--- a/packages/atom.io/__scripts__/define-integration-scope.node.ts
+++ b/packages/atom.io/__scripts__/define-integration-scope.node.ts
@@ -1,19 +1,12 @@
 import { execSync } from "child_process"
 import fs from "fs"
-import path from "path"
 import url from "url"
 
+import { PACKAGE_JSON_PATH, TSCONFIG_JSON_PATH } from "./constants"
 import { createLogger } from "./logger.node"
 
-const __filename = url.fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-
-const SCRIPT_NAME = __filename.split(`/`).pop()?.split(`.`)[0] ?? `unknown_file`
-const ATOM_IO_ROOT = path.resolve(__dirname, `..`)
-const PACKAGE_JSON_PATH = path.join(ATOM_IO_ROOT, `package.json`)
-const PACKAGE_JSON_TEXT = fs.readFileSync(PACKAGE_JSON_PATH, `utf-8`)
-const TSCONFIG_JSON_PATH = path.join(ATOM_IO_ROOT, `tsconfig.prod.json`)
-const TSCONFIG_JSON_TEXT = fs.readFileSync(TSCONFIG_JSON_PATH, `utf-8`)
+const FILENAME = url.fileURLToPath(import.meta.url)
+const SCRIPT_NAME = FILENAME.split(`/`).pop()?.split(`.`)[0] ?? `unknown_file`
 const ARGS = process.argv.slice(2)
 const SHOULD_RUN = ARGS.includes(`--run`)
 if (SHOULD_RUN) {
@@ -28,7 +21,8 @@ if (SHOULD_RUN) {
 
 export default function main(mode: string): void {
 	const logger = createLogger(SCRIPT_NAME)
-	const packageJson = JSON.parse(PACKAGE_JSON_TEXT)
+	const packageJsonText = fs.readFileSync(PACKAGE_JSON_PATH, `utf-8`)
+	const packageJson = JSON.parse(packageJsonText)
 	const distributionFilepaths: string[] =
 		typeof packageJson === `object` &&
 		packageJson !== null &&
@@ -37,7 +31,8 @@ export default function main(mode: string): void {
 		packageJson.files.every((filepath: unknown) => typeof filepath === `string`)
 			? packageJson.files
 			: []
-	const oldTsconfigJson = JSON.parse(TSCONFIG_JSON_TEXT)
+	const tsconfigJsonText = fs.readFileSync(TSCONFIG_JSON_PATH, `utf-8`)
+	const oldTsconfigJson = JSON.parse(tsconfigJsonText)
 	if (
 		typeof oldTsconfigJson === `object` &&
 		oldTsconfigJson !== null &&
@@ -98,7 +93,7 @@ export default function main(mode: string): void {
 		}
 	} else {
 		throw new Error(
-			`Expected tsconfig.prod.json to have an "include" property, but got ${TSCONFIG_JSON_TEXT}`,
+			`Expected tsconfig.prod.json to have an "include" property, but got ${tsconfigJsonText}`,
 		)
 	}
 }

--- a/packages/atom.io/__scripts__/define-submodule-manifests.node.ts
+++ b/packages/atom.io/__scripts__/define-submodule-manifests.node.ts
@@ -111,6 +111,9 @@ function defineSubmoduleManifest(submoduleName: string): Json.Object {
 		name: manifestName,
 		type: `module`,
 		private: true,
+		main: `dist/index.cjs`,
+		module: `dist/index.mjs`,
+		types: `dist/index.d.ts`,
 		exports: {
 			".": {
 				import: `./dist/index.js`,

--- a/packages/atom.io/__scripts__/define-submodule-manifests.node.ts
+++ b/packages/atom.io/__scripts__/define-submodule-manifests.node.ts
@@ -1,0 +1,123 @@
+import fs from "fs"
+import url from "url"
+
+import type { Json } from "atom.io/json"
+
+import discoverSubmodules from "./discover-submodules.node"
+import { createLogger } from "./logger.node"
+
+const FILEPATH = url.fileURLToPath(import.meta.url)
+const SCRIPT_NAME = FILEPATH.split(`/`).pop()?.split(`.`)[0] ?? `unknown_file`
+const ARGS = process.argv.slice(2)
+const SHOULD_RUN = ARGS.includes(`--run`)
+if (SHOULD_RUN) {
+	const mode = ARGS.at(-1)
+	if (!mode) {
+		throw new Error(
+			`No mode specified. Specify 'test' or 'make' as the last argument`,
+		)
+	}
+	main(mode)
+}
+
+export default function main(mode: string): void {
+	const logger = createLogger(SCRIPT_NAME)
+	const submodules = discoverSubmodules()
+
+	const submoduleManifestEntries = submodules.map((moduleName) => {
+		const newManifest = defineSubmoduleManifest(moduleName)
+		try {
+			const modulePath = `${moduleName}/package.json`
+			const oldManifest: Json.Object = JSON.parse(
+				fs.readFileSync(modulePath, `utf-8`),
+			)
+			return [moduleName, modulePath, newManifest, oldManifest] as const
+		} catch (error) {
+			logger.error(
+				`test fail`,
+				`threw while reading "atom.io/${moduleName}/package.json"`,
+				error,
+			)
+			process.exit(1)
+		}
+	})
+
+	switch (mode) {
+		case `test`: {
+			for (const [
+				moduleName,
+				modulePath,
+				newManifest,
+				oldManifest,
+			] of submoduleManifestEntries) {
+				const oldText = fs.statSync(modulePath)
+					? fs.readFileSync(modulePath, `utf-8`)
+					: undefined
+				const newText = JSON.stringify(newManifest, null, `\t`) + `\n`
+				if (oldText === newText) {
+					logger.info(
+						`pass`,
+						`manifest for "atom.io/${moduleName}" is already up to date`,
+					)
+				} else {
+					logger.error(
+						`fail`,
+						`manifest for "atom.io/${moduleName}" is missing or out of date`,
+					)
+					logger.error(`expected`, newManifest)
+					logger.error(`received`, oldManifest)
+					logger.info(
+						`to fix this error`,
+						`run \`build:manifest\` to update manifest files`,
+					)
+					process.exit(1)
+				}
+			}
+			break
+		}
+		case `make`: {
+			for (const [
+				moduleName,
+				modulePath,
+				newManifest,
+			] of submoduleManifestEntries) {
+				const oldText = fs.statSync(modulePath)
+					? fs.readFileSync(modulePath, `utf-8`)
+					: undefined
+				const newText = JSON.stringify(newManifest, null, `\t`) + `\n`
+				if (oldText === newText) {
+					logger.info(
+						`no-op`,
+						`manifest for "atom.io/${moduleName}" is already up to date`,
+					)
+				} else {
+					logger.info(`updating`, `${modulePath}`)
+					fs.writeFileSync(modulePath, newText)
+					logger.info(`done`, `updated manifest for "atom.io/${moduleName}"`)
+				}
+			}
+			break
+		}
+		default:
+			logger.error(`test fail`, `Unknown mode: "${mode}"`)
+			process.exit(1)
+	}
+}
+
+function defineSubmoduleManifest(submoduleName: string): Json.Object {
+	const submoduleNameParts = submoduleName.split(`/`)
+	const manifestName = `atom.io-${submoduleNameParts.join(`-`)}`
+	return {
+		name: manifestName,
+		type: `module`,
+		private: true,
+		exports: {
+			".": {
+				import: `./dist/index.js`,
+				browser: `./dist/index.js`,
+				require: `./dist/index.cjs`,
+				types: `./dist/index.d.ts`,
+			},
+		},
+	}
+}

--- a/packages/atom.io/__scripts__/discover-submodules.node.ts
+++ b/packages/atom.io/__scripts__/discover-submodules.node.ts
@@ -1,0 +1,26 @@
+import fs from "fs"
+import path from "path"
+import { ATOM_IO_ROOT, EXCLUDE_LIST } from "./constants"
+
+export default function discoverSubmodules(): string[] {
+	const folders = fs
+		.readdirSync(ATOM_IO_ROOT, { withFileTypes: true })
+		.filter((dirent) => dirent.isDirectory())
+		.filter((dirent) => !EXCLUDE_LIST.includes(dirent.name))
+		.flatMap((dirent) => {
+			const contents = fs.readdirSync(path.join(ATOM_IO_ROOT, dirent.name))
+			const isLeaf = contents.includes(`src`) && contents.includes(`dist`)
+			return isLeaf
+				? dirent.name
+				: contents.map((content) => path.join(dirent.name, content))
+		})
+		.filter(
+			(folder) =>
+				!EXCLUDE_LIST.includes(folder) &&
+				!folder.startsWith(`__`) &&
+				!folder.endsWith(`__`) &&
+				!folder.startsWith(`.`),
+		)
+
+	return folders
+}

--- a/packages/atom.io/__scripts__/manifest-build.node.ts
+++ b/packages/atom.io/__scripts__/manifest-build.node.ts
@@ -1,5 +1,7 @@
 import defineIntegrationScope from "./define-integration-scope.node"
 import definePackageExports from "./define-package-exports.node"
+import defineSubmoduleManifests from "./define-submodule-manifests.node"
 
 definePackageExports(`make`)
 defineIntegrationScope(`make`)
+defineSubmoduleManifests(`make`)

--- a/packages/atom.io/__scripts__/manifest-test.node.ts
+++ b/packages/atom.io/__scripts__/manifest-test.node.ts
@@ -1,5 +1,7 @@
 import defineIntegrationScope from "./define-integration-scope.node"
 import definePackageExports from "./define-package-exports.node"
+import defineSubmoduleManifests from "./define-submodule-manifests.node"
 
 definePackageExports(`test`)
 defineIntegrationScope(`test`)
+defineSubmoduleManifests(`test`)

--- a/packages/atom.io/data/package.json
+++ b/packages/atom.io/data/package.json
@@ -2,15 +2,12 @@
 	"name": "atom.io-data",
 	"type": "module",
 	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"module": "dist/index.mjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"browser": "./dist/index.js",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"browser": "./dist/index.js",
+			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts"
 		}
 	}
 }

--- a/packages/atom.io/data/package.json
+++ b/packages/atom.io/data/package.json
@@ -2,6 +2,9 @@
 	"name": "atom.io-data",
 	"type": "module",
 	"private": true,
+	"main": "dist/index.cjs",
+	"module": "dist/index.mjs",
+	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
 			"import": "./dist/index.js",

--- a/packages/atom.io/data/tsup.config.ts
+++ b/packages/atom.io/data/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from "tsup"
-import { DECLARATION } from "~/packages/atom.io/tsup.config"
+import { DTS_OPTIONS } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig(DECLARATION)
+export default defineConfig(DTS_OPTIONS)

--- a/packages/atom.io/data/tsup.config.ts
+++ b/packages/atom.io/data/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from "tsup"
-import { BASE_CONFIG_OPTIONS } from "~/packages/atom.io/tsup.config"
+import { DECLARATION } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig(BASE_CONFIG_OPTIONS)
+export default defineConfig(DECLARATION)

--- a/packages/atom.io/internal/package.json
+++ b/packages/atom.io/internal/package.json
@@ -2,6 +2,9 @@
 	"name": "atom.io-internal",
 	"type": "module",
 	"private": true,
+	"main": "dist/index.cjs",
+	"module": "dist/index.mjs",
+	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
 			"import": "./dist/index.js",

--- a/packages/atom.io/internal/package.json
+++ b/packages/atom.io/internal/package.json
@@ -2,15 +2,12 @@
 	"name": "atom.io-internal",
 	"type": "module",
 	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"module": "dist/index.mjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"browser": "./dist/index.js",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"browser": "./dist/index.js",
+			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts"
 		}
 	}
 }

--- a/packages/atom.io/internal/tsup.config.ts
+++ b/packages/atom.io/internal/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from "tsup"
-import { DECLARATION } from "~/packages/atom.io/tsup.config"
+import { DTS_OPTIONS } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig(DECLARATION)
+export default defineConfig(DTS_OPTIONS)

--- a/packages/atom.io/internal/tsup.config.ts
+++ b/packages/atom.io/internal/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from "tsup"
-import { BASE_CONFIG_OPTIONS } from "~/packages/atom.io/tsup.config"
+import { DECLARATION } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig(BASE_CONFIG_OPTIONS)
+export default defineConfig(DECLARATION)

--- a/packages/atom.io/introspection/package.json
+++ b/packages/atom.io/introspection/package.json
@@ -2,15 +2,12 @@
 	"name": "atom.io-introspection",
 	"type": "module",
 	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"module": "dist/index.mjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"browser": "./dist/index.js",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"browser": "./dist/index.js",
+			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts"
 		}
 	}
 }

--- a/packages/atom.io/introspection/package.json
+++ b/packages/atom.io/introspection/package.json
@@ -2,6 +2,9 @@
 	"name": "atom.io-introspection",
 	"type": "module",
 	"private": true,
+	"main": "dist/index.cjs",
+	"module": "dist/index.mjs",
+	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
 			"import": "./dist/index.js",

--- a/packages/atom.io/introspection/tsup.config.ts
+++ b/packages/atom.io/introspection/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from "tsup"
-import { DECLARATION } from "~/packages/atom.io/tsup.config"
+import { DTS_OPTIONS } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig(DECLARATION)
+export default defineConfig(DTS_OPTIONS)

--- a/packages/atom.io/introspection/tsup.config.ts
+++ b/packages/atom.io/introspection/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from "tsup"
-import { BASE_CONFIG_OPTIONS } from "~/packages/atom.io/tsup.config"
+import { DECLARATION } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig(BASE_CONFIG_OPTIONS)
+export default defineConfig(DECLARATION)

--- a/packages/atom.io/json/package.json
+++ b/packages/atom.io/json/package.json
@@ -2,6 +2,9 @@
 	"name": "atom.io-json",
 	"type": "module",
 	"private": true,
+	"main": "dist/index.cjs",
+	"module": "dist/index.mjs",
+	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
 			"import": "./dist/index.js",

--- a/packages/atom.io/json/package.json
+++ b/packages/atom.io/json/package.json
@@ -2,15 +2,12 @@
 	"name": "atom.io-json",
 	"type": "module",
 	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"module": "dist/index.mjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"browser": "./dist/index.js",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"browser": "./dist/index.js",
+			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts"
 		}
 	}
 }

--- a/packages/atom.io/json/tsup.config.ts
+++ b/packages/atom.io/json/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from "tsup"
-import { DECLARATION } from "~/packages/atom.io/tsup.config"
+import { DTS_OPTIONS } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig(DECLARATION)
+export default defineConfig(DTS_OPTIONS)

--- a/packages/atom.io/json/tsup.config.ts
+++ b/packages/atom.io/json/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from "tsup"
-import { BASE_CONFIG_OPTIONS } from "~/packages/atom.io/tsup.config"
+import { DECLARATION } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig(BASE_CONFIG_OPTIONS)
+export default defineConfig(DECLARATION)

--- a/packages/atom.io/package.json
+++ b/packages/atom.io/package.json
@@ -19,6 +19,7 @@
 		"manifest": "tsx __scripts__/manifest-build.node",
 		"build": "concurrently \"npm:build:*\"",
 		"build:main": "tsup",
+		"build:types": "tsup --dts",
 		"build:data": "cd data && tsup",
 		"build:internal": "cd internal && tsup",
 		"build:introspection": "cd introspection && tsup",

--- a/packages/atom.io/react-devtools/package.json
+++ b/packages/atom.io/react-devtools/package.json
@@ -2,6 +2,9 @@
 	"name": "atom.io-react-devtools",
 	"type": "module",
 	"private": true,
+	"main": "dist/index.cjs",
+	"module": "dist/index.mjs",
+	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
 			"import": "./dist/index.js",

--- a/packages/atom.io/react-devtools/package.json
+++ b/packages/atom.io/react-devtools/package.json
@@ -2,15 +2,12 @@
 	"name": "atom.io-react-devtools",
 	"type": "module",
 	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"module": "dist/index.mjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"browser": "./dist/index.js",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"browser": "./dist/index.js",
+			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts"
 		}
 	}
 }

--- a/packages/atom.io/react-devtools/tsup.config.ts
+++ b/packages/atom.io/react-devtools/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from "tsup"
-import { DECLARATION } from "~/packages/atom.io/tsup.config"
+import { DTS_OPTIONS } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig(DECLARATION)
+export default defineConfig(DTS_OPTIONS)

--- a/packages/atom.io/react-devtools/tsup.config.ts
+++ b/packages/atom.io/react-devtools/tsup.config.ts
@@ -1,11 +1,4 @@
 import { defineConfig } from "tsup"
-import { BASE_CONFIG_OPTIONS } from "~/packages/atom.io/tsup.config"
+import { DECLARATION } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig({
-	...BASE_CONFIG_OPTIONS,
-	jsxFactory: `React.createElement`,
-	tsconfig: `../tsconfig.json`,
-	loader: {
-		".scss": `css`,
-	},
-})
+export default defineConfig(DECLARATION)

--- a/packages/atom.io/react/package.json
+++ b/packages/atom.io/react/package.json
@@ -2,6 +2,9 @@
 	"name": "atom.io-react",
 	"type": "module",
 	"private": true,
+	"main": "dist/index.cjs",
+	"module": "dist/index.mjs",
+	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
 			"import": "./dist/index.js",

--- a/packages/atom.io/react/package.json
+++ b/packages/atom.io/react/package.json
@@ -2,15 +2,12 @@
 	"name": "atom.io-react",
 	"type": "module",
 	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"module": "dist/index.mjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"browser": "./dist/index.js",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"browser": "./dist/index.js",
+			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts"
 		}
 	}
 }

--- a/packages/atom.io/react/tsup.config.ts
+++ b/packages/atom.io/react/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from "tsup"
-import { DECLARATION } from "~/packages/atom.io/tsup.config"
+import { DTS_OPTIONS } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig(DECLARATION)
+export default defineConfig(DTS_OPTIONS)

--- a/packages/atom.io/react/tsup.config.ts
+++ b/packages/atom.io/react/tsup.config.ts
@@ -1,7 +1,4 @@
 import { defineConfig } from "tsup"
-import { BASE_CONFIG_OPTIONS } from "~/packages/atom.io/tsup.config"
+import { DECLARATION } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig({
-	...BASE_CONFIG_OPTIONS,
-	jsxFactory: `React.createElement`,
-})
+export default defineConfig(DECLARATION)

--- a/packages/atom.io/react/tsup.config.ts
+++ b/packages/atom.io/react/tsup.config.ts
@@ -4,5 +4,4 @@ import { BASE_CONFIG_OPTIONS } from "~/packages/atom.io/tsup.config"
 export default defineConfig({
 	...BASE_CONFIG_OPTIONS,
 	jsxFactory: `React.createElement`,
-	tsconfig: `../tsconfig.json`,
 })

--- a/packages/atom.io/realtime-client/package.json
+++ b/packages/atom.io/realtime-client/package.json
@@ -2,6 +2,9 @@
 	"name": "atom.io-realtime-client",
 	"type": "module",
 	"private": true,
+	"main": "dist/index.cjs",
+	"module": "dist/index.mjs",
+	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
 			"import": "./dist/index.js",

--- a/packages/atom.io/realtime-client/package.json
+++ b/packages/atom.io/realtime-client/package.json
@@ -2,15 +2,12 @@
 	"name": "atom.io-realtime-client",
 	"type": "module",
 	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"module": "dist/index.mjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"browser": "./dist/index.js",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"browser": "./dist/index.js",
+			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts"
 		}
 	}
 }

--- a/packages/atom.io/realtime-client/tsup.config.ts
+++ b/packages/atom.io/realtime-client/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from "tsup"
-import { DECLARATION } from "~/packages/atom.io/tsup.config"
+import { DTS_OPTIONS } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig(DECLARATION)
+export default defineConfig(DTS_OPTIONS)

--- a/packages/atom.io/realtime-client/tsup.config.ts
+++ b/packages/atom.io/realtime-client/tsup.config.ts
@@ -1,8 +1,4 @@
 import { defineConfig } from "tsup"
-import { BASE_CONFIG_OPTIONS } from "~/packages/atom.io/tsup.config"
+import { DECLARATION } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig({
-	...BASE_CONFIG_OPTIONS,
-	jsxFactory: `React.createElement`,
-	tsconfig: `../tsconfig.json`,
-})
+export default defineConfig(DECLARATION)

--- a/packages/atom.io/realtime-react/package.json
+++ b/packages/atom.io/realtime-react/package.json
@@ -2,6 +2,9 @@
 	"name": "atom.io-realtime-react",
 	"type": "module",
 	"private": true,
+	"main": "dist/index.cjs",
+	"module": "dist/index.mjs",
+	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
 			"import": "./dist/index.js",

--- a/packages/atom.io/realtime-react/package.json
+++ b/packages/atom.io/realtime-react/package.json
@@ -2,15 +2,12 @@
 	"name": "atom.io-realtime-react",
 	"type": "module",
 	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"module": "dist/index.mjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"browser": "./dist/index.js",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"browser": "./dist/index.js",
+			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts"
 		}
 	}
 }

--- a/packages/atom.io/realtime-react/tsup.config.ts
+++ b/packages/atom.io/realtime-react/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from "tsup"
-import { DECLARATION } from "~/packages/atom.io/tsup.config"
+import { DTS_OPTIONS } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig(DECLARATION)
+export default defineConfig(DTS_OPTIONS)

--- a/packages/atom.io/realtime-react/tsup.config.ts
+++ b/packages/atom.io/realtime-react/tsup.config.ts
@@ -1,8 +1,4 @@
 import { defineConfig } from "tsup"
-import { BASE_CONFIG_OPTIONS } from "~/packages/atom.io/tsup.config"
+import { DECLARATION } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig({
-	...BASE_CONFIG_OPTIONS,
-	jsxFactory: `React.createElement`,
-	tsconfig: `../tsconfig.json`,
-})
+export default defineConfig(DECLARATION)

--- a/packages/atom.io/realtime-server/package.json
+++ b/packages/atom.io/realtime-server/package.json
@@ -1,16 +1,13 @@
 {
-	"name": "atom.io-react",
+	"name": "atom.io-realtime-server",
 	"type": "module",
 	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"module": "dist/index.mjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"browser": "./dist/index.js",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"browser": "./dist/index.js",
+			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts"
 		}
 	}
 }

--- a/packages/atom.io/realtime-server/package.json
+++ b/packages/atom.io/realtime-server/package.json
@@ -2,6 +2,9 @@
 	"name": "atom.io-realtime-server",
 	"type": "module",
 	"private": true,
+	"main": "dist/index.cjs",
+	"module": "dist/index.mjs",
+	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
 			"import": "./dist/index.js",

--- a/packages/atom.io/realtime-server/tsup.config.ts
+++ b/packages/atom.io/realtime-server/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from "tsup"
-import { DECLARATION } from "~/packages/atom.io/tsup.config"
+import { DTS_OPTIONS } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig(DECLARATION)
+export default defineConfig(DTS_OPTIONS)

--- a/packages/atom.io/realtime-server/tsup.config.ts
+++ b/packages/atom.io/realtime-server/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from "tsup"
-import { BASE_CONFIG_OPTIONS } from "~/packages/atom.io/tsup.config"
+import { DECLARATION } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig(BASE_CONFIG_OPTIONS)
+export default defineConfig(DECLARATION)

--- a/packages/atom.io/realtime-testing/package.json
+++ b/packages/atom.io/realtime-testing/package.json
@@ -2,6 +2,9 @@
 	"name": "atom.io-realtime-testing",
 	"type": "module",
 	"private": true,
+	"main": "dist/index.cjs",
+	"module": "dist/index.mjs",
+	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
 			"import": "./dist/index.js",

--- a/packages/atom.io/realtime-testing/package.json
+++ b/packages/atom.io/realtime-testing/package.json
@@ -2,15 +2,12 @@
 	"name": "atom.io-realtime-testing",
 	"type": "module",
 	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"module": "dist/index.mjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"browser": "./dist/index.js",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"browser": "./dist/index.js",
+			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts"
 		}
 	}
 }

--- a/packages/atom.io/realtime-testing/tsup.config.ts
+++ b/packages/atom.io/realtime-testing/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from "tsup"
-import { DECLARATION } from "~/packages/atom.io/tsup.config"
+import { DTS_OPTIONS } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig(DECLARATION)
+export default defineConfig(DTS_OPTIONS)

--- a/packages/atom.io/realtime-testing/tsup.config.ts
+++ b/packages/atom.io/realtime-testing/tsup.config.ts
@@ -1,8 +1,4 @@
 import { defineConfig } from "tsup"
-import { BASE_CONFIG_OPTIONS } from "~/packages/atom.io/tsup.config"
+import { DECLARATION } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig({
-	...BASE_CONFIG_OPTIONS,
-	jsxFactory: `React.createElement`,
-	tsconfig: `../tsconfig.json`,
-})
+export default defineConfig(DECLARATION)

--- a/packages/atom.io/transceivers/set-rtx/package.json
+++ b/packages/atom.io/transceivers/set-rtx/package.json
@@ -1,16 +1,13 @@
 {
-	"name": "atom.io-set-rtx",
+	"name": "atom.io-transceivers-set-rtx",
 	"type": "module",
 	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"module": "dist/index.mjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"browser": "./dist/index.js",
 			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"browser": "./dist/index.js",
+			"require": "./dist/index.cjs",
+			"types": "./dist/index.d.ts"
 		}
 	}
 }

--- a/packages/atom.io/transceivers/set-rtx/package.json
+++ b/packages/atom.io/transceivers/set-rtx/package.json
@@ -2,6 +2,9 @@
 	"name": "atom.io-transceivers-set-rtx",
 	"type": "module",
 	"private": true,
+	"main": "dist/index.cjs",
+	"module": "dist/index.mjs",
+	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
 			"import": "./dist/index.js",

--- a/packages/atom.io/transceivers/set-rtx/tsup.config.ts
+++ b/packages/atom.io/transceivers/set-rtx/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from "tsup"
-import { DECLARATION } from "~/packages/atom.io/tsup.config"
+import { DTS_OPTIONS } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig(DECLARATION)
+export default defineConfig(DTS_OPTIONS)

--- a/packages/atom.io/transceivers/set-rtx/tsup.config.ts
+++ b/packages/atom.io/transceivers/set-rtx/tsup.config.ts
@@ -1,7 +1,4 @@
 import { defineConfig } from "tsup"
-import { BASE_CONFIG_OPTIONS } from "~/packages/atom.io/tsup.config"
+import { DECLARATION } from "~/packages/atom.io/tsup.config"
 
-export default defineConfig({
-	...BASE_CONFIG_OPTIONS,
-	tsconfig: `../../tsconfig.json`,
-})
+export default defineConfig(DECLARATION)

--- a/packages/atom.io/tsup.config.ts
+++ b/packages/atom.io/tsup.config.ts
@@ -24,16 +24,21 @@ export const BUNDLE_EXCLUDE_LIST = [
 ]
 
 export const BASE_CONFIG_OPTIONS: Options = {
-	clean: true,
+	clean: false,
 	dts: true,
-	entry: [`src/index.ts`],
+	outDir: `.`,
+	// entry: [`src/index.ts`],
 	external: BUNDLE_EXCLUDE_LIST,
 	format: [`esm`, `cjs`],
 	metafile: true,
-	outDir: `./dist`,
 	sourcemap: true,
 	splitting: true,
 	treeshake: true,
+
+	entry: {
+		"dist/index": `src/index.ts`,
+		"react/dist/index": `react/src/index.ts`,
+	},
 }
 
 export default defineConfig({

--- a/packages/atom.io/tsup.config.ts
+++ b/packages/atom.io/tsup.config.ts
@@ -17,6 +17,7 @@ export const BUNDLE_EXCLUDE_LIST = [
 	`socket.io`,
 	`socket.io-client`,
 	`react`,
+	`@types/react`,
 	`@testing-library/react`,
 	`@floating-ui/react`,
 	`framer-motion`,
@@ -25,19 +26,42 @@ export const BUNDLE_EXCLUDE_LIST = [
 
 export const BASE_CONFIG_OPTIONS: Options = {
 	clean: false,
-	dts: true,
 	outDir: `.`,
-	// entry: [`src/index.ts`],
+	entry: {
+		"dist/index": `src/index.ts`,
+		"data/dist/index": `data/src/index.ts`,
+		"internal/dist/index": `internal/src/index.ts`,
+		"introspection/dist/index": `introspection/src/index.ts`,
+		"json/dist/index": `json/src/index.ts`,
+		"react/dist/index": `react/src/index.ts`,
+		"react-devtools/dist/index": `react-devtools/src/index.ts`,
+		"realtime-client/dist/index": `realtime-client/src/index.ts`,
+		"realtime-react/dist/index": `realtime-react/src/index.ts`,
+		"realtime-server/dist/index": `realtime-server/src/index.ts`,
+		"realtime-testing/dist/index": `realtime-testing/src/index.ts`,
+		"transceivers/set-rtx/dist/index": `transceivers/set-rtx/src/index.ts`,
+	},
+	esbuildOptions: (options) => {
+		options.chunkNames = `dist/[name]-[hash]`
+		options.assetNames = `dist/[name]-[hash]`
+	},
 	external: BUNDLE_EXCLUDE_LIST,
 	format: [`esm`, `cjs`],
 	metafile: true,
 	sourcemap: true,
-	splitting: true,
 	treeshake: true,
+	jsxFactory: `React.createElement`,
+	loader: {
+		".scss": `css`,
+	},
+}
 
-	entry: {
-		"dist/index": `src/index.ts`,
-		"react/dist/index": `react/src/index.ts`,
+export const DECLARATION: Options = {
+	...BASE_CONFIG_OPTIONS,
+	entry: [`src/index.ts`],
+	outDir: `dist`,
+	dts: {
+		only: true,
 	},
 }
 

--- a/packages/atom.io/tsup.config.ts
+++ b/packages/atom.io/tsup.config.ts
@@ -65,7 +65,11 @@ export const DECLARATION: Options = {
 	},
 }
 
-export default defineConfig({
-	...BASE_CONFIG_OPTIONS,
-	tsconfig: `tsconfig.json`,
-})
+export default defineConfig((options) =>
+	options.dts
+		? DECLARATION
+		: {
+				...BASE_CONFIG_OPTIONS,
+				tsconfig: `tsconfig.json`,
+		  },
+)

--- a/packages/hamr/src/react-elastic-input/ElasticInput.tsx
+++ b/packages/hamr/src/react-elastic-input/ElasticInput.tsx
@@ -1,4 +1,8 @@
-import type { DetailedHTMLProps, InputHTMLAttributes } from "react"
+import type {
+	DetailedHTMLProps,
+	ForwardRefExoticComponent,
+	InputHTMLAttributes,
+} from "react"
 import {
 	forwardRef,
 	useImperativeHandle,
@@ -7,12 +11,18 @@ import {
 	useState,
 } from "react"
 
-export const ElasticInput = forwardRef<
-	HTMLInputElement,
+export type ElasticInputProps = DetailedHTMLProps<
+	InputHTMLAttributes<HTMLInputElement>,
+	HTMLInputElement
+> & {
+	widthPadding?: number
+}
+
+export const ElasticInput: ForwardRefExoticComponent<
 	DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> & {
 		widthPadding?: number
 	}
->(function ElasticInputFC(props, ref) {
+> = forwardRef(function ElasticInputFC(props, ref) {
 	const inputRef = useRef<HTMLInputElement>(null)
 	const spanRef = useRef<HTMLSpanElement>(null)
 	const [inputWidth, setInputWidth] = useState(`auto`)


### PR DESCRIPTION
- ✨ add build script for submodule manifest files
- 🛠️  produce automated manifests
- 🚧
- 🛠️ update manifests for testing
- 🛠️ simplify tsup configs
- 🙈 ignore metafiles
- 🏷️ improve type
- 🛠️ add types for main package
