### PR TITLE
atom.io remove source map for now

### DIFF
--- a/.changeset/tame-waves-notice.md
+++ b/.changeset/tame-waves-notice.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 The sourcemap shipped to npm is deficient. Removing for now; just use built js in the debugger instead.

--- a/packages/atom.io/tsup.config.ts
+++ b/packages/atom.io/tsup.config.ts
@@ -25,7 +25,7 @@ export const BASE_OPTIONS: Options = {
 	jsxFactory: `React.createElement`,
 	loader: { ".scss": `css` },
 	metafile: true,
-	sourcemap: true,
+	sourcemap: false,
 	treeshake: true,
 	tsconfig: `tsconfig.json`,
 }


### PR DESCRIPTION
## **User description**
- **🛠️ sourcemap: false**
- **🦋**


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Disabled source map generation in `tsup.config.ts` to address deficiencies with the source map shipped to npm.
- Added a changeset entry to document the removal of the source map and its impact.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tsup.config.ts</strong><dd><code>Disable Source Map Generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/tsup.config.ts
- Disabled source map generation by setting `sourcemap` to `false`.



</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1496/files#diff-e21a0df20e9d072869149529f25656f2f60faab49534399fdb32ac9820a9a388">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tame-waves-notice.md</strong><dd><code>Document Source Map Removal in Changeset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/tame-waves-notice.md
<li>Added a changeset file to document the patch update for <code>atom.io</code>.<br> <li> Described the removal of the source map due to deficiencies.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1496/files#diff-fc86b7ab5207e43d7016b4cec582f89481767edfee5d94926b023cf66f85bd1e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

