### PR TITLE
🐛 fix bad use of indexOf in molecule

### DIFF
--- a/.changeset/nine-cherries-hear.md
+++ b/.changeset/nine-cherries-hear.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 Fix issue where some molecules could be missed during the disposal process.

--- a/packages/atom.io/immortal/src/molecule.ts
+++ b/packages/atom.io/immortal/src/molecule.ts
@@ -111,11 +111,11 @@ export class Molecule<Key extends Json.Serializable> {
 
 	public detach(child: Molecule<any>): void {
 		const childIndex = this.below.indexOf(child)
-		if (childIndex !== undefined) {
+		if (childIndex !== -1) {
 			this.below.splice(childIndex, 1)
 		}
 		const parentIndex = child.above.indexOf(this)
-		if (parentIndex !== undefined) {
+		if (parentIndex !== -1) {
 			child.above.splice(parentIndex, 1)
 		}
 	}


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the incorrect use of `indexOf` in the `detach` method of the `Molecule` class by changing the condition from `!== undefined` to `!== -1`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>molecule.ts</strong><dd><code>Corrected index check in `detach` method of Molecule class.</code></dd></summary>
<hr>

packages/atom.io/immortal/src/molecule.ts
<li>Fixed the condition to check for valid index in <code>detach</code> method.<br> <li> Replaced <code>!== undefined</code> with <code>!== -1</code> for <code>indexOf</code> results.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/1992/files#diff-96ca29c99231ece5de9212e6cb1a247b1abc61f2bc688eb211048f5a2c53be6f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

