### PR TITLE
🛠️ build and run with just bun

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,2 +1,11 @@
 [phases.setup]
-nixPkgs = ['nodejs_20', 'bun']
+nixPkgs = ['bun']
+
+[phases.install]
+cmds = ['bun i']
+
+[phases.build]
+cmds = ['cd apps/node/lodge', 'bun run build']
+
+[start]
+cmds = ['cd apps/node/lodge', 'bun run start']


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Simplified the build and run process by exclusively using Bun for package management and script execution.
- Removed Node.js from the setup phase, indicating a shift to Bun as the primary runtime.
- Added specific commands for installation, build, and start phases to ensure the application is correctly set up and executed within the Bun environment.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nixpacks.toml</strong><dd><code>Simplify Build and Run Process Using Bun</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nixpacks.toml
<li>Removed <code>nodejs_20</code> from <code>nixPkgs</code> in the setup phase.<br> <li> Defined <code>bun i</code> as the install command.<br> <li> Specified build commands to navigate to <code>apps/node/lodge</code> and run <code>bun </code><br><code>run build</code>.<br> <li> Set start commands to navigate to <code>apps/node/lodge</code> and execute <code>bun run </code><br><code>start</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1420/files#diff-f8f0421b01aa1e4a1eea752ad7173771d9765d0bd8782c8f459354068609834c">+10/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

