### PR TITLE
atom.io merge join tool into bond

### DIFF
--- a/.changeset/gentle-flowers-shake.md
+++ b/.changeset/gentle-flowers-shake.md
@@ -1,0 +1,5 @@
+---
+"atom.io": minor
+---
+
+💥 BREAKING CHANGE: The method `join` from `MoleculeToolkit` has been absorbed into the `bond` method; it now returns tokens for the relations of the entity bonded to the join in question.

--- a/packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
+++ b/packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
@@ -95,7 +95,7 @@ describe(`immortal integrations`, () => {
 			key: `item`,
 			new: class Item {
 				public constructor(transactors: MoleculeTransactors<string>) {
-					transactors.join(holdersOfItems)
+					transactors.bond(holdersOfItems, { as: `item` })
 				}
 			},
 		})
@@ -104,7 +104,7 @@ describe(`immortal integrations`, () => {
 			key: `character`,
 			new: class Character {
 				public constructor(transactors: MoleculeTransactors<string>) {
-					transactors.join(holdersOfItems)
+					transactors.bond(holdersOfItems, { as: `holder` })
 				}
 			},
 		})

--- a/packages/atom.io/data/src/join.ts
+++ b/packages/atom.io/data/src/join.ts
@@ -435,7 +435,7 @@ export class Join<
 							transactors: MoleculeTransactors<string>,
 							public key: string,
 						) {
-							transactors.join(joinToken)
+							transactors.bond(joinToken, { as: null } as any)
 						}
 					},
 				},

--- a/packages/atom.io/internal/src/molecule/make-molecule-in-store.ts
+++ b/packages/atom.io/internal/src/molecule/make-molecule-in-store.ts
@@ -124,7 +124,6 @@ export function makeMoleculeInStore<M extends MoleculeConstructor>(
 				}
 			}
 		},
-		// join: <J extends JoinToken<any, any, any, any>>(joinToken: J) => {},
 		spawn: (f: MoleculeFamilyToken<any>, k: any, ...p: any[]) =>
 			makeMoleculeInStore(
 				newest(store),

--- a/packages/atom.io/src/molecule.ts
+++ b/packages/atom.io/src/molecule.ts
@@ -36,10 +36,23 @@ export type MoleculeTransactors<K extends Json.Serializable> = Flat<
 		bond<T>(family: ReadonlySelectorFamilyToken<T, K>): ReadonlySelectorToken<T>
 		bond<T>(family: WritableFamilyToken<T, K>): WritableToken<T>
 		bond<T>(family: ReadableFamilyToken<T, K>): ReadableToken<T>
+		bond<J extends JoinToken<any, any, any, any>>(
+			joinToken: J,
+			role: {
+				as: J extends JoinToken<infer A, infer B, any, any> ? A | B : never
+			},
+		): J extends JoinToken<any, any, any, infer Content>
+			? Content extends null
+				? { relatedKeys: ReadonlySelectorToken<string[]> }
+				: {
+						relatedKeys: ReadonlySelectorToken<string[]>
+						relatedEntries: ReadonlySelectorToken<
+							[key: string, value: Content][]
+						>
+					}
+			: never
 
-		claim(below: MoleculeToken<any>, options: { exclusive: boolean })
-
-		join<J extends JoinToken<any, any, any, any>>(joinToken: J): J
+		claim(below: MoleculeToken<any>, options: { exclusive: boolean }): void
 
 		spawn<Key extends Json.Serializable, Ctor extends MoleculeConstructor>(
 			family: MoleculeFamilyToken<Ctor>,


### PR DESCRIPTION
### **User description**
- **♻️ join molecule tool absorbed into bond**
- **🦋**


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Replaced the `join` method with the `bond` method across multiple modules.
- Enhanced the `bond` method to handle `JoinToken` and return related tokens.
- Updated test cases to use the `bond` method instead of `join`.
- Documented the breaking change in a changeset file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>immortal.test.ts</strong><dd><code>Update test cases to use `bond` method instead of `join`</code>&nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/experimental/immortal/immortal.test.ts

<li>Replaced <code>transactors.join</code> with <code>transactors.bond</code> in test cases.<br> <li> Updated parameters for <code>bond</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2176/files#diff-07f4bcf7cde881144c4d396d2b1b2c345ae79bf0dc9e2ebfbb924625f7af8d99">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>join.ts</strong><dd><code>Replace `join` method with `bond` in data module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/data/src/join.ts

<li>Replaced <code>transactors.join</code> with <code>transactors.bond</code>.<br> <li> Updated parameters for <code>bond</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2176/files#diff-8ede6a54b258362ab00273b6cca0dabe03db72089527006b1cca991abe187da8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>make-molecule-in-store.ts</strong><dd><code>Enhance `bond` method and remove `join` method in molecule store</code></dd></summary>
<hr>

packages/atom.io/internal/src/molecule/make-molecule-in-store.ts

<li>Added <code>capitalize</code> function.<br> <li> Replaced <code>join</code> method with <code>bond</code> method.<br> <li> Enhanced <code>bond</code> method to handle <code>JoinToken</code> and return related tokens.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2176/files#diff-9290c58cae75db30c79a6b21212d054970787da764fcf55c447be4fef776a67e">+36/-13</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>molecule.ts</strong><dd><code>Add `bond` method overloads and remove `join` method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/molecule.ts

<li>Added <code>bond</code> method overloads for <code>JoinToken</code>.<br> <li> Removed <code>join</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2176/files#diff-a9225f960ed0f6fe0eb3b43a57433d9b2c2ff7888f6832b22595890f34eab990">+16/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gentle-flowers-shake.md</strong><dd><code>Document breaking change for `join` method absorption</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/gentle-flowers-shake.md

<li>Documented breaking change for the absorption of <code>join</code> method into <br><code>bond</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2176/files#diff-9aac5daf04132297988bef9578028aef968cfaca46d28657df116a6ba26d0414">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

