### PR TITLE
atom.io molecule hierarchy claim

### DIFF
--- a/.changeset/big-tables-speak.md
+++ b/.changeset/big-tables-speak.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+✨ `moleculeFamily` passes the `claim` transactor to the constructor of the molecule instance. This transactor allows your molecule to place itself above another molecule.

--- a/packages/atom.io/internal/src/molecule/dispose-molecule.ts
+++ b/packages/atom.io/internal/src/molecule/dispose-molecule.ts
@@ -30,6 +30,21 @@ export function disposeMolecule<M extends MoleculeConstructor>(
 		return
 	}
 	const { family } = token
+
+	for (const state of molecule.tokens.values()) {
+		disposeFromStore(state, store)
+	}
+	for (const child of molecule.below.values()) {
+		if (child.family?.dependsOn === `all`) {
+			disposeMolecule(child, store)
+		} else {
+			child.above.delete(molecule.stringKey)
+			if (child.above.size === 0) {
+				disposeMolecule(child, store)
+			}
+		}
+	}
+	molecule.below.clear()
 	if (family) {
 		const Formula = withdraw(family, store)
 		const disposalEvent: MoleculeDisposal = {
@@ -54,19 +69,6 @@ export function disposeMolecule<M extends MoleculeConstructor>(
 		store.molecules.delete(molecule.stringKey)
 	}
 
-	for (const state of molecule.tokens.values()) {
-		disposeFromStore(state, store)
-	}
-	for (const child of molecule.below.values()) {
-		if (child.family?.dependsOn === `all`) {
-			disposeMolecule(child, store)
-		} else {
-			child.above.delete(molecule.stringKey)
-			if (child.above.size === 0) {
-				disposeMolecule(child, store)
-			}
-		}
-	}
 	for (const join of molecule.joins.values()) {
 		join.molecules.delete(molecule.stringKey)
 	}

--- a/packages/atom.io/internal/src/molecule/make-molecule-in-store.ts
+++ b/packages/atom.io/internal/src/molecule/make-molecule-in-store.ts
@@ -84,6 +84,23 @@ export function makeMoleculeInStore<M extends MoleculeConstructor>(
 				withdraw(f, store),
 				newest(store),
 			)) as MoleculeTransactors<MK<M>>[`bond`],
+		claim: (below, options) => {
+			const { exclusive } = options
+			const belowMolecule = newest(store).molecules.get(stringifyJson(below.key))
+			if (belowMolecule) {
+				if (exclusive) {
+					for (const value of belowMolecule.above.values()) {
+						value.below.delete(belowMolecule.stringKey)
+					}
+					belowMolecule.above.clear()
+					belowMolecule.above.set(molecule.stringKey, molecule)
+					molecule.below.set(belowMolecule.stringKey, belowMolecule)
+				} else {
+					belowMolecule.above.set(molecule.stringKey, molecule)
+					molecule.below.set(belowMolecule.stringKey, belowMolecule)
+				}
+			}
+		},
 		join: (joinToken: JoinToken<any, any, any, any>) => {
 			const join = getJoin(joinToken, store)
 			join.molecules.set(stringifyJson(key), molecule)

--- a/packages/atom.io/src/molecule.ts
+++ b/packages/atom.io/src/molecule.ts
@@ -37,6 +37,8 @@ export type MoleculeTransactors<K extends Json.Serializable> = Flat<
 		bond<T>(family: WritableFamilyToken<T, K>): WritableToken<T>
 		bond<T>(family: ReadableFamilyToken<T, K>): ReadableToken<T>
 
+		claim(below: MoleculeToken<any>, options: { exclusive: boolean })
+
 		join(joinToken: JoinToken<any, any, any, any>): void
 
 		spawn<Key extends Json.Serializable, Ctor extends MoleculeConstructor>(


### PR DESCRIPTION
### **User description**
- **✨ claim molecule transactor**
- **🦋**


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added new test cases for exclusive and nonexclusive molecule hierarchies.
- Enhanced molecule disposal logic to handle child molecules based on their dependencies.
- Introduced `claim` transactor to manage molecule hierarchy, supporting both exclusive and nonexclusive claims.
- Updated `MoleculeTransactors` type to include the `claim` method.
- Documented the new `claim` transactor functionality in a changeset.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>molecule.test.ts</strong><dd><code>Add tests for exclusive and nonexclusive molecule hierarchies</code></dd></summary>
<hr>

packages/atom.io/__tests__/experimental/immortal/molecule.test.ts
<li>Added new test cases for exclusive and nonexclusive molecule <br>hierarchies.<br> <li> Introduced logging setup in <code>beforeEach</code> hook.<br> <li> Updated existing test to use new molecule hierarchy logic.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2013/files#diff-5f77227150127691a50d1c59716155d6a74649ff4d9240f2449c7244c5c29b85">+92/-18</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dispose-molecule.ts</strong><dd><code>Enhance molecule disposal logic with dependency checks</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/molecule/dispose-molecule.ts
<li>Added logic to dispose child molecules based on their dependencies.<br> <li> Cleared <code>below</code> molecules after disposal.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2013/files#diff-70817b012eb1c8499334a404aa38ac052c80401d5cf9f665cec8d88f3f03189b">+15/-13</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>make-molecule-in-store.ts</strong><dd><code>Introduce `claim` transactor for molecule hierarchy management</code></dd></summary>
<hr>

packages/atom.io/internal/src/molecule/make-molecule-in-store.ts
<li>Added <code>claim</code> transactor to handle exclusive and nonexclusive claims.<br> <li> Updated molecule creation logic to support new <code>claim</code> functionality.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2013/files#diff-9290c58cae75db30c79a6b21212d054970787da764fcf55c447be4fef776a67e">+17/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>molecule.ts</strong><dd><code>Add `claim` method to MoleculeTransactors type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/molecule.ts
- Added `claim` method to `MoleculeTransactors` type.



</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2013/files#diff-a9225f960ed0f6fe0eb3b43a57433d9b2c2ff7888f6832b22595890f34eab990">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>big-tables-speak.md</strong><dd><code>Document `claim` transactor addition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/big-tables-speak.md
<li>Documented the addition of the <code>claim</code> transactor in <code>moleculeFamily</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2013/files#diff-3766504b501a00f5707651d434005b9f5991f1c857e1e2e8a09abbe96baa08bc">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

