### PR TITLE
atom.io fix ephemeral react

### DIFF
--- a/.changeset/young-comics-sort.md
+++ b/.changeset/young-comics-sort.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 Fix bug where, when using `useO` in `ephemeral` stores, a state would not be created as needed in React components.

--- a/packages/atom.io/__tests__/experimental/immortal/react-immortal.test.tsx
+++ b/packages/atom.io/__tests__/experimental/immortal/react-immortal.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render } from "@testing-library/react"
+import type { CtorToolkit, Func, Logger } from "atom.io"
+import {
+	atomFamily,
+	makeMolecule,
+	makeRootMolecule,
+	moleculeFamily,
+} from "atom.io"
+import * as Internal from "atom.io/internal"
+import * as AR from "atom.io/react"
+import type { FC } from "react"
+
+import * as Utils from "../../__util__"
+
+const LOG_LEVELS = [null, `error`, `warn`, `info`] as const
+const CHOOSE = 2
+
+let logger: Logger
+
+beforeEach(() => {
+	Internal.clearStore(Internal.IMPLICIT.STORE)
+	Internal.IMPLICIT.STORE.config.lifespan = `immortal`
+	Internal.IMPLICIT.STORE.loggers[0].logLevel = LOG_LEVELS[CHOOSE]
+	logger = Internal.IMPLICIT.STORE.logger
+	vitest.spyOn(logger, `error`)
+	vitest.spyOn(logger, `warn`)
+	vitest.spyOn(logger, `info`)
+	vitest.spyOn(Utils, `stdout`)
+})
+
+describe(`family usage`, () => {
+	const setters: Func[] = []
+	const scenario = () => {
+		const letterAtoms = atomFamily<string, string>({
+			key: `letter`,
+			default: `A`,
+		})
+		const componentMolecules = moleculeFamily({
+			key: `component`,
+			new: class Component {
+				public constructor(
+					tools: CtorToolkit<string>,
+					public key: string,
+					public letterState = tools.bond(letterAtoms),
+				) {}
+			},
+		})
+
+		const Letter: FC = () => {
+			const setLetter = AR.useI(letterAtoms, `letter`)
+			const letter = AR.useO(letterAtoms, `letter`)
+			setters.push(setLetter)
+			return (
+				<>
+					<div data-testid={letter}>{letter}</div>
+					<button
+						type="button"
+						onClick={() => {
+							setLetter(`B`)
+						}}
+						data-testid="changeStateButton"
+					/>
+				</>
+			)
+		}
+		function run() {
+			return render(
+				<AR.StoreProvider>
+					<Letter />
+				</AR.StoreProvider>,
+			)
+		}
+		return { run, componentMolecules }
+	}
+
+	it(`successfully finds a state preexisting in the store`, () => {
+		const { run, componentMolecules } = scenario()
+		const rootMolecule = makeRootMolecule(`root`)
+		makeMolecule(rootMolecule, componentMolecules, `letter`)
+		const { getByTestId } = run()
+		const changeStateButton = getByTestId(`changeStateButton`)
+		fireEvent.click(changeStateButton)
+		const option = getByTestId(`B`)
+		expect(option).toBeTruthy()
+		expect(setters.length).toBe(2)
+		expect(setters[0]).toBe(setters[1])
+	})
+
+	it(`throws an error if the state is not found`, () => {
+		const { run } = scenario()
+		expect(run).toThrowError(
+			`Atom Family "letter" member "letter" not found in store "IMPLICIT_STORE".`,
+		)
+	})
+})

--- a/packages/atom.io/react/src/parse-state-overloads.ts
+++ b/packages/atom.io/react/src/parse-state-overloads.ts
@@ -1,0 +1,43 @@
+import type {
+	ReadableFamilyToken,
+	ReadableToken,
+	WritableFamilyToken,
+	WritableToken,
+} from "atom.io"
+import type { Store } from "atom.io/internal"
+import { findInStore, NotFoundError, seekInStore } from "atom.io/internal"
+import type { Json } from "atom.io/json"
+
+export function parseStateOverloads<T, K extends Json.Serializable>(
+	store: Store,
+	...rest: [WritableFamilyToken<T, K>, K] | [WritableToken<T>]
+): WritableToken<T>
+
+export function parseStateOverloads<T, K extends Json.Serializable>(
+	store: Store,
+	...rest: [ReadableFamilyToken<T, K>, K] | [ReadableToken<T>]
+): ReadableToken<T>
+
+export function parseStateOverloads<T, K extends Json.Serializable>(
+	store: Store,
+	...rest: [ReadableFamilyToken<T, K>, K] | [ReadableToken<T>]
+): ReadableToken<T> {
+	let token: ReadableToken<any>
+	if (rest.length === 2) {
+		const family = rest[0]
+		const key = rest[1]
+
+		if (store.config.lifespan === `immortal`) {
+			const maybeToken = seekInStore(family, key, store)
+			if (!maybeToken) {
+				throw new NotFoundError(family, key, store)
+			}
+			token = maybeToken
+		} else {
+			token = findInStore(family, key, store)
+		}
+	} else {
+		token = rest[0]
+	}
+	return token
+}

