### PR TITLE
deprecate family-as-function

### DIFF
--- a/.changeset/witty-snails-attack.md
+++ b/.changeset/witty-snails-attack.md
@@ -1,0 +1,18 @@
+---
+"atom.io": patch
+---
+
+🗑️ Formally deprecate the family-as-function style of usage.
+
+```ts
+const countAtoms = atomFamily<number, string>({
+  key: `count`,
+  default: 0,
+})
+
+// Deprecated
+const countState = countAtoms('find-me')
+
+// Use this instead
+const countState = findState(countAtoms, 'find-me')
+```

--- a/packages/atom.io/__tests__/__util__/use-family.ts
+++ b/packages/atom.io/__tests__/__util__/use-family.ts
@@ -4,19 +4,18 @@ import * as AR from "atom.io/react"
 import * as React from "react"
 
 export function getFamily<
-	Family extends AtomIO.MutableAtomFamily<any, any, any>,
->(family: Family, store: Store): Family
-export function getFamily<Family extends AtomIO.RegularAtomFamily<any, any>>(
-	family: Family,
-	store: Store,
-): Family
-export function getFamily<
-	Family extends AtomIO.WritableSelectorFamily<any, any>,
+	Family extends AtomIO.MutableAtomFamilyToken<any, any, any>,
 >(family: Family, store: Store): Family
 export function getFamily<
-	Family extends AtomIO.ReadonlySelectorFamily<any, any>,
+	Family extends AtomIO.RegularAtomFamilyToken<any, any>,
 >(family: Family, store: Store): Family
