### PR TITLE
👷 add token for gh cli

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
@@ -55,6 +54,8 @@ jobs:
         run: bun i
 
       - name: Update Lockfile
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./lib/update-lockfile.sh
 
       - name: Set up Git


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Removed the global `GITHUB_TOKEN` environment variable to refine scope.
- Introduced `GH_TOKEN` in the `Update Lockfile` job, ensuring secure and scoped access for GitHub CLI operations.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coverage.yml</strong><dd><code>Enhance GitHub Actions Workflow for Lockfile Update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/coverage.yml
<li>Removed <code>GITHUB_TOKEN</code> from global <code>env</code>.<br> <li> Added <code>GH_TOKEN</code> with <code>GITHUB_TOKEN</code> value to <code>Update Lockfile</code> job.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1445/files#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