--- a/packages/atom.io/react/src/use-i.ts
+++ b/packages/atom.io/react/src/use-i.ts
@@ -1,13 +1,9 @@
-import type { ReadableToken, WritableFamilyToken, WritableToken } from "atom.io"
-import {
-	findInStore,
-	NotFoundError,
-	seekInStore,
-	setIntoStore,
-} from "atom.io/internal"
+import type { WritableFamilyToken, WritableToken } from "atom.io"
+import { setIntoStore } from "atom.io/internal"
 import type { Json } from "atom.io/json"
 import * as React from "react"
 
+import { parseStateOverloads } from "./parse-state-overloads"
 import { StoreContext } from "./store-context"
 
 export function useI<T>(
@@ -23,24 +19,7 @@ export function useI<T, K extends Json.Serializable>(
 	...params: [WritableFamilyToken<T, K>, K] | [WritableToken<T>]
 ): <New extends T>(next: New | ((old: T) => New)) => void {
 	const store = React.useContext(StoreContext)
-
-	let token: ReadableToken<any>
-	if (params.length === 2) {
-		const family = params[0]
-		const key = params[1]
-
-		if (store.config.lifespan === `immortal`) {
-			const maybeToken = seekInStore(family, key, store)
-			if (!maybeToken) {
-				throw new NotFoundError(family, key, store)
-			}
-			token = maybeToken
-		} else {
-			token = findInStore(family, key, store)
-		}
-	} else {
-		token = params[0]
-	}
+	const token = parseStateOverloads(store, ...params)
 	const setter: React.MutableRefObject<
 		(<New extends T>(next: New | ((old: T) => New)) => void) | null
 	> = React.useRef(null)

--- a/packages/atom.io/react/src/use-i.ts
+++ b/packages/atom.io/react/src/use-i.ts
@@ -20,27 +20,33 @@ export function useI<T, K extends Json.Serializable>(
 ): <New extends T>(next: New | ((old: T) => New)) => void
 
 export function useI<T, K extends Json.Serializable>(
-	token: WritableFamilyToken<T, K> | WritableToken<T>,
-	key?: K,
+	...params: [WritableFamilyToken<T, K>, K] | [WritableToken<T>]
 ): <New extends T>(next: New | ((old: T) => New)) => void {
 	const store = React.useContext(StoreContext)
-	const stateToken: ReadableToken<any> | undefined =
-		token.type === `atom_family` ||
-		token.type === `mutable_atom_family` ||
-		token.type === `selector_family`
-			? store.config.lifespan === `immortal`
-				? seekInStore(token, key as K, store)
-				: findInStore(token, key as K, store)
-			: token
-	if (!stateToken) {
-		throw new NotFoundError(token, key, store)
+
+	let token: ReadableToken<any>
+	if (params.length === 2) {
+		const family = params[0]
+		const key = params[1]
+
+		if (store.config.lifespan === `immortal`) {
+			const maybeToken = seekInStore(family, key, store)
+			if (!maybeToken) {
+				throw new NotFoundError(family, key, store)
+			}
+			token = maybeToken
+		} else {
+			token = findInStore(family, key, store)
+		}
+	} else {
+		token = params[0]
 	}
 	const setter: React.MutableRefObject<
 		(<New extends T>(next: New | ((old: T) => New)) => void) | null
 	> = React.useRef(null)
 	if (setter.current === null) {
 		setter.current = (next) => {
-			setIntoStore(stateToken, next, store)
+			setIntoStore(token, next, store)
 		}
 	}
 	return setter.current

--- a/packages/atom.io/react/src/use-o.ts
+++ b/packages/atom.io/react/src/use-o.ts
@@ -21,6 +21,9 @@ export function useO<T, K extends Json.Serializable>(
 export function useO<T, K extends Json.Serializable>(
 	token: ReadableFamilyToken<T, K> | ReadableToken<T>,
 	key?: K,
+	// ...params:
+	// 	| [ReadableFamilyToken<T, K>, K]
+	// 	| [ReadableToken<T>]
 ): T {
 	const store = React.useContext(StoreContext)
 	const stateToken: ReadableToken<any> | undefined =
@@ -33,7 +36,7 @@ export function useO<T, K extends Json.Serializable>(
 				: findInStore(token, key as K, store)
 			: token
 	if (!stateToken) {
-		throw new NotFoundError(token, store)
+		throw new NotFoundError(token, key, store)
 	}
 	const id = React.useId()
 	return React.useSyncExternalStore<T>(

--- a/packages/atom.io/react/src/use-o.ts
+++ b/packages/atom.io/react/src/use-o.ts
@@ -1,5 +1,6 @@
 import type { ReadableFamilyToken, ReadableToken } from "atom.io"
 import {
+	findInStore,
 	getFromStore,
 	NotFoundError,
 	seekInStore,
@@ -27,7 +28,9 @@ export function useO<T, K extends Json.Serializable>(
 		token.type === `mutable_atom_family` ||
 		token.type === `selector_family` ||
 		token.type === `readonly_selector_family`
-			? seekInStore(token, key as K, store)
+			? store.config.lifespan === `immortal`
+				? seekInStore(token, key as K, store)
+				: findInStore(token, key as K, store)
 			: token
 	if (!stateToken) {
 		throw new NotFoundError(token, store)


### PR DESCRIPTION
### **User description**
- **🐛 useO uses find in an ephemeral store**
- **✅ test react-immortal... leaves something to be desired**
- **🏷️ fix types**
- **✅ finish coverage**
- **🦋**


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added new test cases for `useO` in `ephemeral` stores to verify state creation and error handling in React components.
- Introduced `parseStateOverloads` function to handle state token parsing based on store lifespan.
- Refactored `useI` and `useO` hooks to use the new `parseStateOverloads` function, simplifying their logic.
- Added a changeset entry documenting the bug fix related to `useO` in `ephemeral` stores.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>react-immortal.test.tsx</strong><dd><code>Add tests for `useO` in `ephemeral` stores</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/experimental/immortal/react-immortal.test.tsx

<li>Added new test cases for <code>useO</code> in <code>ephemeral</code> stores.<br> <li> Verified state creation and error handling in React components.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2203/files#diff-a9b65486b1a555a1fd549d440ac20d0c68e6f80c5cef1995bbc8fa82d7bc1d48">+95/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parse-state-overloads.ts</strong><dd><code>Add `parseStateOverloads` function for state token parsing</code></dd></summary>
<hr>

packages/atom.io/react/src/parse-state-overloads.ts

<li>Introduced <code>parseStateOverloads</code> function to handle state token parsing.<br> <li> Implemented logic to find or seek tokens based on store lifespan.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2203/files#diff-aceae23faf62d90ae110ec08e7a5e416439b07e006b1a685383cfdd1d3c0a45b">+43/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>use-i.ts</strong><dd><code>Refactor `useI` to use `parseStateOverloads`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/react/src/use-i.ts

<li>Refactored <code>useI</code> to use <code>parseStateOverloads</code> for token parsing.<br> <li> Simplified logic for setting state into the store.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2203/files#diff-a5062343b15965375864fa60ce5600920dad990a81eb6564eecac052246fa320">+6/-11</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>use-o.ts</strong><dd><code>Refactor `useO` to use `parseStateOverloads`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/react/src/use-o.ts

<li>Refactored <code>useO</code> to use <code>parseStateOverloads</code> for token parsing.<br> <li> Simplified logic for getting state from the store.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2203/files#diff-0bc472849e63474db5d721801aed430e9fff8cb73b7beacf77ca85689724859d">+7/-21</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>young-comics-sort.md</strong><dd><code>Add changeset entry for `useO` bug fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/young-comics-sort.md

<li>Added changeset entry for the bug fix related to <code>useO</code> in <code>ephemeral</code> <br>stores.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2203/files#diff-6dfa1f7139efcf98e65fcac2e286dc87328991d8df366dd0aea98c25460b4aaf">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

