### PR TITLE
atom.io lifecycle rule

### DIFF
--- a/packages/atom.io/__tests__/public/eslint-plugin/lifespan.test.ts
+++ b/packages/atom.io/__tests__/public/eslint-plugin/lifespan.test.ts
@@ -1,0 +1,57 @@
+import parser from "@typescript-eslint/parser"
+import { Rules } from "atom.io/eslint-plugin"
+import { RuleTester } from "eslint-v9"
+
+const ruleTester = new RuleTester({ languageOptions: { parser } })
+Object.assign(ruleTester, { describe, it })
+const rule = Rules.lifespan
+
+ruleTester.run(`lifespan`, rule, {
+	valid: [
+		{
+			name: `import from ephemeral with no option set`,
+			code: `
+        import * as Ephemeral from "atom.io/ephemeral"
+      `,
+		},
+		{
+			name: `import from ephemeral with ephemeral option set`,
+			options: [`ephemeral`],
+			code: `
+        import * as Ephemeral from "atom.io/ephemeral"
+      `,
+		},
+		{
+			name: `import from immortal with immortal option set`,
+			options: [`immortal`],
+			code: `
+        import * as Immortal from "atom.io/immortal"
+      `,
+		},
+	],
+	invalid: [
+		{
+			name: `import from immortal with no option set`,
+			code: `
+        import * as Immortal from "atom.io/immortal"
+      `,
+			errors: 1,
+		},
+		{
+			name: `import from immortal with ephemeral option set`,
+			options: [`ephemeral`],
+			code: `
+        import * as Immortal from "atom.io/immortal"
+      `,
+			errors: 1,
+		},
+		{
+			name: `import from ephemeral with immortal option set`,
+			options: [`immortal`],
+			code: `
+        import * as Ephemeral from "atom.io/ephemeral"
+      `,
+			errors: 1,
+		},
+	],
+})

