### PR TITLE
fix bugs with push

### DIFF
--- a/lib/update-lockfile.sh
+++ b/lib/update-lockfile.sh
@@ -3,10 +3,6 @@
 # Configure Git to recognize the repository as a safe directory
 git config --global --add safe.directory "$(pwd)"
 
-# Extract the branch name from the GITHUB_REF env variable or fallback to git command
-# This assumes the script is run in a GitHub Actions environment
-# BRANCH_NAME=$(echo GITHUB_HEAD_REF | sed 's|refs/heads/||')
-
 # Log the current branch name
 echo "Current branch: $GITHUB_HEAD_REF"
 
@@ -25,5 +21,5 @@ else
     git config --global user.name "GitHub Action"
     git add bun.lockb
     git commit -m "📦"
-    git push
+    git push origin "$GITHUB_HEAD_REF"
 fi


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Fixed an issue where the lockfile update script did not correctly push changes to the intended branch.
- Simplified the script by removing unnecessary branch name extraction, assuming the environment provides `GITHUB_HEAD_REF`.
- Ensured that `git push` explicitly targets the correct origin and branch, improving reliability in automated environments.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update-lockfile.sh</strong><dd><code>Enhance Lockfile Update Script for Renovate Branches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/update-lockfile.sh
<li>Configured Git to recognize the repository as a safe directory.<br> <li> Removed extraction of branch name from <code>GITHUB_REF</code> environment <br>variable.<br> <li> Added explicit origin and branch name to <code>git push</code> command to ensure <br>correct branch is pushed.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1441/files#diff-315c1ef5966db907895bbe6916f82bf32e351b9552e34274af6a5e0be2ea121d">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