-export function getFamily<Family extends AtomIO.ReadableFamily<any, any>>(
+export function getFamily<
+	Family extends AtomIO.WritableSelectorFamilyToken<any, any>,
+>(family: Family, store: Store): Family
+export function getFamily<
+	Family extends AtomIO.ReadonlySelectorFamilyToken<any, any>,
+>(family: Family, store: Store): Family
+export function getFamily<Family extends AtomIO.ReadableFamilyToken<any, any>>(
 	family: Family,
 	store: Store,
 ): Family
@@ -32,18 +31,18 @@ export function getFamily(
 	return storeFamily
 }
 export function useFamily<
-	Family extends AtomIO.MutableAtomFamily<any, any, any>,
->(family: Family): Family
-export function useFamily<Family extends AtomIO.RegularAtomFamily<any, any>>(
-	family: Family,
-): Family
-export function useFamily<
-	Family extends AtomIO.WritableSelectorFamily<any, any>,
+	Family extends AtomIO.MutableAtomFamilyToken<any, any, any>,
 >(family: Family): Family
 export function useFamily<
-	Family extends AtomIO.ReadonlySelectorFamily<any, any>,
+	Family extends AtomIO.RegularAtomFamilyToken<any, any>,
 >(family: Family): Family
-export function useFamily(family: AtomIO.ReadableFamily<any, any>): any {
+export function useFamily<
+	Family extends AtomIO.WritableSelectorFamilyToken<any, any>,
+>(family: Family): Family
+export function useFamily<
+	Family extends AtomIO.ReadonlySelectorFamilyToken<any, any>,
+>(family: Family): Family
+export function useFamily(family: AtomIO.ReadableFamilyToken<any, any>): any {
 	const store = React.useContext(AR.StoreContext)
 	const storeFamily = getFamily(family, store)
 	return storeFamily

--- a/packages/atom.io/__tests__/mutability/tracker.test.ts
+++ b/packages/atom.io/__tests__/mutability/tracker.test.ts
@@ -82,13 +82,15 @@ describe(`tracker`, () => {
 
 describe(`trackerFamily`, () => {
 	test(`tracks the state of a family of mutable atoms`, () => {
-		const findSetState = atomFamily<SetRTX<string>, SetRTXJson<string>, string>({
+		const setAtoms = atomFamily<SetRTX<string>, SetRTXJson<string>, string>({
 			key: `findSetState`,
 			default: () => new SetRTX(),
 			mutable: true,
 			toJson: (set) => set.toJSON(),
 			fromJson: (json) => SetRTX.fromJSON(json),
 		})
+		const findSetState = Internal.withdraw(setAtoms, Internal.IMPLICIT.STORE)
+		if (!findSetState) throw 0
 		const { findLatestUpdateState } = new FamilyTracker(
 			findSetState,
 			Internal.IMPLICIT.STORE,
@@ -98,13 +100,15 @@ describe(`trackerFamily`, () => {
 		expect(getState(findLatestUpdateState(`a`))).toEqual(null)
 	})
 	test(`updates the core of a new family member in a transaction`, () => {
-		const findSetState = atomFamily<SetRTX<string>, SetRTXJson<string>, string>({
+		const setAtoms = atomFamily<SetRTX<string>, SetRTXJson<string>, string>({
 			key: `findSetState`,
 			default: () => new SetRTX(),
 			mutable: true,
 			toJson: (set) => set.toJSON(),
 			fromJson: (json) => SetRTX.fromJSON(json),
 		})
+		const findSetState = Internal.withdraw(setAtoms, Internal.IMPLICIT.STORE)
+		if (!findSetState) throw 0
 		const { findLatestUpdateState } = new FamilyTracker(
 			findSetState,
 			Internal.IMPLICIT.STORE,

--- a/packages/atom.io/__tests__/struct.test.ts
+++ b/packages/atom.io/__tests__/struct.test.ts
@@ -1,4 +1,4 @@
-import { getState, setState } from "atom.io"
+import { findState, getState, setState } from "atom.io"
 import { struct, structFamily } from "atom.io/data"
 
 describe(`struct`, () => {
@@ -26,7 +26,7 @@ describe(`struct`, () => {
 
 describe(`structFamily`, () => {
 	it(`breaks a flat object structure into separate atoms (family-style)`, () => {
-		const [atomFamilies, selectorFamily] = structFamily({
+		const [piecemealStates, clusterStates] = structFamily({
 			key: `user`,
 			default: {
 				name: ``,
@@ -34,12 +34,13 @@ describe(`structFamily`, () => {
 				email: ``,
 			},
 		})
-		setState(atomFamilies.findUserAgeState(`a`), 42)
-		expect(atomFamilies.findUserAgeState.key).toEqual(`user.age`)
-		expect(atomFamilies.findUserEmailState.key).toEqual(`user.email`)
-		expect(atomFamilies.findUserNameState.key).toEqual(`user.name`)
-		expect(selectorFamily.key).toEqual(`user`)
-		expect(getState(selectorFamily(`a`))).toEqual({
+		setState(piecemealStates.findUserAgeState(`a`), 42)
+		expect(piecemealStates.findUserAgeState.key).toEqual(`user.age`)
+		expect(piecemealStates.findUserEmailState.key).toEqual(`user.email`)
+		expect(piecemealStates.findUserNameState.key).toEqual(`user.name`)
+		expect(clusterStates.key).toEqual(`user`)
+		const aClusterState = findState(clusterStates, `a`)
+		expect(getState(aClusterState)).toEqual({
 			name: ``,
 			age: 42,
 			email: ``,

--- a/packages/atom.io/__unstable__/react-explorer/src/AtomIOExplorer.tsx
+++ b/packages/atom.io/__unstable__/react-explorer/src/AtomIOExplorer.tsx
@@ -1,4 +1,4 @@
-import { runTransaction, setState } from "atom.io"
+import { findState, runTransaction, setState } from "atom.io"
 import { useI, useO } from "atom.io/react"
 import type { FC, ReactNode } from "react"
 import { useEffect } from "react"
@@ -60,7 +60,7 @@ export const composeExplorer = ({
 		viewId: string
 	}> = ({ children, viewId }) => {
 		const location = useLocation()
-		const viewState = findViewState(viewId)
+		const viewState = findState(findViewState, viewId)
 		const view = useO(viewState)
 		const setView = useI(viewState)
 		useEffect(() => {
@@ -92,9 +92,9 @@ export const composeExplorer = ({
 	}
 
 	const Tab: FC<{ viewId: string; spaceId: string }> = ({ viewId, spaceId }) => {
-		const view = useO(findViewState(viewId))
-		const spaceFocusedView = useO(findSpaceFocusedViewState(spaceId))
-		const setSpaceFocusedView = useI(findSpaceFocusedViewState(spaceId))
+		const view = useO(findViewState, viewId)
+		const spaceFocusedView = useO(findSpaceFocusedViewState, spaceId)
+		const setSpaceFocusedView = useI(findSpaceFocusedViewState, spaceId)
 		const handleClick = () => setSpaceFocusedView(viewId)
 		return (
 			<div
@@ -126,7 +126,7 @@ export const composeExplorer = ({
 		spaceId: string
 		viewIds: string[]
 	}> = ({ children, focusedViewId, spaceId, viewIds }) => {
-		const view = useO(findViewState(focusedViewId))
+		const view = useO(findViewState, focusedViewId)
 		return (
 			<div className="space">
 				<RecoverableErrorBoundary>
@@ -145,9 +145,9 @@ export const composeExplorer = ({
 		children,
 		spaceId = `root`,
 	}) => {
-		const spaceLayout = useO(findSpaceLayoutNode(spaceId))
-		const viewIds = useO(findSpaceViewsState(spaceId))
-		const focusedViewId = useO(findSpaceFocusedViewState(spaceId))
+		const spaceLayout = useO(findSpaceLayoutNode, spaceId)
+		const viewIds = useO(findSpaceViewsState, spaceId)
+		const focusedViewId = useO(findSpaceFocusedViewState, spaceId)
 		return (
 			<div className="spaces">
 				{spaceLayout.childSpaceIds.length === 0 ? (
@@ -206,7 +206,8 @@ export const composeExplorer = ({
 		const viewId = locationView?.[0] ?? null
 		useEffect(() => {
 			if (viewId) {
-				setState(findViewState(viewId), (v) => ({ ...v, title }))
+				const viewState = findState(findViewState, viewId)
+				setState(viewState, (v) => ({ ...v, title }))
 			}
 		}, [viewId])
 	}

--- a/packages/atom.io/__unstable__/react-explorer/src/space-states.ts
+++ b/packages/atom.io/__unstable__/react-explorer/src/space-states.ts
@@ -1,7 +1,9 @@
 import { atom, atomFamily, selectorFamily } from "atom.io"
 import type {
 	ReadonlySelectorFamily,
+	ReadonlySelectorFamilyToken,
 	RegularAtomFamily,
+	RegularAtomFamilyToken,
 	RegularAtomToken,
 } from "atom.io"
 import { parseJson, stringifyJson } from "atom.io/json"
@@ -56,7 +58,10 @@ export const makeSpaceLayoutState = (
 export const makeSpaceLayoutNodeFamily = (
 	key: string,
 	spaceLayoutState: RegularAtomToken<Join<{ size: number }, `parent`, `child`>>,
-): ReadonlySelectorFamily<{ childSpaceIds: string[]; size: number }, string> =>
+): ReadonlySelectorFamilyToken<
+	{ childSpaceIds: string[]; size: number },
+	string
+> =>
 	selectorFamily<{ childSpaceIds: string[]; size: number }, string>({
 		key: `${key}:explorer_space`,
 		get:
@@ -74,7 +79,7 @@ export const makeSpaceLayoutNodeFamily = (
 
 export const makeSpaceFamily = (
 	key: string,
-): RegularAtomFamily<number, string> =>
+): RegularAtomFamilyToken<number, string> =>
 	atomFamily<number, string>({
 		key: `${key}:space`,
 		default: 1,

--- a/packages/atom.io/__unstable__/react-explorer/src/view-states.ts
+++ b/packages/atom.io/__unstable__/react-explorer/src/view-states.ts
@@ -1,4 +1,8 @@
-import type { RegularAtomFamily, RegularAtomToken } from "atom.io"
+import type {
+	RegularAtomFamily,
+	RegularAtomFamilyToken,
+	RegularAtomToken,
+} from "atom.io"
 import { atom, atomFamily } from "atom.io"
 import type { Location } from "react-router-dom"
 import { lazyLocalStorageEffect } from "~/packages/atom.io/__unstable__/web-effects/src"
@@ -10,7 +14,9 @@ export type View = {
 	location: Omit<Location, `state`>
 }
 
-export const makeViewFamily = (key: string): RegularAtomFamily<View, string> =>
+export const makeViewFamily = (
+	key: string,
+): RegularAtomFamilyToken<View, string> =>
 	atomFamily<View, string>({
 		key: `${key}:view`,
 		default: {
@@ -34,7 +40,7 @@ export const makeViewIndex = (key: string): RegularAtomToken<Set<string>> =>
 
 export const makeViewFocusedFamily = (
 	key: string,
-): RegularAtomFamily<number, string> =>
+): RegularAtomFamilyToken<number, string> =>
 	atomFamily<number, string>({
 		key: `${key}:view_focused`,
 		default: 0,

--- a/packages/atom.io/data/src/dict.ts
+++ b/packages/atom.io/data/src/dict.ts
@@ -1,12 +1,16 @@
 import type * as AtomIO from "atom.io"
 import type { Store } from "atom.io/internal"
-import { IMPLICIT, createStandaloneSelector } from "atom.io/internal"
+import {
+	IMPLICIT,
+	createStandaloneSelector,
+	findInStore,
+} from "atom.io/internal"
 import type { Json, Stringified } from "atom.io/json"
 
 export function dict<State, Key extends Json.Serializable>(
 	findState:
-		| AtomIO.ReadonlySelectorFamily<State, Key>
-		| AtomIO.RegularAtomFamily<State, Key>
+		| AtomIO.ReadonlySelectorFamilyToken<State, Key>
+		| AtomIO.RegularAtomFamilyToken<State, Key>
 		| AtomIO.WritableSelectorFamily<State, Key>,
 	index:
 		| AtomIO.ReadonlySelectorToken<Key[]>
@@ -20,7 +24,7 @@ export function dict<State, Key extends Json.Serializable>(
 			get: ({ get }) => {
 				const keys = get(index)
 				return keys.reduce((acc, key) => {
-					acc[key] = get(findState(key))
+					acc[key] = get(findInStore(findState, key, store))
 					return acc
 				}, {} as any)
 			},

--- a/packages/atom.io/data/src/struct-family.ts
+++ b/packages/atom.io/data/src/struct-family.ts
@@ -21,7 +21,7 @@ export function structFamily<
 			K & string
 		>}State`]: AtomIO.RegularAtomFamily<Struct[K], string>
 	},
-	AtomIO.ReadonlySelectorFamily<Struct>,
+	AtomIO.ReadonlySelectorFamilyToken<Struct, string>,
 ] {
 	const atoms: {
 		[K in keyof Struct as `find${Capitalize<Key & string>}${Capitalize<
@@ -38,21 +38,22 @@ export function structFamily<
 		)
 		return acc
 	}, {} as any)
-	const findStructState = createSelectorFamily(
-		{
-			key: options.key,
-			get:
-				(id) =>
-				({ get }) => {
-					return Object.keys(options.default).reduce((acc, subKey) => {
-						acc[subKey] = get(
-							(atoms as any)[nameFamily(options.key, subKey)](id),
-						)
-						return acc
-					}, {} as any)
-				},
-		},
-		IMPLICIT.STORE,
-	)
+	const findStructState: AtomIO.ReadonlySelectorFamilyToken<Struct, string> =
+		createSelectorFamily(
+			{
+				key: options.key,
+				get:
+					(id) =>
+					({ get }) => {
+						return Object.keys(options.default).reduce((acc, subKey) => {
+							acc[subKey] = get(
+								(atoms as any)[nameFamily(options.key, subKey)](id),
+							)
+							return acc
+						}, {} as any)
+					},
+			},
+			IMPLICIT.STORE,
+		)
 	return [atoms, findStructState]
 }

--- a/packages/atom.io/internal/src/store/withdraw.ts
+++ b/packages/atom.io/internal/src/store/withdraw.ts
@@ -1,18 +1,31 @@
 import type {
+	AtomFamily,
+	AtomFamilyToken,
 	AtomToken,
+	MutableAtomFamily,
+	MutableAtomFamilyToken,
 	MutableAtomToken,
 	ReadableToken,
+	ReadonlySelectorFamily,
+	ReadonlySelectorFamilyToken,
 	ReadonlySelectorToken,
+	RegularAtomFamily,
+	RegularAtomFamilyToken,
 	RegularAtomToken,
+	SelectorFamily,
+	SelectorFamilyToken,
 	SelectorToken,
 	TimelineManageable,
 	TimelineToken,
 	TransactionToken,
+	WritableSelectorFamily,
+	WritableSelectorFamilyToken,
 	WritableSelectorToken,
 	WritableToken,
 	ƒn,
 } from "atom.io"
 
+import type { Json } from "atom.io/json"
 import type {
 	Atom,
 	MutableAtom,
@@ -28,7 +41,24 @@ import type { Timeline } from "../timeline"
 import type { Transaction } from "../transaction"
 import type { Store } from "./store"
 
-export type Withdrawable = ReadableState<any> | Timeline<any> | Transaction<any>
+export type Withdrawable =
+	| Atom<any>
+	| AtomFamily<any, any>
+	| MutableAtom<any, any>
+	| MutableAtomFamily<any, any, any>
+	| ReadableState<any>
+	| ReadableState<any>
+	| ReadonlySelector<any>
+	| ReadonlySelectorFamily<any, any>
+	| RegularAtom<any>
+	| RegularAtomFamily<any, any>
+	| Selector<any>
+	| SelectorFamily<any, any>
+	| Timeline<any>
+	| Transaction<any>
+	| WritableSelector<any>
+	| WritableSelectorFamily<any, any>
+	| WritableState<any>
 
 export function withdraw<T>(
 	token: RegularAtomToken<T>,
@@ -62,6 +92,36 @@ export function withdraw<T>(
 	token: ReadableToken<T>,
 	store: Store,
 ): ReadableState<T> | undefined
+
+export function withdraw<T, K extends Json.Serializable>(
+	token: RegularAtomFamilyToken<T, K>,
+	store: Store,
+): RegularAtomFamily<T, K> | undefined
+export function withdraw<
+	T extends Transceiver<any>,
+	J extends Json.Serializable,
+	K extends Json.Serializable,
+>(
+	token: MutableAtomFamilyToken<T, J, K>,
+	store: Store,
+): MutableAtomFamily<T, J, K> | undefined
+export function withdraw<T, K extends Json.Serializable>(
+	token: AtomFamilyToken<T>,
+	store: Store,
+): AtomFamily<T, any> | undefined
+export function withdraw<T, K extends Json.Serializable>(
+	token: ReadonlySelectorFamilyToken<T, K>,
+	store: Store,
+): ReadonlySelectorFamily<T, any> | undefined
+export function withdraw<T, K extends Json.Serializable>(
+	token: WritableSelectorFamilyToken<T, K>,
+	store: Store,
+): WritableSelectorFamily<T, any> | undefined
+export function withdraw<T, K extends Json.Serializable>(
+	token: SelectorFamilyToken<T, K>,
+	store: Store,
+): SelectorFamily<T, any> | undefined
+
 export function withdraw<T>(
 	token: TransactionToken<T>,
 	store: Store,
@@ -72,11 +132,15 @@ export function withdraw<T>(
 ): Timeline<T extends TimelineManageable ? T : never> | undefined
 export function withdraw<T>(
 	token:
+		| RegularAtomFamilyToken<T, any>
 		| RegularAtomToken<T>
+		| SelectorFamilyToken<T, any>
 		| SelectorToken<T>
 		| TimelineToken<T>
 		| TransactionToken<T>
-		| (T extends Transceiver<any> ? MutableAtomToken<T, any> : never),
+		| (T extends Transceiver<any>
+				? MutableAtomFamilyToken<T, any, any> | MutableAtomToken<T, any>
+				: never),
 	store: Store,
 ): Withdrawable | undefined {
 	let withdrawn: Withdrawable | undefined

--- a/packages/atom.io/internal/src/store/withdraw.ts
+++ b/packages/atom.io/internal/src/store/withdraw.ts
@@ -157,6 +157,12 @@ export function withdraw<T>(
 			case `readonly_selector`:
 				withdrawn = target.readonlySelectors.get(token.key)
 				break
+			case `atom_family`:
+			case `mutable_atom_family`:
+			case `selector_family`:
+			case `readonly_selector_family`:
+				withdrawn = target.families.get(token.key)
+				break
 			case `timeline`:
 				withdrawn = target.timelines.get(token.key)
 				break

--- a/packages/atom.io/internal/src/timeline/create-timeline.ts
+++ b/packages/atom.io/internal/src/timeline/create-timeline.ts
@@ -1,5 +1,6 @@
 import type {
 	AtomFamily,
+	AtomFamilyToken,
 	FamilyMetadata,
 	StateUpdate,
 	TimelineManageable,
@@ -86,7 +87,17 @@ export function createTimeline<ManagedAtom extends TimelineManageable>(
 			tokenOrFamily.type === `atom_family` ||
 			tokenOrFamily.type === `mutable_atom_family`
 		) {
-			const family: AtomFamily<any> = tokenOrFamily
+			const familyToken: AtomFamilyToken<any> = tokenOrFamily
+			const family = withdraw(familyToken, store)
+			if (family === undefined) {
+				store.logger.error(
+					`❌`,
+					`timeline`,
+					options.key,
+					`Failed to add family "${familyToken.key}" because it does not exist in the store`,
+				)
+				continue
+			}
 			const familyKey = family.key
 			target.timelineAtoms.set({ atomKey: familyKey, timelineKey })
 			family.subject.subscribe(`timeline:${options.key}`, (token) => {

--- a/packages/atom.io/introspection/src/attach-introspection-states.ts
+++ b/packages/atom.io/introspection/src/attach-introspection-states.ts
@@ -1,5 +1,6 @@
 import type {
 	ReadonlySelectorFamily,
+	ReadonlySelectorFamilyToken,
 	ReadonlySelectorToken,
 	TimelineToken,
 	TransactionToken,
@@ -23,9 +24,12 @@ export const attachIntrospectionStates = (
 	atomIndex: ReadonlySelectorToken<AtomTokenIndex>
 	selectorIndex: ReadonlySelectorToken<SelectorTokenIndex>
 	transactionIndex: ReadonlySelectorToken<TransactionToken<ƒn>[]>
-	findTransactionLogState: ReadonlySelectorFamily<TransactionUpdate<ƒn>[]>
+	findTransactionLogState: ReadonlySelectorFamilyToken<
+		TransactionUpdate<ƒn>[],
+		string
+	>
 	timelineIndex: ReadonlySelectorToken<TimelineToken<any>[]>
-	findTimelineState: ReadonlySelectorFamily<Timeline<any>>
+	findTimelineState: ReadonlySelectorFamilyToken<Timeline<any>, string>
 } => {
 	return {
 		atomIndex: attachAtomIndex(store),

--- a/packages/atom.io/introspection/src/attach-timeline-family.ts
+++ b/packages/atom.io/introspection/src/attach-timeline-family.ts
@@ -1,4 +1,7 @@
-import type { ReadonlySelectorFamily } from "atom.io"
+import type {
+	ReadonlySelectorFamily,
+	ReadonlySelectorFamilyToken,
+} from "atom.io"
 import type { Store, Timeline } from "atom.io/internal"
 import {
 	IMPLICIT,
@@ -9,7 +12,7 @@ import {
 
 export const attachTimelineFamily = (
 	store: Store = IMPLICIT.STORE,
-): ReadonlySelectorFamily<Timeline<any>> => {
+): ReadonlySelectorFamilyToken<Timeline<any>, string> => {
 	const findTimelineLogState__INTERNAL = createRegularAtomFamily<
 		Timeline<any>,
 		string

--- a/packages/atom.io/introspection/src/attach-transaction-logs.ts
+++ b/packages/atom.io/introspection/src/attach-transaction-logs.ts
@@ -1,4 +1,4 @@
-import type { ReadonlySelectorFamily, TransactionUpdate, ƒn } from "atom.io"
+import type { ReadonlySelectorFamilyToken, TransactionUpdate, ƒn } from "atom.io"
 import type { Store } from "atom.io/internal"
 import {
 	IMPLICIT,
@@ -8,7 +8,7 @@ import {
 
 export const attachTransactionLogs = (
 	store: Store = IMPLICIT.STORE,
-): ReadonlySelectorFamily<TransactionUpdate<ƒn>[]> => {
+): ReadonlySelectorFamilyToken<TransactionUpdate<ƒn>[], string> => {
 	const findTransactionUpdateLog = createRegularAtomFamily<
 		TransactionUpdate<ƒn>[],
 		string

--- a/packages/atom.io/react-devtools/src/TimelineIndex.tsx
+++ b/packages/atom.io/react-devtools/src/TimelineIndex.tsx
@@ -3,7 +3,7 @@ import type {
 	RegularAtomToken,
 	TimelineToken,
 } from "atom.io"
-import { redo, undo } from "atom.io"
+import { findState, redo, undo } from "atom.io"
 import type { Timeline } from "atom.io/internal"
 import { useI, useO } from "atom.io/react"
 import { type FC, Fragment } from "react"
@@ -82,8 +82,8 @@ export const TimelineIndex: FC = () => {
 						<TimelineLog
 							key={token.key}
 							token={token}
-							isOpenState={findViewIsOpenState(token.key)}
-							timelineState={findTimelineState(token.key)}
+							isOpenState={findState(findViewIsOpenState, token.key)}
+							timelineState={findState(findTimelineState, token.key)}
 						/>
 					)
 				})}

--- a/packages/atom.io/react-devtools/src/TransactionIndex.tsx
+++ b/packages/atom.io/react-devtools/src/TransactionIndex.tsx
@@ -1,9 +1,10 @@
-import type {
-	ReadonlySelectorToken,
-	RegularAtomToken,
-	TransactionToken,
-	TransactionUpdate,
-	ƒn,
+import {
+	type ReadonlySelectorToken,
+	type RegularAtomToken,
+	type TransactionToken,
+	type TransactionUpdate,
+	findState,
+	type ƒn,
 } from "atom.io"
 import { useI, useO } from "atom.io/react"
 import type { FC } from "react"
@@ -60,8 +61,8 @@ export const TransactionIndex: FC = () => {
 						<TransactionLog
 							key={token.key}
 							token={token}
-							isOpenState={findViewIsOpenState(token.key)}
-							logState={findTransactionLogState(token.key)}
+							isOpenState={findState(findViewIsOpenState, token.key)}
+							logState={findState(findTransactionLogState, token.key)}
 						/>
 					)
 				})}

--- a/packages/atom.io/realtime-server/src/realtime-mutable-family-provider.ts
+++ b/packages/atom.io/realtime-server/src/realtime-mutable-family-provider.ts
@@ -2,6 +2,7 @@ import type * as AtomIO from "atom.io"
 import type { Transceiver } from "atom.io/internal"
 import {
 	IMPLICIT,
+	findInStore,
 	getFromStore,
 	getJsonToken,
 	getUpdateToken,
@@ -24,7 +25,7 @@ export function realtimeMutableFamilyProvider({
 		J extends Json.Serializable,
 		K extends Json.Serializable,
 	>(
-		family: AtomIO.MutableAtomFamily<T, J, K>,
+		family: AtomIO.MutableAtomFamilyToken<T, J, K>,
 		index: AtomIO.ReadableToken<Iterable<K>>,
 	): () => void {
 		const unsubCallbacksByKey = new Map<string, () => void>()
@@ -42,7 +43,7 @@ export function realtimeMutableFamilyProvider({
 			const exposedSubKeys = getFromStore(index, store)
 			for (const exposedSubKey of exposedSubKeys) {
 				if (stringifyJson(exposedSubKey) === stringifyJson(subKey)) {
-					const token = family(subKey)
+					const token = findInStore(family, subKey, store)
 					const jsonToken = getJsonToken(token)
 					const updateToken = getUpdateToken(token)
 					socket.emit(`init:${token.key}`, getFromStore(jsonToken, store))

--- a/packages/atom.io/src/atom.ts
+++ b/packages/atom.io/src/atom.ts
@@ -45,23 +45,30 @@ export type RegularAtomFamilyOptions<T, K extends Json.Serializable> = {
 	effects?: (key: K) => AtomEffect<T>[]
 }
 
-export type RegularAtomFamily<
-	T,
-	K extends Json.Serializable = Json.Serializable,
-> = ((key: K) => RegularAtomToken<T>) & {
-	key: string
-	type: `atom_family`
-	subject: Subject<RegularAtomToken<T>>
-	install: (store: Store) => void
-	__T?: T
-	__K?: K
-}
 export type RegularAtomFamilyToken<T, K extends Json.Serializable> = {
 	key: string
 	type: `atom_family`
 	__T?: T
 	__K?: K
 }
+// biome-ignore format: intersection
+export type RegularAtomFamilyTokenWithCall<
+	T,
+	K extends Json.Serializable,
+> = 
+	& RegularAtomFamilyToken<T, K>
+	& {
+		/** @deprecated Prefer the `findState`, `findInStore`, or `find` functions. */
+		(key: K): RegularAtomToken<T>
+	}
+// biome-ignore format: intersection
+export type RegularAtomFamily<T, K extends Json.Serializable> = 
+	& RegularAtomFamilyToken<T, K>
+	& {
+		(key: K): RegularAtomToken<T>
+		subject: Subject<RegularAtomToken<T>>
+		install: (store: Store) => void
+	}
 
 // biome-ignore format: intersection
 export type MutableAtomFamilyOptions<
@@ -77,23 +84,6 @@ export type MutableAtomFamilyOptions<
 		mutable: true,
 	}
 
-// biome-ignore format: intersection
-export type MutableAtomFamily<
-	T extends Transceiver<any>,
-	J extends Json.Serializable,
-	K extends Json.Serializable,
-> = 
-	& JsonInterface<T, J>
-	& ((key: K) => MutableAtomToken<T, J>) 
-	& {
-			key: string
-			type: `mutable_atom_family`
-			subject: Subject<MutableAtomToken<T, J>>
-			install: (store: Store) => void
-			__T?: T
-			__J?: J
-			__K?: K
-		}
 export type MutableAtomFamilyToken<
 	T extends Transceiver<any>,
 	J extends Json.Serializable,
@@ -105,6 +95,30 @@ export type MutableAtomFamilyToken<
 	__J?: J
 	__K?: K
 }
+// biome-ignore format: intersection
+export type MutableAtomFamilyTokenWithCall<
+	T extends Transceiver<any>,
+	J extends Json.Serializable,
+	K extends Json.Serializable,
+> = 
+	& MutableAtomFamilyToken<T, J, K>
+	& {
+		/** @deprecated Prefer the `findState`, `findInStore`, or `find` functions. */
+		(key: K): MutableAtomToken<T, J>
+	}
+// biome-ignore format: intersection
+export type MutableAtomFamily<
+	T extends Transceiver<any>,
+	J extends Json.Serializable,
+	K extends Json.Serializable,
+> = 
+	& JsonInterface<T, J>
+	& MutableAtomFamilyToken<T, J, K>
+	& {
+			(key: K): MutableAtomToken<T, J>
+			subject: Subject<MutableAtomToken<T, J>>
+			install: (store: Store) => void
+		}
 
 export type AtomFamily<T, K extends Json.Serializable = Json.Serializable> =
 	| MutableAtomFamily<T extends Transceiver<any> ? T : never, any, K>
@@ -117,14 +131,18 @@ export function atomFamily<
 	T extends Transceiver<any>,
 	J extends Json.Serializable,
 	K extends Json.Serializable,
->(options: MutableAtomFamilyOptions<T, J, K>): MutableAtomFamily<T, J, K>
+>(
+	options: MutableAtomFamilyOptions<T, J, K>,
+): MutableAtomFamilyTokenWithCall<T, J, K>
 export function atomFamily<T, K extends Json.Serializable>(
 	options: RegularAtomFamilyOptions<T, K>,
-): RegularAtomFamily<T, K>
+): RegularAtomFamilyTokenWithCall<T, K>
 export function atomFamily<T, K extends Json.Serializable>(
 	options:
 		| MutableAtomFamilyOptions<any, any, any>
 		| RegularAtomFamilyOptions<T, K>,
-): MutableAtomFamily<any, any, any> | RegularAtomFamily<T, K> {
+):
+	| MutableAtomFamilyTokenWithCall<any, any, any>
+	| RegularAtomFamilyTokenWithCall<T, K> {
 	return createAtomFamily(options, IMPLICIT.STORE)
 }

--- a/packages/atom.io/src/selector.ts
+++ b/packages/atom.io/src/selector.ts
@@ -41,41 +41,58 @@ export type ReadonlySelectorFamilyOptions<T, K extends Json.Serializable> = {
 	get: (key: K) => Read<() => T>
 }
 
-export type WritableSelectorFamily<
-	T,
-	K extends Json.Serializable = Json.Serializable,
-> = ((key: K) => WritableSelectorToken<T>) & {
-	key: string
-	type: `selector_family`
-	subject: Subject<WritableSelectorToken<T>>
-	install: (store: Store) => void
-	__T?: T
-	__K?: K
-}
 export type WritableSelectorFamilyToken<T, K extends Json.Serializable> = {
 	key: string
 	type: `selector_family`
 	__T?: T
 	__K?: K
 }
-
-export type ReadonlySelectorFamily<
+// biome-ignore format: intersection
+export type WritableSelectorFamilyTokenWithCall<
 	T,
-	K extends Json.Serializable = Json.Serializable,
-> = ((key: K) => ReadonlySelectorToken<T>) & {
-	key: string
-	type: `readonly_selector_family`
-	subject: Subject<ReadonlySelectorToken<T>>
-	install: (store: Store) => void
-	__T?: T
-	__K?: K
-}
+	K extends Json.Serializable,
+> = 
+	& WritableSelectorFamilyToken<T, K>
+	& {
+		/** @deprecated Prefer the `findState`, `findInStore`, or `find` functions. */
+		(key: K): WritableSelectorToken<T>
+	}
+// biome-ignore format: intersection
+export type WritableSelectorFamily<T, K extends Json.Serializable> = 
+	& WritableSelectorFamilyToken<T, K> 
+	& {
+		(key: K): WritableSelectorToken<T>
+		subject: Subject<WritableSelectorToken<T>>
+		install: (store: Store) => void
+	}
+
 export type ReadonlySelectorFamilyToken<T, K extends Json.Serializable> = {
 	key: string
 	type: `readonly_selector_family`
 	__T?: T
 	__K?: K
 }
+// biome-ignore format: intersection
+export type ReadonlySelectorFamilyTokenWithCall<
+	T,
+	K extends Json.Serializable,
+> = 
+	& ReadonlySelectorFamilyToken<T, K>
+	& {
+		/** @deprecated Prefer the `findState`, `findInStore`, or `find` functions. */
+		(key: K): ReadonlySelectorToken<T>
+	}
+// biome-ignore format: intersection
+export type ReadonlySelectorFamily<T, K extends Json.Serializable> = 
+	& ((key: K) => ReadonlySelectorToken<T>)
+	& {
+		key: string
+		type: `readonly_selector_family`
+		subject: Subject<ReadonlySelectorToken<T>>
+		install: (store: Store) => void
+		__T?: T
+		__K?: K
+	}
 
 export type SelectorFamily<T, K extends Json.Serializable> =
 	| ReadonlySelectorFamily<T, K>
@@ -86,14 +103,16 @@ export type SelectorFamilyToken<T, K extends Json.Serializable> =
 
 export function selectorFamily<T, K extends Json.Serializable>(
 	options: WritableSelectorFamilyOptions<T, K>,
-): WritableSelectorFamily<T, K>
+): WritableSelectorFamilyTokenWithCall<T, K>
 export function selectorFamily<T, K extends Json.Serializable>(
 	options: ReadonlySelectorFamilyOptions<T, K>,
-): ReadonlySelectorFamily<T, K>
+): ReadonlySelectorFamilyTokenWithCall<T, K>
 export function selectorFamily<T, K extends Json.Serializable>(
 	options:
 		| ReadonlySelectorFamilyOptions<T, K>
 		| WritableSelectorFamilyOptions<T, K>,
-): ReadonlySelectorFamily<T, K> | WritableSelectorFamily<T, K> {
+):
+	| ReadonlySelectorFamilyTokenWithCall<T, K>
+	| WritableSelectorFamilyTokenWithCall<T, K> {
 	return createSelectorFamily(options, IMPLICIT.STORE)
 }

--- a/packages/atom.io/src/timeline.ts
+++ b/packages/atom.io/src/timeline.ts
@@ -6,9 +6,9 @@ import type {
 } from "atom.io/internal"
 import { IMPLICIT, createTimeline, timeTravel } from "atom.io/internal"
 
-import type { AtomFamily, AtomToken } from "."
+import type { AtomFamilyToken, AtomToken } from "."
 
-export type TimelineManageable = AtomFamily<any, any> | AtomToken<any>
+export type TimelineManageable = AtomFamilyToken<any, any> | AtomToken<any>
 
 export type TimelineToken<M> = {
 	key: string

--- a/packages/atom.io/src/validators.ts
+++ b/packages/atom.io/src/validators.ts
@@ -1,23 +1,29 @@
 import type {
 	MutableAtomFamily,
+	MutableAtomFamilyToken,
 	MutableAtomToken,
 	ReadableFamily,
+	ReadableFamilyToken,
 	ReadableToken,
 	ReadonlySelectorFamily,
+	ReadonlySelectorFamilyToken,
 	ReadonlySelectorToken,
 	RegularAtomFamily,
+	RegularAtomFamilyToken,
 	RegularAtomToken,
 	WritableFamily,
+	WritableFamilyToken,
 	WritableSelectorFamily,
+	WritableSelectorFamilyToken,
 	WritableSelectorToken,
 	WritableToken,
 } from "atom.io"
 
 export type TokenType<
-	Comparison extends ReadableFamily<any, any> | ReadableToken<any>,
+	Comparison extends ReadableFamilyToken<any, any> | ReadableToken<any>,
 > = Comparison extends ReadableToken<infer RepresentedValue>
 	? RepresentedValue
-	: Comparison extends ReadableFamily<infer RepresentedValue, any>
+	: Comparison extends ReadableFamilyToken<infer RepresentedValue, any>
 	  ? RepresentedValue
 	  : never
 
@@ -52,31 +58,31 @@ export function isToken<KnownToken extends ReadableToken<any>>(
 	return knownToken.key === unknownToken.key
 }
 
-export function belongsTo<Family extends RegularAtomFamily<any, any>>(
+export function belongsTo<Family extends RegularAtomFamilyToken<any, any>>(
 	family: Family,
 	unknownToken: ReadableToken<any>,
 ): unknownToken is RegularAtomToken<TokenType<Family>>
-export function belongsTo<Family extends MutableAtomFamily<any, any, any>>(
+export function belongsTo<Family extends MutableAtomFamilyToken<any, any, any>>(
 	family: Family,
 	unknownToken: ReadableToken<any>,
 ): unknownToken is MutableAtomToken<TokenType<Family>, any>
-export function belongsTo<Family extends WritableSelectorFamily<any, any>>(
+export function belongsTo<Family extends WritableSelectorFamilyToken<any, any>>(
 	family: Family,
 	unknownToken: ReadableToken<any>,
 ): unknownToken is WritableSelectorToken<TokenType<Family>>
-export function belongsTo<Family extends ReadonlySelectorFamily<any, any>>(
+export function belongsTo<Family extends ReadonlySelectorFamilyToken<any, any>>(
 	family: Family,
 	unknownToken: ReadableToken<any>,
 ): unknownToken is ReadonlySelectorToken<TokenType<Family>>
-export function belongsTo<Family extends WritableFamily<any, any>>(
+export function belongsTo<Family extends WritableFamilyToken<any, any>>(
 	family: Family,
 	unknownToken: ReadableToken<any>,
 ): unknownToken is WritableToken<TokenType<Family>>
-export function belongsTo<Family extends ReadableFamily<any, any>>(
+export function belongsTo<Family extends ReadableFamilyToken<any, any>>(
 	family: Family,
 	unknownToken: ReadableToken<any>,
 ): unknownToken is ReadableToken<TokenType<Family>>
-export function belongsTo<Family extends ReadableFamily<any, any>>(
+export function belongsTo<Family extends ReadableFamilyToken<any, any>>(
 	family: Family,
 	unknownToken: ReadableToken<any>,
 ): unknownToken is ReadableToken<TokenType<Family>> {


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Refactored atom and selector family types and creation functions to use new token-based types, enhancing type safety and clarity.
- Expanded `withdraw` function to support a wider range of token types, improving flexibility.
- Updated various components and utilities to use the new token types, ensuring consistency across the codebase.
- Added error handling and robust state retrieval mechanisms in tests and real-time server implementations.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>tracker.test.ts</strong><dd><code>Refactor and Improve Error Handling in Tracker Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/mutability/tracker.test.ts
<li>Refactored <code>atomFamily</code> usage to use <code>setAtoms</code> and <code>findSetState</code> for <br>better clarity and separation of concerns.<br> <li> Added error handling for when <code>findSetState</code> is not found in the store.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1382/files#diff-b222ac1cf7b7346ef90715406e90eaf4b869362848ff335050e64b14f6b38173">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>view-states.ts</strong><dd><code>Update View State Types for Consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__unstable__/react-explorer/src/view-states.ts
<li>Updated type imports to include <code>RegularAtomFamilyToken</code>.<br> <li> Changed <code>makeViewFamily</code> and <code>makeViewFocusedFamily</code> to return <br><code>RegularAtomFamilyToken</code> types for consistency.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1382/files#diff-94ef5d1d82cf93e73a54be206781b86f30028cd5391bd4f64808f38479a78920">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dict.ts</strong><dd><code>Enhance Dict State Retrieval with Token Types and findInStore</code></dd></summary>
<hr>

packages/atom.io/data/src/dict.ts
<li>Updated type imports to use token-based types for families and <br>selectors.<br> <li> Added <code>findInStore</code> usage for more robust state retrieval.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1382/files#diff-fd81617099fc6b9662685e6403c1b59ccfbd867a74192e14283edc84d1ccc122">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>struct-family.ts</strong><dd><code>Update Struct Family Return Type for Enhanced Type Safety</code></dd></summary>
<hr>

packages/atom.io/data/src/struct-family.ts
<li>Updated return type to use <code>ReadonlySelectorFamilyTokenWithCall</code> for <br>better type safety and clarity.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1382/files#diff-21d5683d69769f2cb90f37363ca9c36749da61353433d387370e113cb9bda185">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>withdraw.ts</strong><dd><code>Expand Withdraw Function to Support More Token Types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/store/withdraw.ts
<li>Expanded <code>withdraw</code> function to support a wider range of token types <br>including families and selectors.<br> <li> Added comprehensive type handling for atom families and selector <br>families.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1382/files#diff-4272d49abd49cc98f47d0ccc589ef35a1603770339ebb56be75244b01c792d90">+66/-2</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create-timeline.ts</strong><dd><code>Add AtomFamilyToken Support in Timeline Creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/timeline/create-timeline.ts
<li>Added handling for <code>AtomFamilyToken</code> types in timeline creation, <br>including error logging for missing families in the store.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1382/files#diff-80d8652ac82c84c4de60ea0e6471302623238e5c84a8defe03945b00872c4873">+12/-1</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>attach-timeline-family.ts</strong><dd><code>Update Attach Timeline Family Return Type to Token</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/introspection/src/attach-timeline-family.ts
<li>Updated return type to <code>ReadonlySelectorFamilyToken</code> for consistency <br>with new token-based types.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1382/files#diff-ae9cb007ec1985667d01537482ff18478596b4847430562b7522936c73805193">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>attach-transaction-logs.ts</strong><dd><code>Align Attach Transaction Logs Return Type with Token System</code></dd></summary>
<hr>

packages/atom.io/introspection/src/attach-transaction-logs.ts
<li>Changed return type to <code>ReadonlySelectorFamilyToken</code> to align with <br>updated type system.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1382/files#diff-b14bde7c78b016d5ff4cd3a8283e465696a5aa06a71579a0da425c9547b46ee6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>realtime-mutable-family-provider.ts</strong><dd><code>Enhance Realtime Mutable Family Provider with Token Types</code></dd></summary>
<hr>

packages/atom.io/realtime-server/src/realtime-mutable-family-provider.ts
<li>Updated to use <code>MutableAtomFamilyToken</code> for type safety.<br> <li> Implemented <code>findInStore</code> for robust state retrieval in real-time <br>scenarios.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1382/files#diff-529a50ed14c62d117d3aaccd9b775bfa3919b68e1d17c17fdc5ea392dd5d0a9a">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>atom.ts</strong><dd><code>Refactor Atom Family Types and Creation for Clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/atom.ts
<li>Introduced token-based types for atom families with deprecated call <br>signatures.<br> <li> Refactored atom family creation to return token types with call <br>signatures.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1382/files#diff-1b18eaa66e66bd13d179fb4e02295c11376b9d25b3be22812b2d6e1993e46f16">+49/-31</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>selector.ts</strong><dd><code>Update Selector Family Types and Creation with Tokens</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/selector.ts
<li>Added token-based types for selector families with deprecated call <br>signatures.<br> <li> Updated selector family creation to return new token types.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1382/files#diff-5a6b3bc499ec325f1fdea52698e73b551742a2d4f748332d27475c171f815e47">+44/-25</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>timeline.ts</strong><dd><code>Update Timeline Manageable Type to Use AtomFamilyToken</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/timeline.ts
<li>Updated <code>TimelineManageable</code> type to use <code>AtomFamilyToken</code> for <br>consistency.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1382/files#diff-bd5f70cfb8cabcd472c55a7f72a953212a5470f50e7ca97feb73de4b321b88cb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>validators.ts</strong><dd><code>Update Validators to Support New Token Types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/validators.ts
<li>Updated validator functions to support the new token-based family and <br>selector types.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1382/files#diff-e622d253dfd557e0ecd486c08243d041aeba85783e1d8f12ffb991df495bfb44">+15/-9</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
