### PR TITLE
🔧 point at the dist folder where it should live

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,7 +39,7 @@
 	"json.schemas": [
 		{
 			"fileMatch": ["**/break-check.config.json"],
-			"url": "./packages/break-check/break-check.schema.json"
+			"url": "./packages/break-check/dist/break-check.schema.json"
 		}
 	],
 	"editor.formatOnSave": true,


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- The path for `break-check.schema.json` in `.vscode/settings.json` has been updated to point to the `dist` folder, ensuring that the schema is correctly linked for development environments.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.json</strong><dd><code>Update JSON Schema Path in VSCode Settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.vscode/settings.json
<li>Updated the path for <code>break-check.schema.json</code> to point to the <code>dist</code> <br>folder.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1909/files#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

