### PR TITLE
atom.io dedupe built declarations

### DIFF
--- a/.changeset/long-flies-report.md
+++ b/.changeset/long-flies-report.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🚀 Redundant .d.cts files, which were unreferenced in atom.io's manifests, and identical to their respective .d.ts files, have been removed.

--- a/packages/atom.io/tsup.config.ts
+++ b/packages/atom.io/tsup.config.ts
@@ -54,7 +54,9 @@ export const JS_OPTIONS: Options = {
 export const DTS_OPTIONS: Options = {
 	...BASE_OPTIONS,
 	dts: { only: true },
+	format: [`esm`],
 	entry: [`src/index.ts`],
+	metafile: false,
 	outDir: `dist`,
 }
 


### PR DESCRIPTION
- 🔧 remove unused .d.cts and redundant metafiles from build output
- 🦋
