### PR TITLE
atom.io fix polymorphic selector subscription

### DIFF
--- a/.changeset/cyan-radios-roll.md
+++ b/.changeset/cyan-radios-roll.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 Fix bug where, when a subscribed selector was re-evaluated, and its root atoms changed, the subscription would not be updated to track those new roots, but would instead remain tracking the roots that were present when the subscription was originally created.


### PR DESCRIPTION
## **User description**
- **🐛 rebuild selector dependency subscriptions**
- **✅ test that this works**
- **🦋**


___

## **Type**
Bug fix, Enhancement


___

## **Description**
- Enhanced test suite in `atom-selector.test.ts` to include tests for selectors with conditional dependencies.
- Refactored subscription logic in `subscribe-to-state.ts` to dynamically manage dependencies of selectors, improving robustness.
- Added detailed logging for subscription events, aiding in debugging and transparency.
- Documented the bug fix in `.changeset/cyan-radios-roll.md`, ensuring proper version tracking and changelog management.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>atom-selector.test.ts</strong><dd><code>Update atom-selector tests to handle conditional dependencies</code></dd></summary>
<hr>

packages/atom.io/__tests__/public/atom-selector.test.ts
<li>Replaced a test for verifying default selector values with a new test <br>for conditional dependencies.<br> <li> Introduced <code>countAtom</code> and <code>countIsTrackedAtom</code> to manage state based on <br>conditions.<br> <li> Added <code>trackedCountSelector</code> to handle conditional logic and output <br>changes via <code>Utils.stdout</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1828/files#diff-a631c339ed20d56c9bbfbe1a7ec6dc99dcabe162c4a0a150197e87f649a68f80">+28/-9</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>subscribe-to-state.ts</strong><dd><code>Refactor subscription management for dynamic selector dependencies</code></dd></summary>
<hr>

packages/atom.io/internal/src/subscribe/subscribe-to-state.ts
<li>Enhanced subscription logic to handle dynamic dependencies in <br>selectors.<br> <li> Added logging for subscription additions and removals.<br> <li> Simplified the unsubscribe function to handle dependencies more <br>effectively.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1828/files#diff-9e64433be7da03e3ccc1ac94f1e0b9ecec9b6ab552157f057df12c6f13b2a984">+28/-33</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cyan-radios-roll.md</strong><dd><code>Document bug fix in changeset for subscription management</code></dd></summary>
<hr>

.changeset/cyan-radios-roll.md
<li>Added a changeset entry describing the bug fix related to subscription <br>updates in selectors.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1828/files#diff-f0c2a17adcd9ea68686c003c47f32b6989be86e3b2843620ad8da3a6d7bdca68">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

