### PR TITLE
atom.io fix selector bug

### DIFF
--- a/.changeset/brown-dragons-sin.md
+++ b/.changeset/brown-dragons-sin.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 Fix bug where, `GetterToolkit`'s and `SetterToolkit`'s `get` method would error when retrieving state from a family that wasn't an `AtomFamily`.


### PR DESCRIPTION
### **User description**
- **🔧 fix config**
- **🐛 fix bug with selector get**
- **🦋**


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fixed a bug in the `get` method of `GetterToolkit` and `SetterToolkit` to correctly handle family tokens.
- Updated parameter handling for `get` and `set` methods to improve clarity and functionality.
- Replaced `WritableSelectorFamilyToken` with `WritableFamilyToken` for consistency.
- Added a changeset entry to document the bug fix.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>register-selector.ts</strong><dd><code>Fix selector `get` method and update token types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/selector/register-selector.ts

<li>Fixed the <code>get</code> method to handle family tokens correctly.<br> <li> Changed parameter handling for <code>get</code> and <code>set</code> methods.<br> <li> Replaced <code>WritableSelectorFamilyToken</code> with <code>WritableFamilyToken</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2188/files#diff-613871cd6ba651c13a86c399ea124efccbe8c472497ff20a6226c7e8fd9222e6">+17/-14</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>brown-dragons-sin.md</strong><dd><code>Add changeset entry for selector `get` method bug fix</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/brown-dragons-sin.md

<li>Added a changeset entry describing the bug fix for the <code>get</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2188/files#diff-1a56c116c92240fe35ecf723f868b363d8f25a8adcef12d0525c0a2c8b6d1b97">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

