### PR TITLE
atom.io enqueue set

### DIFF
--- a/.changeset/weak-shrimps-think.md
+++ b/.changeset/weak-shrimps-think.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+✨ Calling `setState` during a `setState` operation is more forgiving now. Instead of logging an error and doing nothing, it will now log a warning and enqueue the update for as soon as the current operation completes.

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
@@ -164,45 +164,4 @@ describe(`synchronizing transactions`, () => {
 		await waitFor(() => dave.renderResult.getByTestId(`2`), { timeout: 3000 })
 		teardown()
 	})
-	test.skip(`recovery`, async () => {
-		const { clients, teardown } = scenario()
-
-		const jane = clients.jane.init()
-		const dave = clients.dave.init()
-
-		await waitFor(() => {
-			throwUntil(jane.socket.connected)
-		})
-		await waitFor(() => {
-			throwUntil(dave.socket.connected)
-		})
-
-		await act(() => jane.socket.disconnect())
-		await waitFor(() => {
-			throwUntil(!jane.socket.connected)
-		})
-
-		act(() => {
-			jane.renderResult.getByTestId(`increment`).click()
-		})
-
-		act(() => {
-			dave.renderResult.getByTestId(`increment`).click()
-		})
-		act(() => {
-			dave.renderResult.getByTestId(`increment`).click()
-		})
-
-		await waitFor(() => jane.renderResult.getByTestId(`1`))
-		await waitFor(() => dave.renderResult.getByTestId(`2`))
-
-		await act(() => jane.socket.connect())
-		await waitFor(() => {
-			throwUntil(jane.socket.connected)
-		})
-
-		await waitFor(() => dave.renderResult.getByTestId(`3`))
-		await waitFor(() => jane.renderResult.getByTestId(`3`))
-		teardown()
-	}, 3000)
 })

