### PR TITLE
advanced future

### DIFF
--- a/.changeset/new-turkeys-laugh.md
+++ b/.changeset/new-turkeys-laugh.md
@@ -1,0 +1,38 @@
+---
+"atom.io": minor
+---
+
+🐛 Fix bug with `Loadable` (async) selectors.
+
+  It remains the case that, when an atom or selector is set to a Promise, the store will wrap that Promise in an internal mechanism called a "Future". When the Future is resolved, the atom or selector will be updated to the resolved value.
+  
+  Previously, the store had the option to "cancel" a Future in the event that a selector was evicted from the store, due to states upstream of the selector being changed. The idea was to prevent a race condition where an earlier value might override a later one. But because a cancelled Future will never resolve, a problem arose with code like the following:
+  
+  ```ts
+  const urlAtom = atom<string>({
+    key: `url`,
+    default: `https://example.com`,
+  })
+  const fetchResponseSelector = selector<Loadable<Response>>({
+    key: `fetch`,
+    get: async ({ get }) => {
+      const url = get(urlAtom)
+      return await fetch(url)
+    }
+  })
+  const fetchedJsonSelector = selector<Loadable<Json.Serializable>>({
+    key: `fetchedJson`,
+    get: async ({ get }) => {
+      const responseLoadable = get(fetchResponseSelector)
+      const response = await responseLoadable // <-- ❗ this might never resolve if the urlAtom changes
+      return await response.json()
+    }
+  })
+  ```
+
+  The problem here is that, if the `urlAtom` changes while `fetchedJsonSelector`'s getter is running, the `fetchResponseSelector`'s current future value will be cancelled and will never resolve, leading to a getter will hang forever.
+
+  This fix guarantees that every instance of a Loadable selector will always resolve, so atom.io won't cause code like the above to hang.
+
+  However, this also means that selectors whose values are currently a future will not be evicted, and will always be recomputed eagerly when their dependencies change. This behavior may become somewhat lazier in a future release.
+  

--- a/packages/atom.io/__tests__/public/async-state.test.ts
+++ b/packages/atom.io/__tests__/public/async-state.test.ts
@@ -79,7 +79,7 @@ describe(`async atom`, async () => {
 		// biome-ignore lint/style/noNonNullAssertion: it's a test, so
 		resolveAtAnInconvenientTime!()
 		await new Promise((resolve) => setTimeout(resolve, 0))
-		expect(Internal.IMPLICIT.STORE.valueMap.get(`doubled`)).toBe(undefined)
+		expect(Internal.IMPLICIT.STORE.valueMap.get(`doubled`)).toBe(2)
 	})
 })
 

--- a/packages/atom.io/__tests__/public/async-state.test.ts
+++ b/packages/atom.io/__tests__/public/async-state.test.ts
@@ -75,7 +75,9 @@ describe(`async atom`, async () => {
 			Internal.Future,
 		)
 		AtomIO.setState(countState, 1)
-		expect(Internal.IMPLICIT.STORE.valueMap.get(`doubled`)).toBe(undefined)
+		expect(Internal.IMPLICIT.STORE.valueMap.get(`doubled`)).toBeInstanceOf(
+			Internal.Future,
+		)
 		// biome-ignore lint/style/noNonNullAssertion: it's a test, so
 		resolveAtAnInconvenientTime!()
 		await new Promise((resolve) => setTimeout(resolve, 0))

--- a/packages/atom.io/break-check.config.json
+++ b/packages/atom.io/break-check.config.json
@@ -2,5 +2,5 @@
 	"tagPattern": "atom.io",
 	"testPattern": "__tests__/public/**/*.test.{ts,tsx}",
 	"testCommand": "bun run build && bun run test:once:public",
-	"certifyCommand": "grep -q -F '\"atom.io\": major' ../../.changeset/*.md"
+	"certifyCommand": "grep -q -F '\"atom.io\": minor' ../../.changeset/*.md"
 }

--- a/packages/atom.io/internal/src/caching.ts
+++ b/packages/atom.io/internal/src/caching.ts
@@ -69,6 +69,7 @@ export const evictCachedValue = (key: string, target: Store): void => {
 		if (selector) {
 			future.use(selector.get())
 		}
+		return
 	}
 	if (target.operation.open) {
 		target.operation.prev.set(key, currentValue)

--- a/packages/atom.io/internal/src/future.ts
+++ b/packages/atom.io/internal/src/future.ts
@@ -1,5 +1,5 @@
 /**
- * A Promise that can be canceled.
+ * A Promise whose incoming value can be hot swapped.
  * @internal
  * @private
  * @typeParam T The type of the value that the promise will resolve to.
@@ -8,29 +8,66 @@
  * Can be constructed like a Promise, or from an existing Promise.
  */
 export class Future<T> extends Promise<T> {
-	public isCanceled = false
+	private destiny: Promise<T> | undefined
+	private resolve: (value: T) => void
+	private reject: (reason?: any) => void
 
 	public constructor(
 		executor:
 			| Promise<T>
 			| ((resolve: (value: T) => void, reject: (reason?: any) => void) => void),
 	) {
+		let promise: Promise<T> | undefined
+		let superResolve: ((value: T) => void) | undefined
+		let superReject: ((reason?: any) => void) | undefined
 		super((resolve, reject) => {
-			const pass = (value: T) => {
-				this.isCanceled ? reject(`canceled`) : resolve(value)
-			}
-			const fail = (reason: any) => {
-				this.isCanceled ? reject(`canceled`) : reject(reason)
-			}
-			if (typeof executor === `function`) {
-				executor(pass, fail)
-			} else {
-				executor.then(pass, fail)
-			}
+			superResolve = resolve
+			superReject = reject
+			promise = executor instanceof Promise ? executor : new Promise(executor)
+			promise.then(
+				(value) => {
+					if (promise) {
+						this.pass(promise, value)
+					}
+				},
+				(reason) => {
+					if (promise) {
+						this.fail(promise, reason)
+					}
+				},
+			)
 		})
+		this.destiny = promise
+		this.resolve = superResolve as (value: T) => void
+		this.reject = superReject as (reason?: any) => void
 	}
 
-	public cancel(): void {
-		this.isCanceled = true
+	private pass(promise: Promise<T>, value: T) {
+		if (promise === this.destiny) {
+			this.resolve(value)
+		}
+	}
+	private fail(promise: Promise<T>, reason: any) {
+		if (promise === this.destiny) {
+			this.reject(reason)
+		}
+	}
+
+	public use(value: Promise<T> | T): void {
+		if (value instanceof Promise) {
+			const promise = value
+			this.destiny = promise
+			promise.then(
+				(resolved) => {
+					this.pass(promise, resolved)
+				},
+				(reason) => {
+					this.fail(promise, reason)
+				},
+			)
+		} else {
+			this.resolve(value)
+			this.destiny = undefined
+		}
 	}
 }


### PR DESCRIPTION
## **User description**
- **🔧 adjust break-check rules in anticipation of breaking change**
- **💥 change the way future handles replacement**
- **🐛 return early; don't remove reference to future in ValueMap**
- **🦋**


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Redesigned the `Future` class to support dynamic value replacement instead of cancellation, enhancing robustness and flexibility.
- Updated and extended test suites in `future-internal.test.ts` and `async-state.test.ts` to align with the new `Future` behavior.
- Refactored caching strategies in `caching.ts` to utilize the new capabilities of the `Future` class, removing the need for cancellation.
- Added comprehensive documentation in `.changeset` to explain the bug fix and the rationale behind the changes.
- Adjusted the break-check configuration to reflect the minor version update.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>future-internal.test.ts</strong><dd><code>Update and Extend Future Class Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/private/future-internal.test.ts
<li>Simplified imports and removed unused ones.<br> <li> Modified existing tests to reflect changes in the Future class's <br>behavior.<br> <li> Added new test cases to handle different scenarios of promise <br>rejection and resolution.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1812/files#diff-c7e6964ea151991aed420d64f6f72292a153c4ea30c91f4596f414a010a1f0fa">+62/-80</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>async-state.test.ts</strong><dd><code>Adjust Async State Tests for Future Instance Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/public/async-state.test.ts
<li>Adjusted test expectations to align with the new behavior of Future <br>instances in the valueMap.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1812/files#diff-3c0592098839f0a7e88cbf5bebd85e703a77816a844913bd091b61bb80d29f42">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>caching.ts</strong><dd><code>Refactor Caching Strategy to Use Future's New Capabilities</code></dd></summary>
<hr>

packages/atom.io/internal/src/caching.ts
<li>Removed cancellation of Future instances and replaced with new 'use' <br>method.<br> <li> Adjusted error handling and future management in cacheValue function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1812/files#diff-d335bdb5dd6ac3929e2c1878ed04fc2466fd428ba7ecea461d54bd8f98506c94">+12/-9</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>future.ts</strong><dd><code>Redesign Future to Allow Hot Swapping of Values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/future.ts
<li>Transformed Future from a cancellable promise to one that allows hot <br>swapping of incoming values.<br> <li> Added methods to handle promise resolution and rejection internally.<br> <li> Provided a new 'use' method to replace or set the value of the Future.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1812/files#diff-cc344e2b185ed47ac99da5844176b739d7c36d707b46af3851258de9f28f7d08">+52/-15</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>new-turkeys-laugh.md</strong><dd><code>Document Changes and Bug Fix in Future Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/new-turkeys-laugh.md
<li>Described the changes made to Future handling in atom.io, emphasizing <br>the resolution of a bug and minor version bump.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1812/files#diff-fdd33a7aaded2c97152d6e023f27375f7a261e950928f5b6ecc24fcd0523db8a">+38/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>break-check.config.json</strong><dd><code>Update Break-Check Configuration for Minor Version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/break-check.config.json
<li>Updated the certify command to check for a minor version update in <br>changesets.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1812/files#diff-4bcdfcbf7123f7b1cacf0dc2488a1a2487af0b534bc8f0e79432461483498321">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

