### PR TITLE
👷 push to ref without local name

### DIFF
--- a/lib/update-lockfile.sh
+++ b/lib/update-lockfile.sh
@@ -21,5 +21,5 @@ else
     git config --global user.name "GitHub Action"
     git add bun.lockb
     git commit -m "📦"
-    git push origin "$GITHUB_HEAD_REF"
+    git push origin HEAD:refs/heads/"$GITHUB_HEAD_REF"
 fi


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Enhanced the `git push` command in `update-lockfile.sh` to explicitly specify the remote branch name, improving compatibility with different Git configurations.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update-lockfile.sh</strong><dd><code>Enhance Git Push Command in Lockfile Update Script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/update-lockfile.sh
<li>Modified the <code>git push</code> command to explicitly specify the remote branch <br>name.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1442/files#diff-315c1ef5966db907895bbe6916f82bf32e351b9552e34274af6a5e0be2ea121d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

