### PR TITLE
varmint preemptively erase outputs

### DIFF
--- a/.changeset/large-yaks-allow.md
+++ b/.changeset/large-yaks-allow.md
@@ -1,0 +1,5 @@
+---
+"varmint": patch
+---
+
+🐛 Fix issue where sometimes, if a test timed out during a recording, the old output would remain present for a new input. Fixed this by removing old outputs when new inputs are written.

--- a/packages/varmint/src/squirrel.ts
+++ b/packages/varmint/src/squirrel.ts
@@ -56,6 +56,9 @@ export class Squirrel {
 			fs.mkdirSync(this.baseDir)
 		}
 		fs.writeFileSync(pathToInputFile, inputStringified)
+		if (fs.existsSync(pathToOutputFile)) {
+			fs.unlinkSync(pathToOutputFile)
+		}
 		const output = await get(...args)
 		fs.writeFileSync(pathToOutputFile, JSON.stringify(output, null, `\t`))
 		return output


### PR DESCRIPTION
- **🐛 remove output files when recording new inputs**
- **🦋**
