### PR TITLE
use gh cli

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,8 +22,6 @@ jobs:
   Coverage:
     name: Coveralls
     runs-on: ubuntu-latest
-    container:
-      image: node:lts
     timeout-minutes: 15
 
     services:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,8 +21,6 @@ defaults:
 jobs:
   Lint:
     runs-on: ubuntu-latest
-    container:
-      image: node:lts
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -51,8 +49,6 @@ jobs:
   Test:
     name: Build & Test
     runs-on: ubuntu-latest
-    container:
-      image: node:lts
     timeout-minutes: 15
     env:
       NEXT_PUBLIC_REMOTE_ORIGIN: ${{ secrets.NEXT_PUBLIC_REMOTE_ORIGIN }}


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Removed the container specification from `coverage.yml` and `integration.yml` workflows to use the default GitHub Actions runner instead of a specific Docker container.
- This change simplifies the workflows by relying on the default runner's environment, potentially improving the execution time and reducing complexity.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coverage.yml</strong><dd><code>Simplify Coverage Workflow by Using Default Runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/coverage.yml
<li>Removed the container specification to use the default runner <br>environment.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1447/files#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>integration.yml</strong><dd><code>Use Default Runner for Lint and Test Jobs in Integration Workflow</code></dd></summary>
<hr>

.github/workflows/integration.yml
<li>Removed the container specification for both Lint and Test jobs to use <br>the default runner environment.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1447/files#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8b">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

