### PR TITLE
♻️ refactor away from setImmediate; suspect this may lead to flaky branching

### DIFF
--- a/packages/atom.io/__tests__/private/future-internal.test.ts
+++ b/packages/atom.io/__tests__/private/future-internal.test.ts
@@ -9,32 +9,34 @@ beforeEach(() => {
 
 describe(`Future`, () => {
 	it(`is a Promise whose fate can change`, async () => {
-		const future = new Future<number>((resolve) =>
-			setImmediate(() => {
-				resolve(1)
-			}),
-		)
+		const future = new Future<number>((resolve) => {
+			resolve(1)
+		})
 		future.use(
-			new Promise((resolve) =>
-				setImmediate(() => {
-					resolve(2)
-				}),
-			),
+			new Promise((resolve) => {
+				resolve(2)
+			}),
 		)
 		expect(await future.then((value) => value)).toBe(2)
 	})
 	it(`can be resolved to a value immediately`, async () => {
-		const future = new Future<number>((resolve) =>
-			setImmediate(() => {
-				resolve(1)
-			}),
-		)
+		const future = new Future<number>((resolve) => {
+			resolve(1)
+		})
 		future.use(2)
 		expect(await future.then((value) => value)).toBe(2)
 	})
 	it(`handles an initial executor that rejects`, async () => {
-		const future = new Future<number>((_, reject) =>
-			setImmediate(() => {
+		const future = new Future<number>((_, reject) => {
+			reject(new Error(`whoops`))
+		})
+		await expect(async () => future.then((value) => value)).rejects.toThrow(
+			`whoops`,
+		)
+	})
+	it(`handles an initial promise that rejects`, async () => {
+		const future = new Future<number>(
+			new Promise((_, reject) => {
 				reject(new Error(`whoops`))
 			}),
 		)
@@ -42,47 +44,27 @@ describe(`Future`, () => {
 			`whoops`,
 		)
 	})
-	it(`handles an initial promise that rejects`, async () => {
-		const future = new Future<number>(
-			new Promise((_, reject) =>
-				setImmediate(() => {
-					reject(new Error(`whoops`))
-				}),
-			),
-		)
-		await expect(async () => future.then((value) => value)).rejects.toThrow(
-			`whoops`,
-		)
-	})
 	it(`handles a new use-Promise that rejects`, async () => {
-		const future = new Future<number>((resolve) =>
-			setImmediate(() => {
-				resolve(1)
-			}),
-		)
+		const future = new Future<number>((resolve) => {
+			resolve(1)
+		})
 		future.use(
-			new Promise((_, reject) =>
-				setImmediate(() => {
-					reject(new Error(`whoops`))
-				}),
-			),
+			new Promise((_, reject) => {
+				reject(new Error(`whoops`))
+			}),
 		)
 		await expect(async () => future.then((value) => value)).rejects.toThrow(
 			`whoops`,
 		)
 	})
 	it(`does not care about a previous rejection, after a new use-static`, async () => {
-		const future = new Future<number>((resolve) =>
-			setImmediate(() => {
-				resolve(1)
-			}),
-		)
+		const future = new Future<number>((resolve) => {
+			resolve(1)
+		})
 		future.use(
-			new Promise((_, reject) =>
-				setImmediate(() => {
-					reject(new Error(`whoops`))
-				}),
-			),
+			new Promise((_, reject) => {
+				reject(new Error(`whoops`))
+			}),
 		)
 		future.use(2)
 		expect(await future.then((value) => value)).toBe(2)


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed `setImmediate` from the `Future` class in test cases to avoid potential flakiness and directly resolve or reject promises.
- This change simplifies the promise handling in tests, making the test outcomes more predictable and immediate.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>future-internal.test.ts</strong><dd><code>Refactor Future class to remove setImmediate for immediate promise </code><br><code>resolution</code></dd></summary>
<hr>

packages/atom.io/__tests__/private/future-internal.test.ts
<li>Removed usage of <code>setImmediate</code> in favor of immediate resolution or <br>rejection within the <code>Future</code> class.<br> <li> Simplified the promise handling in various test cases to directly <br>resolve or reject without delay.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1906/files#diff-c7e6964ea151991aed420d64f6f72292a153c4ea30c91f4596f414a010a1f0fa">+27/-45</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

