### PR TITLE
only dispose family members

### DIFF
--- a/.changeset/witty-masks-reflect.md
+++ b/.changeset/witty-masks-reflect.md
@@ -1,0 +1,5 @@
+---
+"atom.io": minor
+---
+
+💥 BREAKING CHANGE: `disposeState` now only disposes of states that belong to atom families or selector families. An error will be logged when attempting to dispose of standalone states.

--- a/packages/atom.io/__tests__/public/disposal.test.ts
+++ b/packages/atom.io/__tests__/public/disposal.test.ts
@@ -1,5 +1,14 @@
 import type { Logger, RegularAtomOptions, RegularAtomToken } from "atom.io"
-import { atom, disposeState, getState, selector } from "atom.io"
+import {
+	atom,
+	atomFamily,
+	disposeState,
+	findState,
+	getState,
+	selector,
+	selectorFamily,
+	setState,
+} from "atom.io"
 import * as Internal from "atom.io/internal"
 
 const LOG_LEVELS = [null, `error`, `warn`, `info`] as const
@@ -16,72 +25,76 @@ beforeEach(() => {
 	vitest.spyOn(logger, `info`)
 })
 
-describe(`dispose`, () => {
-	it(`deletes an atom`, () => {
+describe(`disposeState`, () => {
+	it(`does not delete a standalone atom`, () => {
 		const countState = atom<number>({
 			key: `count`,
 			default: 0,
 		})
 		expect(countState.key).toEqual(`count`)
-		disposeState(countState, Internal.IMPLICIT.STORE)
-		expect(countState.key).toEqual(`count`)
-		let caught: Error
-		try {
-			getState(countState)
-		} catch (thrown) {
-			if (thrown instanceof Error) {
-				caught = thrown
-			}
-		}
-		// biome-ignore lint/style/noNonNullAssertion: this is a test
-		if (!caught!) throw new Error(`Expected an error to be thrown`)
-		expect(caught).toBeInstanceOf(Error)
-		expect(caught.message).toEqual(
-			`Atom "count" not found in store "IMPLICIT_STORE".`,
-		)
-	})
-	it(`deletes downstream selectors from atom`, () => {
-		const countState = atom<number>({
-			key: `count`,
-			default: 0,
-		})
-		const doubledState = selector<number>({
-			key: `doubled`,
-			get: ({ get }) => get(countState) * 2,
-		})
-		disposeState(countState, Internal.IMPLICIT.STORE)
-		let caught: Error
-		try {
-			getState(doubledState)
-		} catch (thrown) {
-			if (thrown instanceof Error) {
-				caught = thrown
-			}
-		}
-		// biome-ignore lint/style/noNonNullAssertion: this is a test
-		if (!caught!) throw new Error(`Expected an error to be thrown`)
-		expect(caught).toBeInstanceOf(Error)
-		expect(caught.message).toEqual(
-			`Readonly Selector "doubled" not found in store "IMPLICIT_STORE".`,
-		)
-	})
-	it(`logs an error if the atom is not in the store`, () => {
-		const countState = atom<number>({
-			key: `count`,
-			default: 0,
-		})
-		disposeState(countState, Internal.IMPLICIT.STORE)
 		disposeState(countState, Internal.IMPLICIT.STORE)
 		expect(logger.error).toHaveBeenCalledTimes(1)
 		expect(logger.error).toHaveBeenCalledWith(
 			`❌`,
 			`atom`,
 			`count`,
-			`Tried to delete atom, but it does not exist in the store.`,
+			`Standalone atoms cannot be disposed.`,
+		)
+	})
+	it(`deletes atoms that belong to a family`, () => {
+		const findCountState = atomFamily<number, string>({
+			key: `findCount`,
+			default: 0,
+		})
+		const countState = findCountState(`count`)
+		disposeState(countState, Internal.IMPLICIT.STORE)
+		expect(logger.error).toHaveBeenCalledTimes(0)
+		expect(Internal.IMPLICIT.STORE.atoms.has(countState.key)).toBe(false)
+		expect(Internal.IMPLICIT.STORE.valueMap.has(countState.key)).toBe(false)
+	})
+	it(`deletes downstream selectors from atom`, () => {
+		const countAtoms = atomFamily<number, string>({
+			key: `count`,
+			default: 0,
+		})
+		const doubleSelectors = selectorFamily<number, string>({
+			key: `doubled`,
+			get:
+				(key) =>
+				({ find, get }) =>
+					get(find(countAtoms, key)) * 2,
+		})
+		const countState = findState(countAtoms, `my-key`)
+		const doubledState = findState(doubleSelectors, `my-key`)
+		setState(countState, 2)
+		expect(getState(doubledState)).toBe(4)
+		disposeState(countState, Internal.IMPLICIT.STORE)
+		expect(logger.error).toHaveBeenCalledTimes(0)
+		expect(Internal.IMPLICIT.STORE.atoms.has(countState.key)).toBe(false)
+		expect(Internal.IMPLICIT.STORE.valueMap.has(countState.key)).toBe(false)
+		expect(Internal.IMPLICIT.STORE.readonlySelectors.has(doubledState.key)).toBe(
+			false,
+		)
+		expect(Internal.IMPLICIT.STORE.valueMap.has(doubledState.key)).toBe(false)
+	})
+	it(`logs an error if the atom is not in the store`, () => {
+		const countAtoms = atomFamily<number, string>({
+			key: `count`,
+			default: 0,
+		})
+		const countState = findState(countAtoms, `my-key`)
+		disposeState(countState, Internal.IMPLICIT.STORE)
+		disposeState(countState, Internal.IMPLICIT.STORE)
+		expect(logger.error).toHaveBeenCalledTimes(1)
+		expect(logger.error).toHaveBeenCalledWith(
+			`❌`,
+			`atom`,
+			`count("my-key")`,
+			`Tried to dispose atom, but it does not exist in the store.`,
 		)
 	})
 
-	it(`deletes a selector`, () => {
+	it(`does not delete a standalone selector`, () => {
 		const countState = atom<number>({
 			key: `count`,
 			default: 0,
@@ -91,98 +104,87 @@ describe(`dispose`, () => {
 			get: ({ get }) => get(countState),
 		})
 		disposeState(doubledState, Internal.IMPLICIT.STORE)
-		let caught: Error
-		try {
-			getState(doubledState)
-		} catch (thrown) {
-			if (thrown instanceof Error) {
-				caught = thrown
-			}
-		}
-		// biome-ignore lint/style/noNonNullAssertion: this is a test
-		if (!caught!) throw new Error(`Expected an error to be thrown`)
-		expect(caught).toBeInstanceOf(Error)
-		expect(caught.message).toEqual(
-			`Readonly Selector "doubled" not found in store "IMPLICIT_STORE".`,
+		expect(logger.error).toHaveBeenCalledTimes(1)
+		expect(logger.error).toHaveBeenCalledWith(
+			`❌`,
+			`selector`,
+			`doubled`,
+			`Standalone selectors cannot be disposed.`,
 		)
 	})
 
-	it(`deletes downstream, but not upstream, selectors from selector`, () => {
-		const countState = atom<number>({
+	it(`deletes selectors that belong to a family`, () => {
+		const countAtoms = atomFamily<number, string>({
 			key: `count`,
 			default: 0,
 		})
-		const countPlusOneState = selector<number>({
-			key: `countPlusOne`,
-			get: ({ get }) => get(countState) + 1,
+		const doubledSelectors = selectorFamily<number, string>({
+			key: `doubled`,
+			get:
+				(id) =>
+				({ find, get }) =>
+					get(find(countAtoms, id)) * 2,
 		})
-		const countPlusTwoState = selector<number>({
-			key: `countPlusTwo`,
-			get: ({ get }) => get(countPlusOneState) + 1,
-		})
-		const countPlusThreeState = selector<number>({
-			key: `countPlusThree`,
-			get: ({ get }) => get(countPlusTwoState) + 1,
-		})
-		disposeState(countPlusTwoState, Internal.IMPLICIT.STORE)
-		expect(getState(countPlusOneState)).toEqual(1)
-		let caught: Error
-		try {
-			getState(countPlusThreeState)
-		} catch (thrown) {
-			if (thrown instanceof Error) {
-				caught = thrown
-			}
-		}
-		// biome-ignore lint/style/noNonNullAssertion: this is a test
-		if (!caught!) throw new Error(`Expected an error to be thrown`)
-		expect(caught).toBeInstanceOf(Error)
-		expect(caught.message).toEqual(
-			`Readonly Selector "countPlusThree" not found in store "IMPLICIT_STORE".`,
-		)
+		const doubledState = findState(doubledSelectors, `my-key`)
+		disposeState(doubledState, Internal.IMPLICIT.STORE)
+		expect(logger.error).toHaveBeenCalledTimes(0)
+		expect(Internal.IMPLICIT.STORE.selectors.has(doubledState.key)).toBe(false)
+		expect(Internal.IMPLICIT.STORE.valueMap.has(doubledState.key)).toBe(false)
 	})
-})
 
-describe(`auto disposability concept (just for fun)`, () => {
-	function disposable<T extends object>(
-		object: T,
-		disposeFn: () => void,
-	): Disposable & T {
-		return Object.assign(object, { [Symbol.dispose]: disposeFn })
-	}
-	function disposableAtom<T>(
-		options: RegularAtomOptions<T>,
-	): Disposable & RegularAtomToken<T> {
-		const atomToken = atom<T>(options)
-		return disposable(atomToken, () => {
-			disposeState(atomToken)
+	it(`deletes downstream, but not upstream, selectors from selector`, () => {
+		const countAtoms = atomFamily<number, string>({
+			key: `count`,
+			default: 0,
 		})
-	}
-	it(`automatically disposes of an atom when it is dereferenced`, () => {
-		function doSomeWorkWithAtomIO() {
-			let cycles = 2
-			while (cycles--) {
-				using countState = disposableAtom({
-					key: `count`,
-					default: 0,
-				})
-				expect(getState(countState)).toBe(0)
-			}
-		}
-		doSomeWorkWithAtomIO()
-		let caught: Error
-		try {
-			getState({ key: `count`, type: `atom` })
-		} catch (thrown) {
-			if (thrown instanceof Error) {
-				caught = thrown
-			}
-		}
-		// biome-ignore lint/style/noNonNullAssertion: this is a test
-		if (!caught!) throw new Error(`Expected an error to be thrown`)
-		expect(caught).toBeInstanceOf(Error)
-		expect(caught.message).toEqual(
-			`Atom "count" not found in store "IMPLICIT_STORE".`,
+		const countPlusOneSelectors = selectorFamily<number, string>({
+			key: `countPlusOne`,
+			get:
+				(id) =>
+				({ find, get }) =>
+					get(find(countAtoms, id)) + 1,
+		})
+		const countPlusTwoSelectors = selectorFamily<number, string>({
+			key: `countPlusTwo`,
+			get:
+				(id) =>
+				({ find, get }) =>
+					get(find(countPlusOneSelectors, id)) + 1,
+			set:
+				(id) =>
+				({ find, set }, newValue) => {
+					set(find(countAtoms, id), newValue - 2)
+				},
+		})
+		const countPlusThreeSelectors = selectorFamily<number, string>({
+			key: `countPlusThree`,
+			get:
+				(id) =>
+				({ find, get }) =>
+					get(find(countPlusTwoSelectors, id)) + 1,
+		})
+		const countPlusOneState = findState(countPlusOneSelectors, `my-key`)
+		const countPlusTwoState = findState(countPlusTwoSelectors, `my-key`)
+		const countPlusThreeState = findState(countPlusThreeSelectors, `my-key`)
+		disposeState(countPlusTwoState, Internal.IMPLICIT.STORE)
+		expect(logger.error).toHaveBeenCalledTimes(0)
+		expect(
+			Internal.IMPLICIT.STORE.readonlySelectors.has(countPlusOneState.key),
+		).toBe(true)
+		expect(Internal.IMPLICIT.STORE.valueMap.has(countPlusOneState.key)).toBe(
+			true,
+		)
+		expect(Internal.IMPLICIT.STORE.selectors.has(countPlusTwoState.key)).toBe(
+			false,
+		)
+		expect(Internal.IMPLICIT.STORE.valueMap.has(countPlusTwoState.key)).toBe(
+			false,
+		)
+		expect(Internal.IMPLICIT.STORE.selectors.has(countPlusThreeState.key)).toBe(
+			false,
+		)
+		expect(Internal.IMPLICIT.STORE.valueMap.has(countPlusThreeState.key)).toBe(
+			false,
 		)
 	})
 })

--- a/packages/atom.io/internal/src/atom/dispose-atom.ts
+++ b/packages/atom.io/internal/src/atom/dispose-atom.ts
@@ -12,8 +12,10 @@ export function disposeAtom(atomToken: AtomToken<unknown>, store: Store): void {
 			`❌`,
 			`atom`,
 			key,
-			`Tried to delete atom, but it does not exist in the store.`,
+			`Tried to dispose atom, but it does not exist in the store.`,
 		)
+	} else if (!atom.family) {
+		store.logger.error(`❌`, `atom`, key, `Standalone atoms cannot be disposed.`)
 	} else {
 		atom.cleanup?.()
 		target.atoms.delete(key)

--- a/packages/atom.io/introspection/src/attach-atom-index.ts
+++ b/packages/atom.io/introspection/src/attach-atom-index.ts
@@ -41,59 +41,49 @@ export const attachAtomIndex = (
 			},
 			effects: [
 				({ setSelf }) => {
-					const unsubscribeFromAtomCreation = store.on.atomCreation.subscribe(
-						`introspection`,
-						(atomToken) => {
-							if (atomToken.key.includes(`👁‍🗨`)) {
-								return
-							}
+					store.on.atomCreation.subscribe(`introspection`, (atomToken) => {
+						if (atomToken.key.includes(`👁‍🗨`)) {
+							return
+						}
 
-							setSelf((self) => {
-								if (atomToken.family) {
-									const { key: familyKey, subKey } = atomToken.family
-									let familyNode = self.get(familyKey)
-									if (
-										familyNode === undefined ||
-										!(`familyMembers` in familyNode)
-									) {
-										familyNode = {
-											key: familyKey,
-											familyMembers: new Map(),
-										}
-										self.set(familyKey, familyNode)
+						setSelf((self) => {
+							if (atomToken.family) {
+								const { key: familyKey, subKey } = atomToken.family
+								let familyNode = self.get(familyKey)
+								if (
+									familyNode === undefined ||
+									!(`familyMembers` in familyNode)
+								) {
+									familyNode = {
+										key: familyKey,
+										familyMembers: new Map(),
 									}
-									familyNode.familyMembers.set(subKey, atomToken)
-								} else {
-									self.set(atomToken.key, atomToken)
+									self.set(familyKey, familyNode)
 								}
-								return self
-							})
-						},
-					)
-					const unsubscribeFromAtomDisposal = store.on.atomDisposal.subscribe(
-						`introspection`,
-						(atomToken) => {
-							setSelf((self) => {
-								if (atomToken.family) {
-									const { key: familyKey, subKey } = atomToken.family
-									const familyNode = self.get(familyKey)
-									if (familyNode && `familyMembers` in familyNode) {
-										familyNode.familyMembers.delete(subKey)
-										if (familyNode.familyMembers.size === 0) {
-											self.delete(familyKey)
-										}
+								familyNode.familyMembers.set(subKey, atomToken)
+							} else {
+								self.set(atomToken.key, atomToken)
+							}
+							return self
+						})
+					})
+					store.on.atomDisposal.subscribe(`introspection`, (atomToken) => {
+						setSelf((self) => {
+							if (atomToken.family) {
+								const { key: familyKey, subKey } = atomToken.family
+								const familyNode = self.get(familyKey)
+								if (familyNode && `familyMembers` in familyNode) {
+									familyNode.familyMembers.delete(subKey)
+									if (familyNode.familyMembers.size === 0) {
+										self.delete(familyKey)
 									}
-								} else {
-									self.delete(atomToken.key)
 								}
-								return self
-							})
-						},
-					)
-					return () => {
-						unsubscribeFromAtomCreation()
-						unsubscribeFromAtomDisposal()
-					}
+							} else {
+								self.delete(atomToken.key)
+							}
+							return self
+						})
+					})
 				},
 			],
 		},

--- a/packages/atom.io/introspection/src/attach-selector-index.ts
+++ b/packages/atom.io/introspection/src/attach-selector-index.ts
@@ -44,61 +44,56 @@ export const attachSelectorIndex = (
 				},
 				effects: [
 					({ setSelf }) => {
-						const unsubscribeFromSelectorCreation =
-							store.on.selectorCreation.subscribe(
-								`introspection`,
-								(selectorToken) => {
-									if (selectorToken.key.includes(`👁‍🗨`)) {
-										return
-									}
+						store.on.selectorCreation.subscribe(
+							`introspection`,
+							(selectorToken) => {
+								if (selectorToken.key.includes(`👁‍🗨`)) {
+									return
+								}
 
-									setSelf((self) => {
-										if (selectorToken.family) {
-											const { key: familyKey, subKey } = selectorToken.family
-											let familyNode = self.get(familyKey)
-											if (
-												familyNode === undefined ||
-												!(`familyMembers` in familyNode)
-											) {
-												familyNode = {
-													key: familyKey,
-													familyMembers: new Map(),
-												}
-												self.set(familyKey, familyNode)
+								setSelf((self) => {
+									if (selectorToken.family) {
+										const { key: familyKey, subKey } = selectorToken.family
+										let familyNode = self.get(familyKey)
+										if (
+											familyNode === undefined ||
+											!(`familyMembers` in familyNode)
+										) {
+											familyNode = {
+												key: familyKey,
+												familyMembers: new Map(),
 											}
-											familyNode.familyMembers.set(subKey, selectorToken)
-										} else {
-											self.set(selectorToken.key, selectorToken)
+											self.set(familyKey, familyNode)
 										}
-										return self
-									})
-								},
-							)
-						const unsubscribeFromSelectorDisposal =
-							store.on.selectorDisposal.subscribe(
-								`introspection`,
-								(selectorToken) => {
-									setSelf((self) => {
-										if (selectorToken.family) {
-											const { key: familyKey, subKey } = selectorToken.family
-											const familyNode = self.get(familyKey)
-											if (familyNode && `familyMembers` in familyNode) {
-												familyNode.familyMembers.delete(subKey)
-												if (familyNode.familyMembers.size === 0) {
-													self.delete(familyKey)
-												}
+										familyNode.familyMembers.set(subKey, selectorToken)
+									} else {
+										self.set(selectorToken.key, selectorToken)
+									}
+									return self
+								})
+							},
+						)
+
+						store.on.selectorDisposal.subscribe(
+							`introspection`,
+							(selectorToken) => {
+								setSelf((self) => {
+									if (selectorToken.family) {
+										const { key: familyKey, subKey } = selectorToken.family
+										const familyNode = self.get(familyKey)
+										if (familyNode && `familyMembers` in familyNode) {
+											familyNode.familyMembers.delete(subKey)
+											if (familyNode.familyMembers.size === 0) {
+												self.delete(familyKey)
 											}
-										} else {
-											self.delete(selectorToken.key)
 										}
-										return self
-									})
-								},
-							)
-						return () => {
-							unsubscribeFromSelectorCreation()
-							unsubscribeFromSelectorDisposal()
-						}
+									} else {
+										self.delete(selectorToken.key)
+									}
+									return self
+								})
+							},
+						)
 					},
 				],
 			},

--- a/turbo.json
+++ b/turbo.json
@@ -32,6 +32,7 @@
 		},
 		"test:semver": {
 			"inputs": [
+				"../../.changeset/**",
 				"../break-check/src/**/*.ts",
 				"break-check.config.json",
 				"**/package.json",


### PR DESCRIPTION
### **PR Type**
enhancement, bug_fix


___

### **Description**
- Enhanced `disposeState` function to prevent disposal of standalone atoms and selectors, aligning with singleton management.
- Updated tests to reflect new disposal logic, ensuring proper handling of atom families and selector families.
- Improved error logging in both atom and selector disposal functions to provide clearer diagnostics.
- Added comprehensive tests for new behaviors in atom and selector disposals.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>disposal.test.ts</strong><dd><code>Update Tests for Atom and Selector Disposal Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/public/disposal.test.ts
<li>Updated <code>disposeState</code> tests to handle new logic for standalone atoms <br>and atom families.<br> <li> Added tests for selector families and standalone selectors.<br> <li> Improved error handling and logging within tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1920/files#diff-4511f3c9d783399a64481f9cc38c3b18d391dd4b704c020af0811ffdb36169fa">+116/-114</a></td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dispose-atom.ts</strong><dd><code>Prevent Disposal of Standalone Atoms and Improve Error Logging</code></dd></summary>
<hr>

packages/atom.io/internal/src/atom/dispose-atom.ts
<li>Added a check to prevent the disposal of standalone atoms.<br> <li> Enhanced error logging for disposal attempts on non-existent atoms.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1920/files#diff-b3aa13b732b0ec1c0171698faacfc2481708509a89c04c8b43b3487fec17950f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dispose-selector.ts</strong><dd><code>Enhance Selector Disposal Handling and Logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/selector/dispose-selector.ts
<li>Added a check to prevent the disposal of standalone selectors.<br> <li> Improved error handling and logging for selector disposal.<br> <li> Updated the disposal process for selectors that belong to a family.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1920/files#diff-f9e93767f34f02b447ed4d4c9702104c5e96c031a4f5714a6174566ba1f32f01">+40/-23</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

