### PR TITLE
atom.io/fix symbol dispose as protected

### DIFF
--- a/.changeset/dirty-jokes-think.md
+++ b/.changeset/dirty-jokes-think.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 It is now possible to override the `[Symbol.dispose]()` method when extending the `Molecule` class.

--- a/packages/atom.io/immortal/src/molecule.ts
+++ b/packages/atom.io/immortal/src/molecule.ts
@@ -155,7 +155,7 @@ export class Molecule<Key extends Json.Serializable> {
 		this.joins.push(join)
 	}
 
-	private [Symbol.dispose](): void {
+	protected [Symbol.dispose](): void {
 		this.clear()
 		const target = newest(this.store)
 		target.molecules.delete(stringifyJson(this.token.key))


### PR DESCRIPTION
- **🐛 fix inability to override the disposal method on Molecule**
- **🦋**
