### PR TITLE
atom.io fix molecule constructor type

### DIFF
--- a/.changeset/proud-steaks-tan.md
+++ b/.changeset/proud-steaks-tan.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🏷️ The `MoleculeConstructor` type becomes more permissive to prevent a type error when setting up a `moleculeFamily`.

--- a/packages/atom.io/src/molecule.ts
+++ b/packages/atom.io/src/molecule.ts
@@ -48,7 +48,7 @@ export type MoleculeTransactors<K extends Json.Serializable> = Flat<
 >
 export type MoleculeConstructor = new (
 	transactors: MoleculeTransactors<any>,
-	key: Json.Serializable,
+	key: any,
 	...params: any
 ) => any
 


### PR DESCRIPTION
### **User description**
- **🏷️ fix type**
- **🦋**


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Changed the `key` parameter type in `MoleculeConstructor` from `Json.Serializable` to `any` to prevent a type error when setting up a `moleculeFamily`.
- Added a changeset note explaining the type change in `MoleculeConstructor`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>molecule.ts</strong><dd><code>Relaxed type constraint for `key` in `MoleculeConstructor`.</code></dd></summary>
<hr>

packages/atom.io/src/molecule.ts
<li>Changed the <code>key</code> parameter type in <code>MoleculeConstructor</code> from <br><code>Json.Serializable</code> to <code>any</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2011/files#diff-a9225f960ed0f6fe0eb3b43a57433d9b2c2ff7888f6832b22595890f34eab990">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proud-steaks-tan.md</strong><dd><code>Documented type change for `MoleculeConstructor` in changeset.</code></dd></summary>
<hr>

.changeset/proud-steaks-tan.md
<li>Added a changeset note explaining the type change in <br><code>MoleculeConstructor</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2011/files#diff-e95a8a3e5f75c4db52a604be3a1683c4807250d62586bef5b705226e5d6a4c9a">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

