### PR TITLE
atom.io/add eslint lifespan rule

### DIFF
--- a/.changeset/cuddly-falcons-begin.md
+++ b/.changeset/cuddly-falcons-begin.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 `atom.io/eslint-plugin` was not exporting the `lifespan` rule advertised in 0.22.0. Now it's properly exported.

--- a/packages/atom.io/eslint-plugin/src/index.ts
+++ b/packages/atom.io/eslint-plugin/src/index.ts
@@ -7,6 +7,7 @@ export { Rules }
 export default {
 	rules: {
 		"explicit-state-types": Rules.explicitStateTypes as any,
+		lifespan: Rules.lifespan as any,
 		"synchronous-selector-dependencies": Rules.synchronousSelectorDependencies,
 	},
 } satisfies ESLint.Plugin


### PR DESCRIPTION
### **User description**
- **🐛 add rule to main export**
- **🦋**


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Added the `lifespan` rule to the main export in the `atom.io/eslint-plugin`.
- Documented the export of the `lifespan` rule in a changeset file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add `lifespan` rule to ESLint plugin export.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/eslint-plugin/src/index.ts
- Added `lifespan` rule to the main export in the ESLint plugin.



</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1981/files#diff-5960b420c7d879367f78b979ce185dfeab5f836ed6e73ea1b8c359081ef81336">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cuddly-falcons-begin.md</strong><dd><code>Document the export of `lifespan` rule in changeset.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/cuddly-falcons-begin.md
<li>Documented the addition of the <code>lifespan</code> rule to the ESLint plugin <br>export.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1981/files#diff-aa57ab095654ef0ef30fc4196049821421414752904e2d580535d7bd7efc5d1d">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

