### PR TITLE
improve performance of selector dependency resubscription

### DIFF
--- a/.changeset/cool-turtles-fold.md
+++ b/.changeset/cool-turtles-fold.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🚀 Allocate only one array of dependency unsub functions for the life cycle of a selector subscription.

--- a/lib/clear-array.bench.ts
+++ b/lib/clear-array.bench.ts
@@ -1,0 +1,12 @@
+import * as v from "vitest"
+
+v.describe(`clear array`, () => {
+	v.bench(`setting length to 0`, () => {
+		const arr = new Array(100)
+		arr.length = 0
+	})
+	v.bench(`splicing`, () => {
+		const arr = new Array(100)
+		arr.splice(0, arr.length)
+	})
+})

--- a/packages/atom.io/__tests__/public/atom-selector.test.ts
+++ b/packages/atom.io/__tests__/public/atom-selector.test.ts
@@ -18,6 +18,7 @@ beforeEach(() => {
 	vitest.spyOn(logger, `warn`)
 	vitest.spyOn(logger, `info`)
 	vitest.spyOn(Utils, `stdout`)
+	vitest.spyOn(Utils, `stdout0`)
 })
 
 describe(`atom`, () => {
@@ -183,6 +184,7 @@ describe(`selector`, () => {
 		const trackedCountSelector = selector<number | null>({
 			key: `trackedCount`,
 			get: ({ get }) => {
+				Utils.stdout0(`📝 trackedCountSelector`)
 				const countIsTracked = get(countIsTrackedAtom)
 				if (countIsTracked) {
 					const count = get(countAtom)
@@ -191,17 +193,23 @@ describe(`selector`, () => {
 				return null
 			},
 		})
-		subscribe(trackedCountSelector, Utils.stdout)
+		expect(Utils.stdout0).toHaveBeenCalledTimes(1)
+		const unsubscribe = subscribe(trackedCountSelector, Utils.stdout)
 		expect(getState(trackedCountSelector)).toBe(null)
 		setState(countIsTrackedAtom, true)
+		expect(Utils.stdout0).toHaveBeenCalledTimes(2)
 		expect(Utils.stdout).toHaveBeenCalledWith({
 			newValue: 0,
 			oldValue: null,
 		})
 		setState(countAtom, 1)
+		expect(Utils.stdout0).toHaveBeenCalledTimes(3)
 		expect(Utils.stdout).toHaveBeenCalledWith({
 			newValue: 1,
 			oldValue: 0,
 		})
+		unsubscribe()
+		setState(countAtom, 2)
+		expect(Utils.stdout0).toHaveBeenCalledTimes(3)
 	})
 })

--- a/packages/atom.io/internal/src/subscribe/subscribe-to-root-atoms.ts
+++ b/packages/atom.io/internal/src/subscribe/subscribe-to-root-atoms.ts
@@ -8,7 +8,7 @@ import { recallState } from "./recall-state"
 export const subscribeToRootAtoms = <T>(
 	selector: Selector<T>,
 	store: Store,
-): (() => void)[] | null => {
+): (() => void)[] => {
 	const target = newest(store)
 	const dependencySubscriptions = traceAllSelectorAtoms(selector, store).map(
 		(atomKey) => {

--- a/packages/atom.io/internal/src/subscribe/subscribe-to-state.ts
+++ b/packages/atom.io/internal/src/subscribe/subscribe-to-state.ts
@@ -21,8 +21,8 @@ export function subscribeToState<T>(
 		updateHandler = (update) => {
 			if (dependencyUnsubFunctions) {
 				dependencyUnsubFunctions.length = 0
+				dependencyUnsubFunctions.push(...subscribeToRootAtoms(state, store))
 			}
-			dependencyUnsubFunctions = subscribeToRootAtoms(state, store)
 			handleUpdate(update)
 		}
 	}


### PR DESCRIPTION
## **User description**
- **✅ test unsubscription too**
- **🚀 extremely minor performance enhancement**
- **🦋**
- **🚀 extremely minor performance enhancement**


___

## **Type**
enhancement, tests


___

## **Description**
- Added benchmarks for two array clearing methods in `lib/clear-array.bench.ts`.
- Enhanced selector tests in `packages/atom.io/__tests__/public/atom-selector.test.ts` with additional spying and unsubscription logic.
- Modified `subscribeToRootAtoms` to always return an array, enhancing reliability.
- Optimized dependency management in `subscribeToState` to reuse unsubscribe function array.
- Added a changeset documentation for the patch update in `.changeset/cool-turtles-fold.md`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clear-array.bench.ts</strong><dd><code>Add benchmarks for array clearing methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/clear-array.bench.ts
<li>Added benchmarks for clearing an array using two methods: setting <br>length to 0 and using splice.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1830/files#diff-440fba700da2126e8eaddbdb260c2b7430a0d170ed7b83a747aeb08b76531ec4">+12/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>subscribe-to-root-atoms.ts</strong><dd><code>Ensure subscribeToRootAtoms always returns an array</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/subscribe/subscribe-to-root-atoms.ts
<li>Changed return type of <code>subscribeToRootAtoms</code> to always return an array <br>instead of possibly null.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1830/files#diff-d58a09ec71b4b4a2cff657d5626604d57ffcb1f7edd2c8d8505484a1542a5081">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>subscribe-to-state.ts</strong><dd><code>Optimize dependency management in subscribeToState</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/subscribe/subscribe-to-state.ts
<li>Adjusted logic to reuse dependency unsubscribe functions array instead <br>of reallocating.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1830/files#diff-9e64433be7da03e3ccc1ac94f1e0b9ecec9b6ab552157f057df12c6f13b2a984">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>atom-selector.test.ts</strong><dd><code>Enhance selector tests with unsubscription and additional spying</code></dd></summary>
<hr>

packages/atom.io/__tests__/public/atom-selector.test.ts
<li>Added spying on <code>Utils.stdout0</code> for additional debug output.<br> <li> Modified subscription logic to include unsubscription and enhanced <br>tracking of subscription calls.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1830/files#diff-a631c339ed20d56c9bbfbe1a7ec6dc99dcabe162c4a0a150197e87f649a68f80">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cool-turtles-fold.md</strong><dd><code>Document patch update for atom.io</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/cool-turtles-fold.md
<li>Added a changeset note for patching "atom.io" with optimizations in <br>selector subscription.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1830/files#diff-bd84f7c7e55a82fc962116fdfb415c193981adfdc2f85736202d5df66d3244c3">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

