### PR TITLE
👷 only run semver on PR

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,8 +1,6 @@
 name: Semver
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
     types: [opened, synchronize]
 


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- This PR updates the GitHub Actions workflow for semantic versioning by disabling it for `push` events to the `main` branch. Now, it will only run on pull request events, specifically when they are opened or synchronized.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semver.yml</strong><dd><code>Disable Semver Workflow on Push to Main Branch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/semver.yml
- Removed trigger for `push` events on the `main` branch.



</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1494/files#diff-248962e0d8d239ef3392f051ef2a689de195994852d4b555ff20b7a30f2414d0">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

