### PR TITLE
💬 revise patchnote

### DIFF
--- a/.changeset/tame-waves-notice.md
+++ b/.changeset/tame-waves-notice.md
@@ -2,4 +2,4 @@
 "atom.io": patch
 ---
 
-🐛 The sourcemap shipped to npm is deficient. Removing for now; just use built js in the debugger instead.
+🐛 The sourcemap that was being shipped to npm was deficient, and would indicate lines incorrectly in the debugger. The sourcemap is being removed for now. The built, but non-minified js will appear in the debugger instead.


### PR DESCRIPTION
## **Type**
documentation


___

## **Description**
- Clarified the deficiency in the sourcemap that was being shipped to npm, which caused incorrect line indications in the debugger.
- Announced the removal of the deficient sourcemap and the temporary use of built, but non-minified js in the debugger.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tame-waves-notice.md</strong><dd><code>Clarification and Temporary Solution for Sourcemap Issue</code>&nbsp; </dd></summary>
<hr>

.changeset/tame-waves-notice.md
<li>Updated the patch note to clarify the issue with the sourcemap being <br>shipped to npm.<br> <li> Explained the temporary solution of removing the sourcemap and using <br>built, but non-minified js in the debugger.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1498/files#diff-fc86b7ab5207e43d7016b4cec582f89481767edfee5d94926b023cf66f85bd1e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