--- a/packages/atom.io/__tests__/private/grace.test.ts
+++ b/packages/atom.io/__tests__/private/grace.test.ts
@@ -1,5 +1,4 @@
 import type {
-	AtomFamily,
 	AtomFamilyToken,
 	Logger,
 	RegularAtomToken,
@@ -9,6 +8,7 @@ import {
 	atom,
 	atomFamily,
 	findState,
+	getState,
 	redo,
 	selector,
 	setState,
@@ -50,7 +50,7 @@ describe(`not found`, () => {
 
 describe(`graceful handling of improper usage`, () => {
 	describe(`a nested call to setState is a violation`, () => {
-		test(`the inner call results in a no-op and a logger(error)`, () => {
+		test(`the inner call results in a logger(warn) and enqueues the update`, () => {
 			const a = atom<number>({
 				key: `a`,
 				default: 0,
@@ -83,12 +83,15 @@ describe(`graceful handling of improper usage`, () => {
 				return n + 1
 			})
 
-			expect(logger.error).toHaveBeenCalledWith(
-				`❌`,
+			expect(logger.warn).toHaveBeenCalledWith(
+				`❗`,
 				`atom`,
 				`b`,
-				`failed to setState during a setState for "a"`,
+				`tried to setState, but must wait until setState for "a" completes`,
 			)
+
+			expect(getState(a)).toBe(1)
+			expect(getState(b)).toBe(true)
 		})
 	})
 	describe(`giving an atom to multiple timelines is a violation`, () => {

--- a/packages/atom.io/internal/src/operation.ts
+++ b/packages/atom.io/internal/src/operation.ts
@@ -21,11 +21,11 @@ export const openOperation = (
 	store: Store,
 ): `rejection` | undefined => {
 	if (store.operation.open) {
-		store.logger.error(
-			`❌`,
+		store.logger.warn(
+			`❗`,
 			token.type,
 			token.key,
-			`failed to setState during a setState for "${store.operation.token.key}"`,
+			`tried to setState, but must wait until setState for "${store.operation.token.key}" completes`,
 		)
 		return `rejection`
 	}

--- a/packages/atom.io/internal/src/set-state/set-into-store.ts
+++ b/packages/atom.io/internal/src/set-state/set-into-store.ts
@@ -1,6 +1,5 @@
 import type { WritableToken } from "atom.io"
 
-import { NotFoundError } from "../not-found-error"
 import { closeOperation, openOperation } from "../operation"
 import type { Store } from "../store"
 import { withdrawOrCreate } from "../store"
@@ -13,6 +12,13 @@ export function setIntoStore<T, New extends T>(
 ): void {
 	const rejection = openOperation(token, store)
 	if (rejection) {
+		const unsubscribe = store.on.operationClose.subscribe(
+			`waiting to set "${token.key}"`,
+			() => {
+				unsubscribe()
+				setIntoStore(token, value, store)
+			},
+		)
 		return
 	}
 	const state = withdrawOrCreate(token, store)

--- a/packages/atom.io/src/logger.ts
+++ b/packages/atom.io/src/logger.ts
@@ -8,6 +8,7 @@ const LoggerIconDictionary = {
 	"⏹️": `Time-travel complete`,
 	"✅": `Realtime transaction success`,
 	"✨": `Computation complete`,
+	"❗": `Must wait to proceed with attempted action`,
 	"❌": `Conflict prevents attempted action`,
 	"⭕": `Operation start`,
 	"🐞": `Possible bug in AtomIO`,


### PR DESCRIPTION
## **User description**
- **✨ make the process of setting state more forgiving**
- **✅ update tests**
- **🦋**


___

## **Type**
Enhancement, Bug fix


___

## **Description**
- Removed a skipped test case for recovery in `realtime-continuity.test.tsx`.
- Enhanced error handling by changing from error to warning for nested `setState` calls in `grace.test.ts`.
- Added logic to enqueue updates when `setState` is called within another `setState`.
- Updated concurrent `setState` operation handling to log a warning instead of an error.
- Implemented a subscription mechanism to handle state updates when blocked by ongoing operations.
- Extended the logger functionality with a new warning icon and description for state update attempts.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>realtime-continuity.test.tsx</strong><dd><code>Remove skipped recovery test case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
- Removed a skipped test case related to recovery scenarios.



</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1820/files#diff-4f1c176a31b9dff3ac3aea98ff0474ca2328dacd84a7821b215adbf33f198844">+0/-41</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>grace.test.ts</strong><dd><code>Enhance error handling in nested setState calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/private/grace.test.ts
<li>Changed error handling to warning for nested <code>setState</code> calls.<br> <li> Added logic to enqueue state updates when <code>setState</code> is called within <br>another <code>setState</code>.<br> <li> Updated assertions to check for warnings and state values.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1820/files#diff-704681e68b526dd6ec35340de49c6e296c5f461e7ad23fc3c7bb75e249506176">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>operation.ts</strong><dd><code>Update logging for concurrent setState operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/operation.ts
<li>Modified error logging to warning for concurrent <code>setState</code> operations.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1820/files#diff-70c20ecdebb80b8240566a702a4e92b1fde8a5741a4c04123e352f6d4355bad7">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>set-into-store.ts</strong><dd><code>Implement state update enqueuing on operation block</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/set-state/set-into-store.ts
<li>Implemented a subscription mechanism to enqueue state updates when <br>blocked by ongoing operations.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1820/files#diff-57e5d076356ff8fdd80da1f26bb40baf03de821e36e28df6db760f2697ba9d3e">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>logger.ts</strong><dd><code>Extend logger with new warning icon and description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/logger.ts
<li>Added a new logger icon and description for warnings related to state <br>update attempts.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1820/files#diff-f2d95c39203c617eb5dc522d7b25f0336f303a1561df113186299023a8ea0dcd">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>weak-shrimps-think.md</strong><dd><code>Document changes in changeset file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/weak-shrimps-think.md
<li>Added changeset metadata describing the patch as making <code>setState</code> more <br>forgiving.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1820/files#diff-1034471bbf3daa0313e30811ca57057eeb8561a7400ce530489faa7f6ccfd8fe">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

