### PR TITLE
atom.io 0.25.0 fixes

### DIFF
--- a/.changeset/spicy-games-argue.md
+++ b/.changeset/spicy-games-argue.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 Fixed bug where, when attempting to retrive states with `CtorToolkit["get"]`, the states would be fail to be found.

--- a/.changeset/stupid-suns-hear.md
+++ b/.changeset/stupid-suns-hear.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 Fixed bug where, when a molecule could not be found, its key would not be properly error-logged.

--- a/packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
+++ b/packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
@@ -65,7 +65,7 @@ describe(`immortal mode`, () => {
 		expect(getState(myCounter.$count)).toBe(1)
 		disposeState(myCounterMolecule)
 		expect(() => getState(myCounter.$count)).toThrowErrorMatchingInlineSnapshot(
-			`[Error: Atom "count("my-counter")" not found in store "IMPLICIT_STORE".]`,
+			`[Error: Atom "count(\\"my-counter\\")" not found in store "IMPLICIT_STORE".]`,
 		)
 		expect(() => getState(myCounterMolecule)).toThrowErrorMatchingInlineSnapshot(
 			`[Error: Molecule "my-counter" not found in store "IMPLICIT_STORE".]`,

--- a/packages/atom.io/__tests__/public/silo.test.ts
+++ b/packages/atom.io/__tests__/public/silo.test.ts
@@ -75,14 +75,14 @@ describe(`silo`, () => {
 
 		expect(() => {
 			Uno.getState(countState__Uno)
-		}).toThrowError(`Atom "counts("a")" not found in store "uno".`)
+		}).toThrowError(`Atom "counts(\\"a\\")" not found in store "uno".`)
 		expect(() => Dos.getState(countState__Dos)).toThrowError(
-			`Atom "counts("b")" not found in store "dos".`,
+			`Atom "counts(\\"b\\")" not found in store "dos".`,
 		)
 
 		expect(hasImplicitStoreBeenCreated()).toBe(false)
 		expect(() => getState(countState__Uno)).toThrowError(
-			`Atom "counts("a")" not found in store "IMPLICIT_STORE".`,
+			`Atom "counts(\\"a\\")" not found in store "IMPLICIT_STORE".`,
 		)
 	})
 })

--- a/packages/atom.io/break-check.config.json
+++ b/packages/atom.io/break-check.config.json
@@ -2,5 +2,5 @@
 	"tagPattern": "atom.io",
 	"testPattern": "__tests__/public/**/*.test.{ts,tsx}",
 	"testCommand": "bun run build && bun run test:once:public",
-	"certifyCommand": "grep -q -F '\"atom.io\": minor' ../../.changeset/*.md"
+	"certifyCommand": "grep -q -F '\"atom.io\": patch' ../../.changeset/*.md"
 }

--- a/packages/atom.io/internal/src/lineage.ts
+++ b/packages/atom.io/internal/src/lineage.ts
@@ -10,3 +10,10 @@ export function newest<T extends Lineage>(scion: T): T {
 	}
 	return scion
 }
+
+export function eldest<T extends Lineage>(scion: T): T {
+	while (scion.parent !== null) {
+		scion = scion.parent
+	}
+	return scion
+}

--- a/packages/atom.io/internal/src/not-found-error.ts
+++ b/packages/atom.io/internal/src/not-found-error.ts
@@ -54,7 +54,7 @@ export class NotFoundError extends Error {
 
 		if (params.length === 2) {
 			super(
-				`${prettyPrintTokenType(token)} "${token.key}" not found in store "${
+				`${prettyPrintTokenType(token)} ${stringifyJson(token.key)} not found in store "${
 					store.config.name
 				}".`,
 			)


### PR DESCRIPTION
### **User description**
- **🐛 fix [object Object] when failing to find a molecule**
- **🐛 fix store accesses in ctortoolkit**
- **🦋**


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added a new function `eldest` to find the eldest ancestor in a lineage.
- Fixed store accesses in `makeMoleculeInStore` by using the root store.
- Updated `toolkit` methods to use `rootStore` instead of `store`.
- Fixed error message to properly log the key when a molecule is not found.
- Added changesets for the above fixes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lineage.ts</strong><dd><code>Add function to find the eldest ancestor in lineage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/lineage.ts

<li>Added a new function <code>eldest</code> to find the eldest ancestor in a lineage.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2185/files#diff-5df4edd0c3f83c473e41c792b587abf8a09fb4c5797a62823dd918f416ec36c8">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>make-molecule-in-store.ts</strong><dd><code>Fix store accesses and use root store in toolkit methods</code>&nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/molecule/make-molecule-in-store.ts

<li>Imported <code>getState</code> and <code>setState</code> types.<br> <li> Added <code>eldest</code> function to determine the root store.<br> <li> Updated <code>toolkit</code> methods to use <code>rootStore</code> instead of <code>store</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2185/files#diff-9290c58cae75db30c79a6b21212d054970787da764fcf55c447be4fef776a67e">+20/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>not-found-error.ts</strong><dd><code>Fix error message for not found molecule key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/not-found-error.ts

<li>Fixed error message to properly log the key when a molecule is not <br>found.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2185/files#diff-7cb9fc6a599019d1e1acd3c28ba0f05ab3f9494af195f36a8a223c32d6900533">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>spicy-games-argue.md</strong><dd><code>Add changeset for state retrieval bug fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/spicy-games-argue.md

<li>Added changeset for fixing state retrieval bug in <code>CtorToolkit["get"]</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2185/files#diff-4c828660a731edc6d021e9f56435b5543e867ce0eb965d7a362b89f56ab65717">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stupid-suns-hear.md</strong><dd><code>Add changeset for molecule not found error logging fix</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/stupid-suns-hear.md

<li>Added changeset for fixing error logging when a molecule is not found.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2185/files#diff-97265efb0ec14f8dff0246c48ba34d1b049698e6586ef1aa303cb85d7f02bbd3">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

