### PR TITLE
atom.io selector dependency tracing perf

### DIFF
--- a/.changeset/fuzzy-mugs-talk.md
+++ b/.changeset/fuzzy-mugs-talk.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🚀 Greatly improve performance for selectors with deep dependency trees. Redundant work is now avoided when discovering a selector's root atoms.

--- a/packages/atom.io/__tests__/public/atom-selector.test.ts
+++ b/packages/atom.io/__tests__/public/atom-selector.test.ts
@@ -262,4 +262,40 @@ describe(`selector`, () => {
 
 		expect(getState(findState(doubles, `root`))).toBe(0)
 	})
+	it.only(`(covers "covered" in trace-selector-atoms) won't trace the same node twice`, () => {
+		const countSelector = atom<number>({
+			key: `count`,
+			default: 0,
+		})
+
+		const countPlusTenSelector = selector<number>({
+			key: `countPlusTen`,
+			get: ({ get }) => get(countSelector) + 10,
+		})
+		const countPlusFiveSelector = selector<number>({
+			key: `countPlusFive`,
+			get: ({ get }) => get(countSelector) + 5,
+		})
+		const doubleCountPlusFifteenSelector = selector<number>({
+			key: `countPlusFifteen`,
+			get: ({ get }) => {
+				const plusTen = get(countPlusTenSelector)
+				const plusFive = get(countPlusFiveSelector)
+				return plusTen + plusFive
+			},
+		})
+		const tripleCountPlusTwentySelector = selector<number>({
+			key: `countPlusTwenty`,
+			get: ({ get }) => {
+				const doublePlusFifteen = get(doubleCountPlusFifteenSelector)
+				const plusFive = get(countPlusFiveSelector)
+				return doublePlusFifteen + plusFive
+			},
+		})
+
+		expect(getState(countPlusTenSelector)).toBe(10)
+		expect(getState(countPlusFiveSelector)).toBe(5)
+		expect(getState(doubleCountPlusFifteenSelector)).toBe(15)
+		expect(getState(tripleCountPlusTwentySelector)).toBe(20)
+	})
 })

--- a/packages/atom.io/__tests__/public/atom-selector.test.ts
+++ b/packages/atom.io/__tests__/public/atom-selector.test.ts
@@ -262,7 +262,7 @@ describe(`selector`, () => {
 
 		expect(getState(findState(doubles, `root`))).toBe(0)
 	})
