### PR TITLE
🔧 fix config

### DIFF
--- a/packages/atom.io/break-check.config.json
+++ b/packages/atom.io/break-check.config.json
@@ -2,5 +2,5 @@
 	"tagPattern": "atom.io",
 	"testPattern": "__tests__/public/**/*.test.{ts,tsx}",
 	"testCommand": "bun run build && bun run test:once:public",
-	"certifyCommand": "grep -q -F '\"atom.io\": patch' ../../.changeset/*.md"
+	"certifyCommand": "grep -q -F '\"atom.io\": minor' ../../.changeset/*.md"
 }


### PR DESCRIPTION
### **PR Type**
bug fix


___

### **Description**
- Fixed the `certifyCommand` in `break-check.config.json` to correctly check for `minor` updates instead of `patch` updates in changeset files.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>break-check.config.json</strong><dd><code>Fix certification command to check for minor updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/break-check.config.json

<li>Updated <code>certifyCommand</code> to check for <code>minor</code> instead of <code>patch</code> in <br>changeset files.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2187/files#diff-4bcdfcbf7123f7b1cacf0dc2488a1a2487af0b534bc8f0e79432461483498321">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

