### PR TITLE
🔧 eslint: disable quote props

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,8 +42,7 @@ const config = {
 		"@typescript-eslint/unified-signatures": `error`,
 
 		"no-mixed-spaces-and-tabs": `off`,
-		"quotes": [`error`, `backtick`],
-		"quote-props": [`error`, `consistent`, { unnecessary: false }],
+		quotes: [`error`, `backtick`],
 	},
 }
 export default [config]


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Simplified ESLint configuration by removing the rule that enforced quotes around object properties.
- Now, the ESLint configuration enforces the use of backticks for quotes without specifying rules for object property quotes, making the code style more consistent and reducing linting errors related to quote styles.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>eslint.config.js</strong><dd><code>Simplify Quote Rules in ESLint Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

eslint.config.js
<li>Removed the rule enforcing quotes around object properties.<br> <li> Simplified the <code>quotes</code> rule to enforce backticks without specifying <br>object property quotes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1575/files#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

