### PR TITLE
👷 try another strategy using a personal access token

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,7 +5,6 @@ on:
     branches: ["main"]
   pull_request:
     types: [opened, synchronize]
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -54,29 +53,13 @@ jobs:
 
       - name: Update Lockfile
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RENOVATE_HELPER_GITHUB_PAT }}
         run: |
-          git config --global --add safe.directory "$(pwd)"
-
-          echo "Current branch: $GITHUB_HEAD_REF"
-
-          if [[ ! $GITHUB_HEAD_REF == renovate/* ]]; then
-              echo "Not on a 'renovate/' branch. Exiting..."
-              exit 0
-          fi
-
-          if git diff --exit-code --name-only -- bun.lockb; then
-              echo "bun.lockb is unchanged."
-          else
-              echo "bun.lockb has changed, committing changes..."
-              git config --global user.email "action@github.com"
-              git config --global user.name "GitHub Action"
-              git add bun.lockb
-              git commit -m "📦"
-              git push origin HEAD:refs/heads/"$GITHUB_HEAD_REF"
-              gh workflow run integration.yml --ref "$GITHUB_HEAD_REF"
-              gh workflow run coverage.yml --ref "$GITHUB_HEAD_REF"
-          fi
+          git config --global user.name 'Your Name'
+          git config --global user.email 'your.email@example.com'
+          git add bun.lockb
+          git commit -m 'Update lock file' || echo "no change to lockfile" && exit 0
+          git push origin HEAD:${{ github.head_ref }}
 
       - name: Set up Git
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,6 @@ on:
     branches: ["main"]
   pull_request:
     types: [opened, synchronize]
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Simplified the "Update Lockfile" step in the coverage workflow to improve efficiency and use a personal access token for authentication.
- Removed the `workflow_dispatch` trigger from both coverage and integration workflows to streamline the CI process.
- Updated environment variable for GitHub token to use a specific personal access token (`RENOVATE_HELPER_GITHUB_PAT`).
- Updated git configuration for user name and email in the coverage workflow.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coverage.yml</strong><dd><code>Simplify Coverage Workflow and Use Personal Access Token</code>&nbsp; </dd></summary>
<hr>

.github/workflows/coverage.yml
<li>Removed <code>workflow_dispatch</code> trigger.<br> <li> Changed environment variable from <code>GH_TOKEN</code> to <code>GITHUB_TOKEN</code> with a new <br>secret <code>RENOVATE_HELPER_GITHUB_PAT</code>.<br> <li> Simplified the "Update Lockfile" step to only commit changes to <br><code>bun.lockb</code> if any, with updated git user config and a new commit <br>message.<br> <li> Removed conditional checks for branch name and lockfile changes, <br>streamlining the process.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1449/files#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6">+6/-23</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>integration.yml</strong><dd><code>Remove Unnecessary Workflow Dispatch Trigger</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/integration.yml
- Removed `workflow_dispatch` trigger.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1449/files#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8b">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

