### PR TITLE
atom.io mutable timetravel

### DIFF
--- a/.changeset/swift-planets-call.md
+++ b/.changeset/swift-planets-call.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 Fix issue where mutable atoms would not be affected when using time travel (`undo` and `redo`) when tracking them on a timeline.

--- a/packages/atom.io/internal/src/atom/create-atom.ts
+++ b/packages/atom.io/internal/src/atom/create-atom.ts
@@ -6,10 +6,11 @@ import type {
 	UpdateHandler,
 } from "atom.io"
 import { setState } from "atom.io"
+import { Json } from "atom.io/json"
 
 import { cacheValue } from "../caching"
 import { newest } from "../lineage"
-import { createMutableAtom } from "../mutable"
+import { Transceiver, createMutableAtom } from "../mutable"
 import type { Store } from "../store"
 import { deposit } from "../store"
 import { Subject } from "../subject"
@@ -19,6 +20,7 @@ import { markAtomAsDefault } from "./is-default"
 export type Atom<T> = {
 	key: string
 	type: `atom`
+	mutable?: boolean
 	family?: FamilyMetadata
 	install: (store: Store) => void
 	subject: Subject<{ newValue: T; oldValue: T }>

--- a/packages/atom.io/internal/src/families/create-atom-family.ts
+++ b/packages/atom.io/internal/src/families/create-atom-family.ts
@@ -39,10 +39,6 @@ export function createAtomFamily<T, K extends Json.Serializable>(
 				if (options.effects) {
 					individualOptions.effects = options.effects(key)
 				}
-				// if (`toJson` in options && `fromJson` in options) {
-				// 	individualOptions.toJson = options.toJson
-				// 	individualOptions.fromJson
-				// }
 				token = createAtom<T>(individualOptions, family, store)
 				subject.next(token)
 			}
@@ -54,6 +50,9 @@ export function createAtomFamily<T, K extends Json.Serializable>(
 			subject,
 		} as const,
 	)
+	if (`mutable` in options && typeof options.mutable === `boolean`) {
+		Object.assign(atomFamily, { mutable: options.mutable })
+	}
 	const target = newest(store)
 	target.families.set(options.key, atomFamily)
 	return atomFamily

--- a/packages/atom.io/internal/src/mutable/get-update-family.ts
+++ b/packages/atom.io/internal/src/mutable/get-update-family.ts
@@ -1,0 +1,23 @@
+import type { AtomFamily, MutableAtomFamily, SelectorFamily } from "atom.io"
+import type { Json } from "atom.io/json"
+
+import { newest } from "../lineage"
+import type { Store } from "../store"
+import type { Signal, Transceiver } from "./transceiver"
+
+export const getUpdateFamily = <
+	Core extends Transceiver<Json.Serializable>,
+	SerializableCore extends Json.Serializable,
+	Key extends string,
+>(
+	mutableAtomFamily: MutableAtomFamily<Core, SerializableCore, Key>,
+	store: Store,
+): AtomFamily<Signal<Core> | null, Key> => {
+	const target = newest(store)
+	const key = `*${mutableAtomFamily.key}`
+	const updateFamily = target.families.get(key) as AtomFamily<
+		Signal<Core> | null,
+		Key
+	>
+	return updateFamily
+}

--- a/packages/atom.io/internal/src/mutable/index.ts
+++ b/packages/atom.io/internal/src/mutable/index.ts
@@ -5,7 +5,7 @@ export * from "./create-mutable-atom-family"
 export * from "./get-json-family"
 export * from "./get-json-token"
 export * from "./get-update-token"
-export * from "./is-atom-token-mutable"
+export * from "./get-update-family"
 export * from "./tracker"
 export * from "./tracker-family"
 export * from "./transceiver"
@@ -13,6 +13,3 @@ export * from "./transceiver"
 export interface MutableAtom<T> extends Atom<T> {
 	mutable: true
 }
-
-export const isAtomMutable = <T>(atom: Atom<T>): atom is MutableAtom<T> =>
-	`isMutable` in atom

--- a/packages/atom.io/internal/src/mutable/is-atom-token-mutable.ts
+++ b/packages/atom.io/internal/src/mutable/is-atom-token-mutable.ts
@@ -1,7 +1,0 @@
-import type { AtomToken, MutableAtomToken } from "atom.io"
-
-export function isAtomTokenMutable(
-	token: AtomToken<any>,
-): token is MutableAtomToken<any, any> {
-	return token.key.endsWith(`::mutable`)
-}

