### PR TITLE
atom.io patient subscriber

### DIFF
--- a/.changeset/spotty-fans-fold.md
+++ b/.changeset/spotty-fans-fold.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 Fix a bug with `subscribe` when subscribing to states. When this was done previously, the update would be emitted to subscribers before the close of the operation, which meant that any `setState` calls in the body of the observer would always be deferred until immediately after the operation closed. This was non-obvious behavior and overall just a bad workflow. Now, the update is emitted after the operation closes, preventing deferrals in this use case.


### PR DESCRIPTION
### **User description**
- **🐛permit updating states in state subscriptions**
- **🦋**


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Introduced a new function `safelyHandleUpdate` to ensure state updates are handled correctly when operations are open, enhancing the reliability of state subscriptions.
- Modified the existing subscription logic to use the new `safelyHandleUpdate` function, ensuring updates are processed after operations close.
- Added documentation in the changeset to explain the rationale behind these changes and the impact on the workflow.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>subscribe-to-state.ts</strong><dd><code>Enhance state subscription handling for safety</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/subscribe/subscribe-to-state.ts
<li>Added <code>StateUpdate</code> to the import from <code>atom.io</code>.<br> <li> Implemented <code>safelyHandleUpdate</code> to manage state updates safely during <br>open operations.<br> <li> Modified the update handler in the subscription logic to use <br><code>safelyHandleUpdate</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1895/files#diff-9e64433be7da03e3ccc1ac94f1e0b9ecec9b6ab552157f057df12c6f13b2a984">+16/-3</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>spotty-fans-fold.md</strong><dd><code>Document the state subscription bug fix in changeset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/spotty-fans-fold.md
<li>Added a changeset file describing the patch update for the <code>atom.io</code> <br>package.<br> <li> Detailed the bug fix in state subscription behavior.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1895/files#diff-795bbc600527c714a1a9bfa030656817ff3ac1768e03dd874554911eaa0d6d96">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