--- a/packages/atom.io/__tests__/public/eslint-plugin/lifespan.test.ts
+++ b/packages/atom.io/__tests__/public/eslint-plugin/lifespan.test.ts
@@ -34,18 +34,17 @@ ruleTester.run(`lifespan: don't import the wrong toolkit for your store`, rule, 
         import * as Immortal from "atom.io/immortal"
       `,
 		},
+		{
+			name: `import from immortal with ephemeral option set`,
+			options: [`ephemeral`],
+			code: `
+        import * as Immortal from "atom.io/immortal"
+      `,
+		},
 	],
 	invalid: [
 		{
 			name: `import from immortal with no option set`,
-			code: `
-        import * as Immortal from "atom.io/immortal"
-      `,
-			errors: 1,
-		},
-		{
-			name: `import from immortal with ephemeral option set`,
-			options: [`ephemeral`],
 			code: `
         import * as Immortal from "atom.io/immortal"
       `,

--- a/packages/atom.io/__tests__/public/eslint-plugin/lifespan.test.ts
+++ b/packages/atom.io/__tests__/public/eslint-plugin/lifespan.test.ts
@@ -9,6 +9,12 @@ const rule = Rules.lifespan
 ruleTester.run(`lifespan`, rule, {
 	valid: [
 		{
+			name: `import from some other package`,
+			code: `
+        import * as SomeOtherPackage from "some-other-package"
+      `,
+		},
+		{
 			name: `import from ephemeral with no option set`,
 			code: `
         import * as Ephemeral from "atom.io/ephemeral"

--- a/packages/atom.io/__tests__/public/eslint-plugin/lifespan.test.ts
+++ b/packages/atom.io/__tests__/public/eslint-plugin/lifespan.test.ts
@@ -6,60 +6,63 @@ const ruleTester = new RuleTester({ languageOptions: { parser } })
 Object.assign(ruleTester, { describe, it })
 const rule = Rules.lifespan
 
-ruleTester.run(`lifespan: don't import the wrong toolkit for your store`, rule, {
-	valid: [
-		{
-			name: `import from some other package`,
-			code: `
+ruleTester.run(
+	`lifespan: don't import ephemeral tools for an immortal store`,
+	rule,
+	{
+		valid: [
+			{
+				name: `import from some other package`,
+				code: `
         import * as SomeOtherPackage from "some-other-package"
       `,
-		},
-		{
-			name: `import from ephemeral with no option set`,
-			code: `
+			},
+			{
+				name: `import from ephemeral with no option set`,
+				code: `
         import * as Ephemeral from "atom.io/ephemeral"
       `,
-		},
-		{
-			name: `import from ephemeral with ephemeral option set`,
-			options: [`ephemeral`],
-			code: `
+			},
+			{
+				name: `import from immortal with no option set`,
+				code: `
+        import * as Immortal from "atom.io/immortal"
+      `,
+			},
+			{
+				name: `import from ephemeral with ephemeral option set`,
+				options: [`ephemeral`],
+				code: `
         import * as Ephemeral from "atom.io/ephemeral"
       `,
-		},
-		{
-			name: `import from immortal with immortal option set`,
-			options: [`immortal`],
-			code: `
+			},
+			{
+				name: `import from immortal with immortal option set`,
+				options: [`immortal`],
+				code: `
         import * as Immortal from "atom.io/immortal"
       `,
-		},
-		{
-			name: `import from immortal with ephemeral option set`,
-			options: [`ephemeral`],
-			code: `
+			},
+			{
+				name: `import from immortal with ephemeral option set`,
+				options: [`ephemeral`],
+				code: `
         import * as Immortal from "atom.io/immortal"
       `,
-		},
-	],
-	invalid: [
-		{
-			name: `import from immortal with no option set`,
-			code: `
-        import * as Immortal from "atom.io/immortal"
-      `,
-			errors: 1,
-		},
-		{
-			name: `import from ephemeral with immortal option set`,
-			options: [`immortal`],
-			code: `
+			},
+		],
+		invalid: [
+			{
+				name: `import from ephemeral with immortal option set`,
+				options: [`immortal`],
+				code: `
         import * as Ephemeral from "atom.io/ephemeral"
       `,
-			errors: 1,
-		},
-	],
-})
+				errors: 1,
+			},
+		],
+	},
+)
 
 ruleTester.run(`lifespan: don't use the find transactor`, rule, {
 	valid: [
@@ -170,6 +173,49 @@ ruleTester.run(`lifespan: don't use the find transactor`, rule, {
 						set(countState, (c) => c + increment)
 					}
 				})
+			`,
+			errors: 1,
+		},
+	],
+})
+
+ruleTester.run(`lifespan: don't use findState in an immortal store`, rule, {
+	valid: [
+		{
+			name: `use findState global with no option set`,
+			code: `
+				const doubleState = findState(doubleSelectors, "my-key")
+			`,
+		},
+		{
+			name: `use findState global with ephemeral option set`,
+			options: [`ephemeral`],
+			code: `
+				const doubleState = findState(doubleSelectors, "my-key")
+			`,
+		},
+		{
+			name: `[edge case]: iife bails early`,
+			options: [`immortal`],
+			code: `
+					(() => {})()
+				`,
+		},
+	],
+	invalid: [
+		{
+			name: `use findState global with immortal option set`,
+			options: [`immortal`],
+			code: `
+				const doubleState = findState(doubleSelectors, "my-key")
+			`,
+			errors: 1,
+		},
+		{
+			name: `use findState Silo method with immortal option set`,
+			options: [`immortal`],
+			code: `
+				const doubleState = Silo("my-key").findState(doubleSelectors)
 			`,
 			errors: 1,
 		},

--- a/packages/atom.io/__tests__/public/eslint-plugin/lifespan.test.ts
+++ b/packages/atom.io/__tests__/public/eslint-plugin/lifespan.test.ts
@@ -6,7 +6,7 @@ const ruleTester = new RuleTester({ languageOptions: { parser } })
 Object.assign(ruleTester, { describe, it })
 const rule = Rules.lifespan
 
-ruleTester.run(`lifespan`, rule, {
+ruleTester.run(`lifespan: don't import the wrong toolkit for your store`, rule, {
 	valid: [
 		{
 			name: `import from some other package`,
@@ -57,6 +57,121 @@ ruleTester.run(`lifespan`, rule, {
 			code: `
         import * as Ephemeral from "atom.io/ephemeral"
       `,
+			errors: 1,
+		},
+	],
+})
+
+ruleTester.run(`lifespan: don't use the find transactor`, rule, {
+	valid: [
+		{
+			name: `transaction, standard`,
+			options: [`ephemeral`],
+			code: `
+				transaction<(increment: number) => void>({
+					key: "increment",
+					do: ({ find, set }, increment) => {
+						const countState = find(countAtoms, "my-key")
+						set(countState, (c) => c + increment)
+					}
+				})
+			`,
+		},
+	],
+	invalid: [
+		{
+			name: `selector, standard`,
+			options: [`immortal`],
+			code: `
+				const clientNameState = selector<Loadable<string | null>>({
+					key: "clientName",
+					get: async ({ find, get }) => {
+						const query = await fetch("https://api.github.com/users/jeremybanka")
+						const json = await query.json()
+						const clientState = find(clientAtoms, json.key)
+						const client = get(clientState)
+						return client?.name
+					}
+				}) 
+			`,
+			errors: 1,
+		},
+		{
+			name: `selector, not destructured`,
+			options: [`immortal`],
+			code: `
+				const clientNameState = selector<Loadable<string | null>>({
+					key: "clientName",
+					get: async (transactors) => {
+						const query = await fetch("https://api.github.com/users/jeremybanka")
+						const json = await query.json()
+						const clientState = transactors.find(clientAtoms, json.key)
+						const client = transactors.get(clientState)
+						return client?.name
+					}
+				}) 
+			`,
+			errors: 1,
+		},
+		{
+			name: `selectorFamily, standard`,
+			options: [`immortal`],
+			code: `
+				const quotientState = selectorFamily<number, string>({
+					key: "quotient",
+					get: (id) => ({ find, get }) => {
+						const a = get(find(dividendAtoms, id))
+						const b = get(find(divisorAtoms, id))
+						return a / b
+					}
+				}) 
+			`,
+			errors: 2,
+		},
+		{
+			name: `selectorFamily, not destructured`,
+			options: [`immortal`],
+			code: `
+				const quotientState = selectorFamily<number, string>({
+					key: "quotient",
+					get: (id) => (transactors) => {
+						const a = transactors.get(transactors.find(dividendAtoms, id))
+						const b = transactors.get(transactors.find(divisorAtoms, id))
+						return a / b
+					}
+				}) 
+			`,
+			errors: 2,
+		},
+		{
+			name: `selectorFamily, intermediate body`,
+			options: [`immortal`],
+			code: `
+				const quotientState = selectorFamily<number, string>({
+					key: "quotient",
+					get: (id) => {
+						return ({ find, get }) => {
+							const a = get(find(dividendAtoms, id))
+							const b = get(find(divisorAtoms, id))
+							return a / b
+						}
+					}
+				}) 
+			`,
+			errors: 2,
+		},
+		{
+			name: `transaction, standard`,
+			options: [`immortal`],
+			code: `
+				transaction<(increment: number) => void>({
+					key: "increment",
+					do: ({ find, set }, increment) => {
+						const countState = find(countAtoms, "my-key")
+						set(countState, (c) => c + increment)
+					}
+				})
+			`,
 			errors: 1,
 		},
 	],

--- a/packages/atom.io/eslint-plugin/src/rules/index.ts
+++ b/packages/atom.io/eslint-plugin/src/rules/index.ts
@@ -1,2 +1,3 @@
 export * from "./explicit-state-types"
+export * from "./lifespan"
 export * from "./synchronous-selector-dependencies"

--- a/packages/atom.io/eslint-plugin/src/rules/lifespan.ts
+++ b/packages/atom.io/eslint-plugin/src/rules/lifespan.ts
@@ -31,10 +31,7 @@ export const lifespan = {
 					return
 				}
 				const [_, subPackageName] = importSource.split(`/`)
-				if (
-					(storeLifespan === `ephemeral` && subPackageName === `immortal`) ||
-					(storeLifespan === `immortal` && subPackageName === `ephemeral`)
-				) {
+				if (storeLifespan === `immortal` && subPackageName === `ephemeral`) {
 					context.report({
 						node,
 						message: `do not import from "${importSource}" in an ${storeLifespan} store`,

--- a/packages/atom.io/eslint-plugin/src/rules/lifespan.ts
+++ b/packages/atom.io/eslint-plugin/src/rules/lifespan.ts
@@ -1,0 +1,47 @@
+import type { Rule } from "eslint"
+import type * as ESTree from "estree"
+
+export const lifespan = {
+	meta: {
+		type: `problem`,
+		docs: {
+			description: `atom.io provides tools for short-lived (ephemeral) and long-lived (immortal) stores. This rule allows you to guard against unsafe usage of tools for the other type of store.`,
+			category: `Possible Errors`,
+			recommended: false,
+			url: ``, // URL to documentation page for this rule
+		},
+		schema: [
+			{
+				type: `string`,
+				enum: [`ephemeral`, `immortal`],
+				default: `ephemeral`,
+			},
+		],
+	},
+	create(context) {
+		const storeLifespan = (context.options[0] ?? `ephemeral`) as
+			| `ephemeral`
+			| `immortal`
+		return {
+			ImportDeclaration(node) {
+				const importSource = node.source.value as string
+				if (!importSource.startsWith(`atom.io/`)) {
+					return
+				}
+				const [_, subPackageName] = importSource.split(`/`)
+				if (!subPackageName) {
+					return
+				}
+				if (
+					(storeLifespan === `ephemeral` && subPackageName === `immortal`) ||
+					(storeLifespan === `immortal` && subPackageName === `ephemeral`)
+				) {
+					context.report({
+						node,
+						message: `do not import from "${importSource}" in an ${storeLifespan} store`,
+					})
+				}
+			},
+		}
+	},
+} satisfies Rule.RuleModule

--- a/packages/atom.io/eslint-plugin/src/rules/lifespan.ts
+++ b/packages/atom.io/eslint-plugin/src/rules/lifespan.ts
@@ -29,9 +29,6 @@ export const lifespan = {
 					return
 				}
 				const [_, subPackageName] = importSource.split(`/`)
-				if (!subPackageName) {
-					return
-				}
 				if (
 					(storeLifespan === `ephemeral` && subPackageName === `immortal`) ||
 					(storeLifespan === `immortal` && subPackageName === `ephemeral`)

--- a/packages/atom.io/eslint-plugin/src/rules/synchronous-selector-dependencies.ts
+++ b/packages/atom.io/eslint-plugin/src/rules/synchronous-selector-dependencies.ts
@@ -1,71 +1,7 @@
 import type { Rule } from "eslint"
 import type * as ESTree from "estree"
 
-function walk(
-	node: ESTree.Node,
-	callback: (node: ESTree.Node, depth: number) => void,
-	depth = 0,
-) {
-	callback(node, depth)
-
-	switch (node.type) {
-		case `FunctionDeclaration`:
-		case `FunctionExpression`:
-		case `ArrowFunctionExpression`:
-			for (const param of node.params) {
-				walk(param, callback, depth + 1)
-			}
-			walk(node.body, callback, depth + 1)
-			break
-		case `BlockStatement`:
-			for (const statement of node.body) {
-				walk(statement, callback, depth + 1)
-			}
-			break
-		case `IfStatement`:
-			walk(node.test, callback, depth)
-			walk(node.consequent, callback, depth)
-			if (node.alternate) {
-				walk(node.alternate, callback, depth)
-			}
-			break
-		case `SwitchStatement`:
-			walk(node.discriminant, callback, depth + 1)
-			for (const caseOrDefault of node.cases) {
-				walk(caseOrDefault, callback, depth)
-			}
-			break
-		case `ReturnStatement`:
-			if (node.argument) {
-				walk(node.argument, callback, depth)
-			}
-			break
-		case `SwitchCase`:
-			if (node.test) {
-				walk(node.test, callback, depth)
-			}
-			for (const statement of node.consequent) {
-				walk(statement, callback, depth)
-			}
-			break
-		case `VariableDeclaration`:
-			for (const declaration of node.declarations) {
-				walk(declaration, callback, depth)
-				if (declaration.init) {
-					walk(declaration.init, callback, depth)
-				}
-			}
-			break
-		case `BinaryExpression`:
-			walk(node.left, callback, depth)
-			walk(node.right, callback, depth)
-			break
-		case `MemberExpression`:
-			walk(node.object, callback, depth)
-			walk(node.property, callback, depth)
-			break
-	}
-}
+import { walk } from "../walk"
 
 export const synchronousSelectorDependencies = {
 	meta: {

--- a/packages/atom.io/eslint-plugin/src/walk.ts
+++ b/packages/atom.io/eslint-plugin/src/walk.ts
@@ -63,5 +63,11 @@ export function walk(
 			walk(node.object, callback, depth)
 			walk(node.property, callback, depth)
 			break
+		case `CallExpression`:
+			walk(node.callee, callback, depth)
+			for (const argument of node.arguments) {
+				walk(argument, callback, depth)
+			}
+			break
 	}
 }

--- a/packages/atom.io/eslint-plugin/src/walk.ts
+++ b/packages/atom.io/eslint-plugin/src/walk.ts
@@ -1,0 +1,67 @@
+import type * as ESTree from "estree"
+
+export function walk(
+	node: ESTree.Node,
+	callback: (node: ESTree.Node, depth: number) => void,
+	depth = 0,
+): void {
+	callback(node, depth)
+
+	switch (node.type) {
+		case `FunctionDeclaration`:
+		case `FunctionExpression`:
+		case `ArrowFunctionExpression`:
+			for (const param of node.params) {
+				walk(param, callback, depth + 1)
+			}
+			walk(node.body, callback, depth + 1)
+			break
+		case `BlockStatement`:
+			for (const statement of node.body) {
+				walk(statement, callback, depth + 1)
+			}
+			break
+		case `IfStatement`:
+			walk(node.test, callback, depth)
+			walk(node.consequent, callback, depth)
+			if (node.alternate) {
+				walk(node.alternate, callback, depth)
+			}
+			break
+		case `SwitchStatement`:
+			walk(node.discriminant, callback, depth + 1)
+			for (const caseOrDefault of node.cases) {
+				walk(caseOrDefault, callback, depth)
+			}
+			break
+		case `ReturnStatement`:
+			if (node.argument) {
+				walk(node.argument, callback, depth)
+			}
+			break
+		case `SwitchCase`:
+			if (node.test) {
+				walk(node.test, callback, depth)
+			}
+			for (const statement of node.consequent) {
+				walk(statement, callback, depth)
+			}
+			break
+		case `VariableDeclaration`:
+			for (const declaration of node.declarations) {
+				walk(declaration, callback, depth)
+				if (declaration.init) {
+					walk(declaration.init, callback, depth)
+				}
+			}
+			break
+		case `BinaryExpression`:
+			walk(node.left, callback, depth)
+			walk(node.right, callback, depth)
+			break
+		case `MemberExpression`:
+			walk(node.object, callback, depth)
+			walk(node.property, callback, depth)
+			break
+	}
+}


### PR DESCRIPTION
### **User description**
- **✨ add eslint rule for store lifespan**
- **✅ improve coverage**
- **🚧**
- **✅ complete coverage on transactors guard**
- **🔧 don't care if you use immortal in ephemeral stores**
- **✅ total rule coverage**


___

### **PR Type**
enhancement, tests


___

### **Description**
- Introduced a new ESLint rule `lifespan` to ensure correct usage of ephemeral and immortal tools in atom.io stores.
- Added comprehensive tests for the `lifespan` rule, covering various valid and invalid scenarios.
- Exported the new `lifespan` rule in the rules index.
- Extracted the `walk` function into a separate module to enhance modularity and reusability across ESLint rules.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lifespan.test.ts</strong><dd><code>Add Tests for Lifespan ESLint Rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/public/eslint-plugin/lifespan.test.ts
<li>Added comprehensive tests for the new ESLint rule <code>lifespan</code>.<br> <li> Tests cover valid and invalid scenarios for importing and using <br>ephemeral and immortal store tools.<br> <li> Includes tests for transactions, selectors, and selector families with <br>various configurations.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1933/files#diff-b91e6f63899e42cfa5fc30defd4ec2cd731cefaf66a0acd9cd124c94ca6f48b8">+223/-0</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export New Lifespan ESLint Rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/eslint-plugin/src/rules/index.ts
- Added export statement for the new `lifespan` rule.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1933/files#diff-7c03de062d537960bc696cc12efea74a521b469d3eb8b8627f7135ff2fe94651">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lifespan.ts</strong><dd><code>Implement Lifespan ESLint Rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/eslint-plugin/src/rules/lifespan.ts
<li>Introduced a new ESLint rule <code>lifespan</code> to manage lifespan constraints <br>in atom.io stores.<br> <li> The rule prevents the import and use of ephemeral tools in immortal <br>stores and vice versa.<br> <li> Utilizes a custom <code>walk</code> function to traverse and validate AST nodes.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1933/files#diff-478fb840378f25e56e74a2779b8d155ae789e97e9ff2c08040b7d2ee6e67fd7f">+204/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>walk.ts</strong><dd><code>Modularize Walk Function for AST Traversal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/eslint-plugin/src/walk.ts
<li>Extracted the <code>walk</code> function into its own module for reuse across <br>different ESLint rules.<br> <li> The function recursively traverses AST nodes and applies a callback <br>function.


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1933/files#diff-5bdd14379a0ae7ae5cc18413c8808319eb0ab06459879c2c388c14c08f37da7e">+73/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