--- a/packages/atom.io/internal/src/mutable/is-mutable.ts
+++ b/packages/atom.io/internal/src/mutable/is-mutable.ts
@@ -1,0 +1,44 @@
+import type {
+	AtomFamily,
+	AtomToken,
+	MutableAtomFamily,
+	MutableAtomToken,
+} from "~/packages/atom.io/src"
+import type { MutableAtom } from "."
+import type { Atom } from "../atom"
+import type { Store } from "../store"
+import { withdraw } from "../store"
+
+export function isMutable(
+	token: AtomToken<any>,
+	store: Store,
+): token is MutableAtomToken<any, any>
+export function isMutable(atom: Atom<any>): atom is MutableAtom<any>
+export function isMutable(
+	family: AtomFamily<any, any>,
+): family is MutableAtomFamily<any, any, any>
+export function isMutable(
+	atomOrTokenOrFamily: Atom<any> | AtomFamily<any, any> | AtomToken<any>,
+	store?: Store,
+): boolean {
+	if (`mutable` in atomOrTokenOrFamily) {
+		return atomOrTokenOrFamily.mutable
+	}
+	if (atomOrTokenOrFamily.type === `atom_family`) {
+		return false
+	}
+	if (`default` in atomOrTokenOrFamily) {
+		return false
+	}
+	if (!store) {
+		throw new Error(`Cannot check mutability without a store`)
+	}
+	const atom = withdraw(atomOrTokenOrFamily, store)
+	if (!atom) {
+		throw new Error(`Cannot check mutability without an atom`)
+	}
+	if (`mutable` in atom) {
+		return atom.mutable
+	}
+	return false
+}

--- a/packages/atom.io/internal/src/mutable/tracker.ts
+++ b/packages/atom.io/internal/src/mutable/tracker.ts
@@ -20,7 +20,8 @@ export class Tracker<Mutable extends Transceiver<any>> {
 		store: Store,
 	): AtomToken<typeof this.Update | null> {
 		const latestUpdateStateKey = `*${mutableState.key}`
-		deleteAtom({ type: `atom`, key: latestUpdateStateKey }, store)
+		store.atoms.delete(latestUpdateStateKey)
+		store.valueMap.delete(latestUpdateStateKey)
 		const familyMetaData: FamilyMetadata | undefined = mutableState.family
 			? {
 					key: `*${mutableState.family.key}`,
@@ -37,6 +38,10 @@ export class Tracker<Mutable extends Transceiver<any>> {
 			familyMetaData,
 			store,
 		)
+		if (store.parent) {
+			const parentValue = store.parent.valueMap.get(latestUpdateStateKey)
+			store.valueMap.set(latestUpdateStateKey, parentValue)
+		}
 
 		return latestUpdateState
 	}

--- a/packages/atom.io/internal/src/mutable/tracker.ts
+++ b/packages/atom.io/internal/src/mutable/tracker.ts
@@ -137,7 +137,9 @@ export class Tracker<Mutable extends Transceiver<any>> {
 					() => {
 						unsubscribe()
 						const mutable = getState(mutableState, store)
-						const updateNumber = mutable.getUpdateNumber(newValue)
+						// debugger
+						const updateNumber =
+							newValue === null ? -1 : mutable.getUpdateNumber(newValue)
 						const eventOffset = updateNumber - mutable.cacheUpdateNumber
 						if (newValue && eventOffset === 1) {
 							// ❗ new:"0=add:\"myHand\"",old:"0=add:\"deckId\""

--- a/packages/atom.io/internal/src/subject.ts
+++ b/packages/atom.io/internal/src/subject.ts
@@ -14,7 +14,8 @@ export class Subject<T> {
 	}
 
 	public next(value: T): void {
-		for (const subscriber of this.subscribers.values()) {
+		const subscribers = this.subscribers.values()
+		for (const subscriber of subscribers) {
 			subscriber(value)
 		}
 	}

--- a/packages/atom.io/src/atom.ts
+++ b/packages/atom.io/src/atom.ts
@@ -56,6 +56,7 @@ export type AtomFamily<T, K extends Json.Serializable = Json.Serializable> = ((
 	key: string
 	type: `atom_family`
 	subject: Subject<AtomToken<T>>
+	mutable?: boolean
 }
 // biome-ignore format: intersection
 export type MutableAtomFamilyOptions<
@@ -76,9 +77,10 @@ export type MutableAtomFamily<
 	& JsonInterface<Core, SerializableCore>
 	& ((key: Key) => MutableAtomToken<Core, SerializableCore>) 
 	& {
-			key: `${string}::mutable`
+			key: `${string}`
 			type: `atom_family`
 			subject: Subject<MutableAtomToken<Core, SerializableCore>>
+			mutable: true
 		}
 
 export function atomFamily<


### PR DESCRIPTION
- 🐛 fix bug where mutables could not timetravel
- 🐛 fix issue where reinitializing a tracker in a transaction would set the update state to its default value--null
- 🦋