-	it.only(`(covers "covered" in trace-selector-atoms) won't trace the same node twice`, () => {
+	it(`(covers "covered" in trace-selector-atoms) won't trace the same node twice`, () => {
 		const countSelector = atom<number>({
 			key: `count`,
 			default: 0,

--- a/packages/atom.io/internal/src/selector/create-readonly-selector.ts
+++ b/packages/atom.io/internal/src/selector/create-readonly-selector.ts
@@ -18,11 +18,16 @@ export const createReadonlySelector = <T>(
 ): ReadonlySelectorToken<T> => {
 	const target = newest(store)
 	const subject = new Subject<{ newValue: T; oldValue: T }>()
-
-	const { get, find, seek, json } = registerSelector(options.key, target)
+	const covered = new Set<string>()
+	const { get, find, seek, json } = registerSelector(
+		options.key,
+		covered,
+		target,
+	)
 	const getSelf = () => {
 		const value = options.get({ get, find, seek, json })
 		cacheValue(options.key, value, subject, newest(store))
+		covered.clear()
 		return value
 	}
 

--- a/packages/atom.io/internal/src/selector/create-writable-selector.ts
+++ b/packages/atom.io/internal/src/selector/create-writable-selector.ts
@@ -21,13 +21,15 @@ export const createWritableSelector = <T>(
 ): WritableSelectorToken<T> => {
 	const target = newest(store)
 	const subject = new Subject<{ newValue: T; oldValue: T }>()
-	const transactors = registerSelector(options.key, target)
+	const covered = new Set<string>()
+	const transactors = registerSelector(options.key, covered, target)
 	const { find, get, seek, json } = transactors
 	const readonlyTransactors = { find, get, seek, json }
 
 	const getSelf = (innerTarget = newest(store)): T => {
 		const value = options.get(readonlyTransactors)
 		cacheValue(options.key, value, subject, innerTarget)
+		covered.clear()
 		return value
 	}
 

--- a/packages/atom.io/internal/src/selector/register-selector.ts
+++ b/packages/atom.io/internal/src/selector/register-selector.ts
@@ -19,6 +19,7 @@ import { updateSelectorAtoms } from "./update-selector-atoms"
 
 export const registerSelector = (
 	selectorKey: string,
+	covered: Set<string>,
 	store: Store,
 ): Transactors => ({
 	get: (dependency: MoleculeToken<MoleculeConstructor> | ReadableToken<any>) => {
@@ -49,7 +50,7 @@ export const registerSelector = (
 				source: dependency.key,
 			},
 		)
-		updateSelectorAtoms(selectorKey, dependency, store)
+		updateSelectorAtoms(selectorKey, dependency, covered, store)
 		return dependencyValue
 	},
 	set: (WritableToken, newValue) => {

--- a/packages/atom.io/internal/src/selector/trace-selector-atoms.ts
+++ b/packages/atom.io/internal/src/selector/trace-selector-atoms.ts
@@ -4,7 +4,6 @@ import { isAtomKey } from "../keys"
 import { getSelectorDependencyKeys } from "./get-selector-dependency-keys"
 
 export const traceSelectorAtoms = (
-	selectorKey: string,
 	directDependencyKey: StateKey<unknown>,
 	covered: Set<string>,
 	store: Store,
@@ -15,7 +14,6 @@ export const traceSelectorAtoms = (
 		directDependencyKey,
 		store,
 	)
-	let depth = 0
 	while (indirectDependencyKeys.length > 0) {
 		// biome-ignore lint/style/noNonNullAssertion: just checked length ^^^
 		const indirectDependencyKey = indirectDependencyKeys.shift()!
@@ -23,12 +21,6 @@ export const traceSelectorAtoms = (
 			continue
 		}
 		covered.add(indirectDependencyKey)
-		++depth
-		if (depth > 99999) {
-			throw new Error(
-				`Maximum selector dependency depth exceeded (> 99999) in selector "${selectorKey}". This is likely due to a circular dependency.`,
-			)
-		}
 
 		if (!isAtomKey(indirectDependencyKey, store)) {
 			indirectDependencyKeys.push(
@@ -52,6 +44,6 @@ export const traceAllSelectorAtoms = (
 	return directDependencyKeys.flatMap((depKey) =>
 		isAtomKey(depKey, store)
 			? depKey
-			: traceSelectorAtoms(selectorKey, depKey, covered, store),
+			: traceSelectorAtoms(depKey, covered, store),
 	)
 }

--- a/packages/atom.io/internal/src/selector/update-selector-atoms.ts
+++ b/packages/atom.io/internal/src/selector/update-selector-atoms.ts
@@ -10,7 +10,9 @@ export const updateSelectorAtoms = (
 	store: Store,
 ): void => {
 	const target = newest(store)
+	const covered = new Set<string>()
 	if (dependency.type === `atom` || dependency.type === `mutable_atom`) {
+		covered.add(dependency.key)
 		target.selectorAtoms.set({
 			selectorKey,
 			atomKey: dependency.key,
@@ -22,7 +24,12 @@ export const updateSelectorAtoms = (
 			`discovers root atom "${dependency.key}"`,
 		)
 	} else {
-		const rootKeys = traceSelectorAtoms(selectorKey, dependency.key, store)
+		const rootKeys = traceSelectorAtoms(
+			selectorKey,
+			dependency.key,
+			covered,
+			store,
+		)
 		store.logger.info(
 			`🔍`,
 			`selector`,

--- a/packages/atom.io/internal/src/selector/update-selector-atoms.ts
+++ b/packages/atom.io/internal/src/selector/update-selector-atoms.ts
@@ -7,12 +7,11 @@ import { traceSelectorAtoms } from "./trace-selector-atoms"
 export const updateSelectorAtoms = (
 	selectorKey: string,
 	dependency: ReadonlySelectorToken<unknown> | WritableToken<unknown>,
+	covered: Set<string>,
 	store: Store,
 ): void => {
 	const target = newest(store)
-	const covered = new Set<string>()
 	if (dependency.type === `atom` || dependency.type === `mutable_atom`) {
-		covered.add(dependency.key)
 		target.selectorAtoms.set({
 			selectorKey,
 			atomKey: dependency.key,
@@ -24,12 +23,7 @@ export const updateSelectorAtoms = (
 			`discovers root atom "${dependency.key}"`,
 		)
 	} else {
-		const rootKeys = traceSelectorAtoms(
-			selectorKey,
-			dependency.key,
-			covered,
-			store,
-		)
+		const rootKeys = traceSelectorAtoms(dependency.key, covered, store)
 		store.logger.info(
 			`🔍`,
 			`selector`,
@@ -45,4 +39,5 @@ export const updateSelectorAtoms = (
 			})
 		}
 	}
+	covered.add(dependency.key)
 }


### PR DESCRIPTION
### **User description**
- **🚀 improve performance greatly for selectors with vast dependency trees**
- **🦋**


___

### **PR Type**
Enhancement


___

### **Description**
- Added a `covered` parameter to `traceSelectorAtoms` and `updateSelectorAtoms` functions to track and skip already visited dependencies, significantly improving performance for selectors with deep dependency trees.
- Updated function calls to include the new `covered` parameter.
- Documented the performance improvements in a changeset entry.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>trace-selector-atoms.ts</strong><dd><code>Add covered set to optimize dependency tracing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/selector/trace-selector-atoms.ts
<li>Added <code>covered</code> parameter to track visited dependencies.<br> <li> Implemented logic to skip already covered dependencies.<br> <li> Updated function calls to include the new <code>covered</code> parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2164/files#diff-f1c3ae6d3b98e2e331d7f8a4fcd2670844c78a2540fb6f8fd3c1c75c9f9aa616">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>update-selector-atoms.ts</strong><dd><code>Optimize selector atom updates with covered set</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/selector/update-selector-atoms.ts
<li>Introduced <code>covered</code> set to track visited dependencies.<br> <li> Updated function calls to include the new <code>covered</code> parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2164/files#diff-8f4f2487907cd596168307428dc919dc70d45bff12129f1613ac8176c20d4cb2">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fuzzy-mugs-talk.md</strong><dd><code>Document performance improvements in changeset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/fuzzy-mugs-talk.md
<li>Added changeset entry for performance improvements in selector <br>dependency tracing.<br>


</details>
    

  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2164/files#diff-261001a207e876f5e0e75b63fe234ab6164ade8934b8f42a6aa44c9995c3a5a3">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

