### PR TITLE
🐛 fix handling of ref in ci

### DIFF
--- a/lib/update-lockfile.sh
+++ b/lib/update-lockfile.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
 
 # Configure Git to recognize the repository as a safe directory
-git config --global --add safe.directory /__w/wayforge/wayforge
+git config --global --add safe.directory "$(pwd)"
+
+# Extract the branch name from the GITHUB_REF env variable or fallback to git command
+# This assumes the script is run in a GitHub Actions environment
+branch_name="${GITHUB_REF##*/}"
+if [ -z "$branch_name" ]; then
+    branch_name=$(git rev-parse --abbrev-ref HEAD)
+fi
+
+# Log the current branch name
+echo "Current branch: $branch_name"
 
 # Verify we're on a renovate/* branch
-current_branch=$(git rev-parse --abbrev-ref HEAD)
-if [[ ! $current_branch == renovate/* ]]; then
+if [[ ! $branch_name =~ ^renovate/ ]]; then
     echo "Not on a 'renovate/' branch. Exiting..."
     exit 0
 fi

--- a/lib/update-lockfile.sh
+++ b/lib/update-lockfile.sh
@@ -5,16 +5,13 @@ git config --global --add safe.directory "$(pwd)"
 
 # Extract the branch name from the GITHUB_REF env variable or fallback to git command
 # This assumes the script is run in a GitHub Actions environment
-branch_name="${GITHUB_REF##*/}"
-if [ -z "$branch_name" ]; then
-    branch_name=$(git rev-parse --abbrev-ref HEAD)
-fi
+# BRANCH_NAME=$(echo GITHUB_HEAD_REF | sed 's|refs/heads/||')
 
 # Log the current branch name
-echo "Current branch: $branch_name"
+echo "Current branch: $GITHUB_HEAD_REF"
 
 # Verify we're on a renovate/* branch
-if [[ ! $branch_name =~ ^renovate/ ]]; then
+if [[ ! $GITHUB_HEAD_REF == renovate/* ]]; then
     echo "Not on a 'renovate/' branch. Exiting..."
     exit 0
 fi


### PR DESCRIPTION
## **Type**
bug_fix, enhancement


___

## **Description**
- Improved the handling of the current branch name by supporting GitHub Actions environment variables and fallback to git command if not available.
- Changed Git configuration to consider the current working directory as a safe directory.
- Added logging for better visibility of the current branch name during CI processes.
- Enhanced branch name check to use regex, ensuring only branches with `renovate/` prefix are processed.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update-lockfile.sh</strong><dd><code>Improved Branch Handling and Git Configuration in CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/update-lockfile.sh
<li>Git configuration now uses the current working directory as a safe <br>directory.<br> <li> Branch name extraction improved to support GitHub Actions environment <br>variables.<br> <li> Added logging for the current branch name.<br> <li> Improved branch name check to use regex for <code>renovate/</code> prefix.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1439/files#diff-315c1ef5966db907895bbe6916f82bf32e351b9552e34274af6a5e0be2ea121d">+12/-3</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

