### PR TITLE
atom.io get molecule

### DIFF
--- a/.changeset/strange-jeans-crash.md
+++ b/.changeset/strange-jeans-crash.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+✨ `getState` and the `get` transactor can now get the Instance for a `MoleculeToken`.

--- a/packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
+++ b/packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
@@ -7,7 +7,6 @@ import {
 	makeRootMolecule,
 	moleculeFamily,
 	setState,
-	useMolecule,
 } from "atom.io"
 import { editRelations, getJoin, join } from "atom.io/data"
 import { findState } from "atom.io/ephemeral"
@@ -58,7 +57,7 @@ describe(`immortal mode`, () => {
 			},
 		})
 		const myCounterMolecule = makeMolecule(world, counters, `my-counter`)
-		const myCounter = useMolecule(myCounterMolecule)
+		const myCounter = getState(myCounterMolecule)
 		if (!myCounter) {
 			throw new Error(`myCounter is undefined`)
 		}
@@ -68,7 +67,7 @@ describe(`immortal mode`, () => {
 		expect(() => getState(myCounter.$count)).toThrowErrorMatchingInlineSnapshot(
 			`[Error: Atom "count("my-counter")" not found in store "IMPLICIT_STORE".]`,
 		)
-		expect(useMolecule(myCounterMolecule)).toBeUndefined()
+		expect(getState(myCounterMolecule)).toBeUndefined()
 	})
 	test(`safe retrieval of state with seekState`, () => {
 		const countStates = atomFamily<number, string>({

--- a/packages/atom.io/__tests__/experimental/immortal/molecule.test.ts
+++ b/packages/atom.io/__tests__/experimental/immortal/molecule.test.ts
@@ -1,10 +1,10 @@
 import type { Logger, MoleculeTransactors } from "atom.io"
 import {
 	disposeState,
+	getState,
 	makeMolecule,
 	makeRootMolecule,
 	moleculeFamily,
-	useMolecule,
 } from "atom.io"
 import { clearStore, IMPLICIT, withdraw } from "atom.io/internal"
 
@@ -118,7 +118,7 @@ describe(`moleculeFamily`, () => {
 		expect(ab.below.size).toBe(0)
 		expect(IMPLICIT.STORE.molecules.size).toBe(4)
 
-		expect(useMolecule(abMolecule)).toBeUndefined()
+		expect(getState(abMolecule)).toBeUndefined()
 
 		disposeState(bcMolecule)
 

--- a/packages/atom.io/internal/src/get-state/get-from-store.ts
+++ b/packages/atom.io/internal/src/get-state/get-from-store.ts
@@ -1,10 +1,39 @@
-import type { ReadableToken } from "atom.io"
+import type { MoleculeConstructor, MoleculeToken, ReadableToken } from "atom.io"
 
 import type { Store } from "../store"
 import { withdraw } from "../store"
 import { readOrComputeValue } from "./read-or-compute-value"
 
-export function getFromStore<T>(token: ReadableToken<T>, store: Store): T {
+export function getFromStore<T>(token: ReadableToken<T>, store: Store): T
+export function getFromStore<M extends MoleculeConstructor>(
+	token: MoleculeToken<M>,
+	store: Store,
+): InstanceType<M> | undefined
+export function getFromStore<
+	T,
+	M extends MoleculeConstructor,
+	Token extends MoleculeToken<M> | ReadableToken<T>,
+>(token: Token, store: Store): InstanceType<M> | T | undefined
+export function getFromStore<
+	Token extends MoleculeToken<any> | ReadableToken<any>,
+>(
+	token: Token,
+	store: Store,
+):
+	| (Token extends MoleculeToken<infer M>
+			? InstanceType<M>
+			: Token extends ReadableToken<infer T>
+				? T
+				: never)
+	| undefined {
+	if (token.type === `molecule`) {
+		try {
+			const molecule = withdraw(token, store)
+			return molecule.instance
+		} catch (_) {
+			return undefined
+		}
+	}
 	const state = withdraw(token, store)
 	return readOrComputeValue(state, store)
 }

--- a/packages/atom.io/src/get-state.ts
+++ b/packages/atom.io/src/get-state.ts
@@ -1,7 +1,11 @@
 import * as Internal from "atom.io/internal"
 
-import type { ReadableToken } from "."
+import type { MoleculeConstructor, MoleculeToken, ReadableToken } from "."
 
-export function getState<T>(token: ReadableToken<T>): T {
+export function getState<T>(token: ReadableToken<T>): T
+export function getState<M extends MoleculeConstructor>(
+	token: MoleculeToken<M>,
+): InstanceType<M> | undefined
+export function getState(token: MoleculeToken<any> | ReadableToken<any>): any {
 	return Internal.getFromStore(token, Internal.IMPLICIT.STORE)
 }

--- a/packages/atom.io/src/molecule.ts
+++ b/packages/atom.io/src/molecule.ts
@@ -100,19 +100,6 @@ export function makeMolecule<M extends MoleculeConstructor>(
 	return makeMoleculeInStore(IMPLICIT.STORE, context, family, key, ...params)
 }
 
-export function useMoleculeFromStore<M extends MoleculeConstructor>(
-	token: MoleculeToken<M>,
-	store: Store,
-): InstanceType<M> | undefined {
-	const molecule = store.molecules.get(stringifyJson(token.key))
-	return molecule?.instance
-}
-export function useMolecule<M extends MoleculeConstructor>(
-	token: MoleculeToken<M>,
-): InstanceType<M> | undefined {
-	return useMoleculeFromStore(token, IMPLICIT.STORE)
-}
-
 export type MoleculeType<T extends MoleculeFamilyToken<any>> =
 	T extends MoleculeFamilyToken<infer M>
 		? M

--- a/packages/atom.io/src/transaction.ts
+++ b/packages/atom.io/src/transaction.ts
@@ -1,4 +1,5 @@
 import type {
+	getState,
 	makeMolecule,
 	MoleculeConstructor,
 	MoleculeFamilyToken,
@@ -78,7 +79,7 @@ export type TransactionUpdate<F extends Func> = {
 }
 
 export type Transactors = Readonly<{
-	get: <S>(state: ReadableToken<S>) => S
+	get: typeof getState
 	set: <S, New extends S>(
 		state: WritableToken<S>,
 		newValue: New | ((oldValue: S) => New),
@@ -90,7 +91,7 @@ export type Transactors = Readonly<{
 	) => WritableSelectorToken<J>
 }>
 export type TransactorsWithRunAndEnv = Readonly<{
-	get: <S>(state: ReadonlySelectorToken<S> | WritableToken<S>) => S
+	get: typeof getState
 	set: <S, New extends S>(
 		state: WritableToken<S>,
 		newValue: New | ((oldValue: S) => New),


### PR DESCRIPTION
### **User description**
- **✨ getState and get can now retrieve Molecule Instances**
- **🦋**


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Replaced `useMolecule` with `getState` for molecule retrieval in test files.
- Enhanced `getFromStore` and `getState` functions to support retrieving molecule instances.
- Removed deprecated `useMolecule` and `useMoleculeFromStore` functions.
- Updated `Transactors` type to use `getState` for state retrieval.
- Added a changeset describing the new `getState` functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>immortal.test.ts</strong><dd><code>Update molecule retrieval method in immortal tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
<li>Replaced <code>useMolecule</code> with <code>getState</code> for molecule retrieval.<br> <li> Updated test cases to reflect the new method for molecule state <br>retrieval.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2019/files#diff-07f4bcf7cde881144c4d396d2b1b2c345ae79bf0dc9e2ebfbb924625f7af8d99">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>molecule.test.ts</strong><dd><code>Update molecule retrieval method in molecule tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/experimental/immortal/molecule.test.ts
<li>Replaced <code>useMolecule</code> with <code>getState</code> for molecule retrieval.<br> <li> Updated test cases to reflect the new method for molecule state <br>retrieval.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2019/files#diff-5f77227150127691a50d1c59716155d6a74649ff4d9240f2449c7244c5c29b85">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>get-from-store.ts</strong><dd><code>Enhance `getFromStore` to support molecule instances retrieval</code></dd></summary>
<hr>

packages/atom.io/internal/src/get-state/get-from-store.ts
<li>Added support for retrieving molecule instances in <code>getFromStore</code>.<br> <li> Updated function overloads and implementation to handle <code>MoleculeToken</code>.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2019/files#diff-135c02462cc277a6e2619cb01e9780522ace6122893402d79ea70e3a0eb0380d">+31/-2</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>get-state.ts</strong><dd><code>Enhance `getState` to support molecule instances retrieval</code></dd></summary>
<hr>

packages/atom.io/src/get-state.ts
<li>Added support for retrieving molecule instances in <code>getState</code>.<br> <li> Updated function overloads and implementation to handle <code>MoleculeToken</code>.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2019/files#diff-78b09afe80d052bbef98e225731acdddfbbb54cb3dff74bd1fc94a91a2970bf2">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>molecule.ts</strong><dd><code>Remove deprecated molecule retrieval functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/molecule.ts
- Removed `useMolecule` and `useMoleculeFromStore` functions.



</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2019/files#diff-a9225f960ed0f6fe0eb3b43a57433d9b2c2ff7888f6832b22595890f34eab990">+0/-13</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>transaction.ts</strong><dd><code>Update transactors to use `getState` for molecule retrieval</code></dd></summary>
<hr>

packages/atom.io/src/transaction.ts
- Updated `Transactors` type to use `getState` for state retrieval.



</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2019/files#diff-19dd74b79d9760a4f29694c35238dd30cacca8fb83354bd11699525c5e0ef925">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>strange-jeans-crash.md</strong><dd><code>Add changeset for `getState` enhancement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/strange-jeans-crash.md
<li>Added changeset for patch update describing the new <code>getState</code> <br>functionality.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2019/files#diff-22e004311694a0812408222c63e28e920c66b6b23402d82a22a069cebc653e97">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

