### PR TITLE
realtime occlusion strategies

### DIFF
--- a/.changeset/dry-news-dress.md
+++ b/.changeset/dry-news-dress.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 (experimental) realtime continuity handles mutable atoms better.

--- a/.changeset/long-dogs-wait.md
+++ b/.changeset/long-dogs-wait.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+✨ `Silo` adds the `runTransaction` method.

--- a/apps/core.wayfarer.quest/.env.dev
+++ b/apps/core.wayfarer.quest/.env.dev
@@ -1,0 +1,2 @@
+PORT=3000
+CLIENT_ORIGINS=["http://localhost:4500","http://eris.local:4500"]

--- a/apps/core.wayfarer.quest/src/system.server.ts
+++ b/apps/core.wayfarer.quest/src/system.server.ts
@@ -62,6 +62,7 @@ pipe(
 			exposeMutableFamily(usersOfSocketsAtoms, RTS.socketIndex)
 			const usersInRoomsAtoms = getInternalRelations(RT.usersInRooms)
 			exposeMutableFamily(usersInRoomsAtoms, RT.roomIndex)
+			exposeMutable(findState(usersInRoomsAtoms, username))
 
 			socket.on(`create-room`, async (roomId) => {
 				await runTransaction(RTS.createRoomTX)(roomId, `bun`, [

--- a/apps/wayfarer.quest/.env.dev
+++ b/apps/wayfarer.quest/.env.dev
@@ -1,0 +1,2 @@
+PORT=4500
+NEXT_PUBLIC_REMOTE_ORIGIN="http://eris.local:3000"

--- a/apps/wayfarer.quest/src/app/Room.tsx
+++ b/apps/wayfarer.quest/src/app/Room.tsx
@@ -21,13 +21,14 @@ import { roomViewState } from "wayfarer.quest/services/store/room-view-state"
 import scss from "./page.module.scss"
 import { UsersInRoom } from "./PlayersInRoom"
 
-export default function Room({ roomId }: { roomId: string }): JSX.Element {
+export default function Room({
+	roomId,
+	myUsername,
+}: { roomId: string; myUsername: string }): JSX.Element {
 	const { socket } = React.useContext(RTR.RealtimeContext)
 
-	const myUsername = useO(myUsernameState)
 	const myRoomKey = useO(findRelations(usersInRooms, myUsername).roomKeyOfUser)
 	const setRoomState = useI(roomViewState)
-	console.log({ myUsername, myRoomKey, roomId })
 
 	const usersInRoomsInternal = getInternalRelations(usersInRooms)
 	RTR.usePullMutableAtomFamilyMember(usersInRoomsInternal, roomId)

--- a/apps/wayfarer.quest/src/app/page.tsx
+++ b/apps/wayfarer.quest/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useO } from "atom.io/react"
+import { myUsernameState } from "atom.io/realtime-client"
 import dynamic from "next/dynamic"
 import { roomViewState } from "wayfarer.quest/services/store/room-view-state"
 
@@ -29,9 +30,14 @@ const AtomIODevtools = dynamic(
 
 export default function SPA(): JSX.Element {
 	const roomView = useO(roomViewState)
+	const myUsername = useO(myUsernameState)
 	return (
 		<main className={scss.class}>
-			{roomView === null ? <Lobby /> : <Room roomId={roomView} />}
+			{roomView === null || myUsername === null ? (
+				<Lobby />
+			) : (
+				<Room roomId={roomView} myUsername={myUsername} />
+			)}
 			<AtomIODevtools />
 		</main>
 	)

--- a/apps/wayfarer.quest/src/services/store/my-room.ts
+++ b/apps/wayfarer.quest/src/services/store/my-room.ts
@@ -10,14 +10,14 @@ export const myRoomKeyState = AtomIO.selector<string | null>({
 	get: ({ get }) => {
 		const roomView = get(roomViewState)
 		const myUsername = get(myUsernameState)
-		const myRoom =
-			roomView && myUsername
-				? get(findRelations(usersInRooms, myUsername).roomKeyOfUser)?.includes(
-						myUsername,
-					)
-					? roomView
-					: null ?? null
-				: null
+		let myRoom: string | null = null
+		if (roomView && myUsername) {
+			const state = findRelations(usersInRooms, myUsername).roomKeyOfUser
+			const myRoomKey = get(state)
+			if (myRoomKey?.includes(myUsername)) {
+				myRoom = roomView
+			}
+		}
 		return myRoom
 	},
 })

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
@@ -1,13 +1,21 @@
 import { act, waitFor } from "@testing-library/react"
 import * as AtomIO from "atom.io"
+import { findRelations, findRelationsInStore, join } from "atom.io/data"
 import type { Store } from "atom.io/internal"
-import { actUponStore, arbitrary } from "atom.io/internal"
+import {
+	actUponStore,
+	arbitrary,
+	findInStore,
+	getFromStore,
+} from "atom.io/internal"
 import * as AR from "atom.io/react"
 import * as RT from "atom.io/realtime"
 import * as RTC from "atom.io/realtime-client"
 import * as RTR from "atom.io/realtime-react"
 import * as RTS from "atom.io/realtime-server"
 import * as RTTest from "atom.io/realtime-testing"
+import type { SetRTXJson } from "atom.io/transceivers/set-rtx"
+import { SetRTX } from "atom.io/transceivers/set-rtx"
 import * as React from "react"
 
 import { throwUntil } from "../../__util__/waiting"
@@ -26,32 +34,32 @@ function prefixLogger(store: Store, prefix: string) {
 	})
 }
 
-AtomIO.getState(RTC.myIdState)
-const countState = AtomIO.atom<number>({ key: `count`, default: 0 })
-const userActionCountServerState = AtomIO.atom<number>({
-	key: `server:userActionCount`,
-	default: 0,
-})
-
-const incrementTX = AtomIO.transaction({
-	key: `increment`,
-	do: ({ set, env }) => {
-		const { name } = env().store.config
-		if (name === `SERVER`) {
-			set(userActionCountServerState, (c) => c + 1)
-		}
-		set(countState, (c) => c + 1)
-	},
-})
-
-const countContinuity = RT.continuity({
-	key: `count`,
-	config: (group) => group.add(countState).add(incrementTX),
-})
+// AtomIO.getState(RTC.myIdState)
 
 describe(`synchronizing transactions`, () => {
-	const scenario = () =>
-		RTTest.multiClient({
+	const scenario = () => {
+		const countState = AtomIO.atom<number>({ key: `count`, default: 0 })
+		const userActionCountServerState = AtomIO.atom<number>({
+			key: `server:userActionCount`,
+			default: 0,
+		})
+
+		const incrementTX = AtomIO.transaction({
+			key: `increment`,
+			do: ({ set, env }) => {
+				const { name } = env().store.config
+				if (name === `SERVER`) {
+					set(userActionCountServerState, (c) => c + 1)
+				}
+				set(countState, (c) => c + 1)
+			},
+		})
+		const countContinuity = RT.continuity({
+			key: `count`,
+			config: (group) => group.add(countState).add(incrementTX),
+		})
+
+		return RTTest.multiClient({
 			port: 5465,
 			server: ({ socket, silo: { store } }) => {
 				// const userKeyState = findInStore(
@@ -126,7 +134,7 @@ describe(`synchronizing transactions`, () => {
 				},
 			},
 		})
-
+	}
 	test(`client 1 -> server -> client 2`, async () => {
 		const { clients, teardown } = scenario()
 
@@ -162,6 +170,106 @@ describe(`synchronizing transactions`, () => {
 
 		await waitFor(() => jane.renderResult.getByTestId(`2`))
 		await waitFor(() => dave.renderResult.getByTestId(`2`), { timeout: 7000 })
+		teardown()
+	})
+})
+
+describe(`mutable atoms in continuity`, () => {
+	const scenario = () => {
+		// const topicsOfSubjects = join({
+		// 	key: `topicsOfSubjects`,
+		// 	between: [`topic`, `subject`],
+		// 	cardinality: `1:n`,
+		// })
+
+		const myListAtom = AtomIO.atom<SetRTX<string>, SetRTXJson<string>>({
+			key: `myList`,
+			default: () => new SetRTX<string>(),
+			mutable: true,
+			toJson: (set) => set.toJSON(),
+			fromJson: (json) => SetRTX.fromJSON(json),
+		})
+
+		const addItemTX = AtomIO.transaction<(item: string) => void>({
+			key: `addItem`,
+			do: ({ get, set }, item) => {
+				const myList = get(myListAtom)
+				set(myListAtom, (list) => list.add(item))
+			},
+		})
+
+		const applicationContinuity = RT.continuity({
+			key: `application`,
+			config: (group) => group.add(myListAtom).add(addItemTX),
+		})
+
+		return Object.assign(
+			RTTest.singleClient({
+				port: 5475,
+				server: ({ socket, silo: { store } }) => {
+					const userKeyState = findRelationsInStore(
+						RTS.usersOfSockets,
+						socket.id,
+						store,
+					).userKeyOfSocket
+					const userKey = getFromStore(userKeyState, store)
+					prefixLogger(store, `server`)
+					socket.onAny((event, ...args) => {
+						console.log(`🛰 `, userKey, event, ...args)
+					})
+					socket.onAnyOutgoing((event, ...args) => {
+						console.log(`🛰  >>`, userKey, event, ...args)
+					})
+					const exposeContinuity = RTS.realtimeContinuitySynchronizer({
+						socket,
+						store,
+					})
+					exposeContinuity(applicationContinuity)
+				},
+				client: () => {
+					RTR.useSyncContinuity(applicationContinuity)
+					// RTR.usePullMutable(myListAtom)
+					const store = React.useContext(AR.StoreContext)
+					prefixLogger(store, `client`)
+					const { socket } = React.useContext(RTR.RealtimeContext)
+					socket?.onAny((event, ...args) => {
+						console.log(`📡 CLIENT`, event, ...args)
+					})
+					socket?.onAnyOutgoing((event, ...args) => {
+						console.log(`📡 CLIENT >>`, event, ...args)
+					})
+					const myList = AR.useJSON(myListAtom)
+
+					return (
+						<>
+							<button
+								type="button"
+								// onClick={() => {
+								// 	myList.add(`hello`)
+								// }}
+								data-testid={`add`}
+							/>
+							<span data-testid={`state`}>{myList.members.length}</span>
+						</>
+					)
+				},
+			}),
+			{ myListAtom, addItemTX },
+		)
+	}
+	test(`mutable initialization`, async () => {
+		const { client, server, teardown, myListAtom, addItemTX } = scenario()
+		const clientApp = client.init()
+		await waitFor(() => {
+			throwUntil(clientApp.socket.connected)
+		})
+		const clientState = clientApp.renderResult.getByTestId(`state`)
+		expect(clientState.textContent).toBe(`0`)
+		act(() => {
+			server.silo.runTransaction(addItemTX)(`hello`)
+		})
+		await waitFor(() => clientApp.renderResult.getByTestId(`state`).textContent)
+		expect(clientApp.renderResult.getByTestId(`state`).textContent).toBe(`1`)
 		teardown()
 	})
 })

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
@@ -1,16 +1,10 @@
 import { act, waitFor } from "@testing-library/react"
 import * as AtomIO from "atom.io"
-import { findRelations, findRelationsInStore, join } from "atom.io/data"
+import { findRelationsInStore } from "atom.io/data"
 import type { Store } from "atom.io/internal"
-import {
-	actUponStore,
-	arbitrary,
-	findInStore,
-	getFromStore,
-} from "atom.io/internal"
+import { actUponStore, arbitrary, getFromStore } from "atom.io/internal"
 import * as AR from "atom.io/react"
 import * as RT from "atom.io/realtime"
-import * as RTC from "atom.io/realtime-client"
 import * as RTR from "atom.io/realtime-react"
 import * as RTS from "atom.io/realtime-server"
 import * as RTTest from "atom.io/realtime-testing"

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
@@ -67,14 +67,6 @@ describe(`synchronizing transactions`, () => {
 					const count = AR.useO(countState)
 					const store = React.useContext(AR.StoreContext)
 					const increment = actUponStore(incrementTX, arbitrary(), store)
-					// prefixLogger(store, `dave`)
-					// const { socket } = React.useContext(RTR.RealtimeContext)
-					// socket?.onAny((event, ...args) => {
-					// 	console.log(`📡 DAVE`, event, ...args)
-					// })
-					// socket?.onAnyOutgoing((event, ...args) => {
-					// 	console.log(`📡 DAVE >>`, event, ...args)
-					// })
 					return (
 						<>
 							<button

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-mutable.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-mutable.test.tsx
@@ -27,12 +27,6 @@ describe(`running transactions`, () => {
 		RTTest.multiClient({
 			port: 5445,
 			server: ({ socket, silo: { store } }) => {
-				socket.onAny((event, ...args) => {
-					console.log(`🛰 `, event, ...args)
-				})
-				socket.onAnyOutgoing((event, ...args) => {
-					console.log(`🛰  >>`, event, ...args)
-				})
 				const exposeMutable = RTS.realtimeMutableProvider({ socket, store })
 				const receiveTransaction = RTS.realtimeActionReceiver({ socket, store })
 				exposeMutable(numbersCollectionState)
@@ -43,13 +37,6 @@ describe(`running transactions`, () => {
 					const addToNumbersCollection = RTR.useServerAction(
 						addToNumbersCollectionTX,
 					)
-					const { socket } = React.useContext(RTR.RealtimeContext)
-					socket?.onAny((event, ...args) => {
-						console.log(`📡  DAVE`, event, ...args)
-					})
-					socket?.onAnyOutgoing((event, ...args) => {
-						console.log(`📡  DAVE >>`, event, ...args)
-					})
 					return (
 						<button
 							type="button"
@@ -61,13 +48,6 @@ describe(`running transactions`, () => {
 				jane: () => {
 					RTR.usePullMutable(numbersCollectionState)
 					const numbers = AR.useJSON(numbersCollectionState)
-					const { socket } = React.useContext(RTR.RealtimeContext)
-					socket?.onAny((event, ...args) => {
-						console.log(`📡 JANE`, event, ...args)
-					})
-					socket?.onAnyOutgoing((event, ...args) => {
-						console.log(`📡 JANE >>`, event, ...args)
-					})
 					return (
 						<>
 							{numbers.members.map((n) => (

--- a/packages/atom.io/package.json
+++ b/packages/atom.io/package.json
@@ -36,6 +36,7 @@
 		"build:realtime-server": "cd realtime-server && tsup",
 		"build:realtime-testing": "cd realtime-testing && tsup",
 		"build:transceivers:set-rtx": "cd transceivers/set-rtx && tsup",
+		"build:web": "cd web && tsup",
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:eslint:build": "bun run build:main",
@@ -169,7 +170,10 @@
 		"realtime-testing/src",
 		"transceivers/set-rtx/dist",
 		"transceivers/set-rtx/package.json",
-		"transceivers/set-rtx/src"
+		"transceivers/set-rtx/src",
+		"web/dist",
+		"web/package.json",
+		"web/src"
 	],
 	"exports": {
 		"./package.json": "./package.json",
@@ -251,6 +255,11 @@
 		"./transceivers/set-rtx": {
 			"import": "./transceivers/set-rtx/dist/index.js",
 			"types": "./transceivers/set-rtx/dist/index.d.ts"
+		},
+		"./web/package.json": "./web/package.json",
+		"./web": {
+			"import": "./web/dist/index.js",
+			"types": "./web/dist/index.d.ts"
 		}
 	}
 }

--- a/packages/atom.io/react-devtools/src/StateEditor.tsx
+++ b/packages/atom.io/react-devtools/src/StateEditor.tsx
@@ -25,16 +25,17 @@ export const StateEditor: FC<{
 		<div className="json_editor">
 			<ElasticInput
 				value={
-					data !== null &&
-					typeof data === `object` &&
-					`toJson` in data &&
-					typeof data.toJson === `function`
-						? JSON.stringify(data.toJson())
-						: data instanceof Set
-							? `Set { ${JSON.stringify([...data]).slice(1, -1)} }`
-							: Object.getPrototypeOf(data).constructor.name +
-								` ` +
-								fallback(() => JSON.stringify(data), `?`)
+					data === undefined || data === null
+						? ``
+						: typeof data === `object` &&
+								`toJson` in data &&
+								typeof data.toJson === `function`
+							? JSON.stringify(data.toJson())
+							: data instanceof Set
+								? `Set { ${JSON.stringify([...data]).slice(1, -1)} }`
+								: Object.getPrototypeOf(data).constructor.name +
+									` ` +
+									fallback(() => JSON.stringify(data), `?`)
 				}
 				disabled={true}
 			/>

--- a/packages/atom.io/react-devtools/src/index.ts
+++ b/packages/atom.io/react-devtools/src/index.ts
@@ -1,2 +1,1 @@
 export * from "./AtomIODevtools"
-export * from "./lazy-local-storage-effect"

--- a/packages/atom.io/react-devtools/src/lazy-local-storage-effect.ts
+++ b/packages/atom.io/react-devtools/src/lazy-local-storage-effect.ts
@@ -22,7 +22,3 @@ export const persistAtom =
 			storage.setItem(key, stringify(newValue))
 		})
 	}
-
-export const lazyLocalStorageEffect: <J extends Json.Serializable>(
-	key: string,
-) => AtomEffect<J> = persistAtom(window.localStorage)(JSON)

--- a/packages/atom.io/react-devtools/src/store.ts
+++ b/packages/atom.io/react-devtools/src/store.ts
@@ -1,7 +1,7 @@
 import { atom, atomFamily } from "atom.io"
 import { attachIntrospectionStates } from "atom.io/introspection"
 
-import { lazyLocalStorageEffect } from "./lazy-local-storage-effect"
+import { persistAtom } from "./lazy-local-storage-effect"
 
 export const {
 	atomIndex,
@@ -16,7 +16,10 @@ export const {
 export const devtoolsAreOpenState = atom<boolean>({
 	key: `👁‍🗨 Devtools Are Open`,
 	default: true,
-	effects: [lazyLocalStorageEffect(`👁‍🗨 Devtools Are Open`)],
+	effects:
+		typeof window === `undefined`
+			? []
+			: [persistAtom(window.localStorage)(JSON)(`👁‍🗨 Devtools Are Open`)],
 })
 
 type DevtoolsView = `atoms` | `selectors` | `timelines` | `transactions`
@@ -24,17 +27,26 @@ type DevtoolsView = `atoms` | `selectors` | `timelines` | `transactions`
 export const devtoolsViewSelectionState = atom<DevtoolsView>({
 	key: `👁‍🗨 Devtools View Selection`,
 	default: `atoms`,
-	effects: [lazyLocalStorageEffect(`👁‍🗨 Devtools View`)],
+	effects:
+		typeof window === `undefined`
+			? []
+			: [persistAtom(window.localStorage)(JSON)(`👁‍🗨 Devtools View`)],
 })
 
 export const devtoolsViewOptionsState = atom<DevtoolsView[]>({
 	key: `👁‍🗨 Devtools View Options`,
 	default: [`atoms`, `selectors`, `transactions`, `timelines`],
-	effects: [lazyLocalStorageEffect(`👁‍🗨 Devtools View Options`)],
+	effects:
+		typeof window === `undefined`
+			? []
+			: [persistAtom(window.localStorage)(JSON)(`👁‍🗨 Devtools View Options`)],
 })
 
 export const viewIsOpenAtoms = atomFamily<boolean, string>({
 	key: `👁‍🗨 Devtools View Is Open`,
 	default: false,
-	effects: (key) => [lazyLocalStorageEffect(key + `:view-is-open`)],
+	effects: (key) =>
+		typeof window === `undefined`
+			? []
+			: [persistAtom(window.localStorage)(JSON)(key + `:view-is-open`)],
 })

--- a/packages/atom.io/react-devtools/src/store.ts
+++ b/packages/atom.io/react-devtools/src/store.ts
@@ -1,7 +1,6 @@
 import { atom, atomFamily } from "atom.io"
 import { attachIntrospectionStates } from "atom.io/introspection"
-
-import { persistAtom } from "./lazy-local-storage-effect"
+import { persistSync } from "atom.io/web"
 
 export const {
 	atomIndex,
@@ -19,7 +18,7 @@ export const devtoolsAreOpenState = atom<boolean>({
 	effects:
 		typeof window === `undefined`
 			? []
-			: [persistAtom(window.localStorage)(JSON)(`👁‍🗨 Devtools Are Open`)],
+			: [persistSync(window.localStorage)(JSON)(`👁‍🗨 Devtools Are Open`)],
 })
 
 type DevtoolsView = `atoms` | `selectors` | `timelines` | `transactions`
@@ -30,7 +29,7 @@ export const devtoolsViewSelectionState = atom<DevtoolsView>({
 	effects:
 		typeof window === `undefined`
 			? []
-			: [persistAtom(window.localStorage)(JSON)(`👁‍🗨 Devtools View`)],
+			: [persistSync(window.localStorage)(JSON)(`👁‍🗨 Devtools View`)],
 })
 
 export const devtoolsViewOptionsState = atom<DevtoolsView[]>({
@@ -39,7 +38,7 @@ export const devtoolsViewOptionsState = atom<DevtoolsView[]>({
 	effects:
 		typeof window === `undefined`
 			? []
-			: [persistAtom(window.localStorage)(JSON)(`👁‍🗨 Devtools View Options`)],
+			: [persistSync(window.localStorage)(JSON)(`👁‍🗨 Devtools View Options`)],
 })
 
 export const viewIsOpenAtoms = atomFamily<boolean, string>({
@@ -48,5 +47,5 @@ export const viewIsOpenAtoms = atomFamily<boolean, string>({
 	effects: (key) =>
 		typeof window === `undefined`
 			? []
-			: [persistAtom(window.localStorage)(JSON)(key + `:view-is-open`)],
+			: [persistSync(window.localStorage)(JSON)(key + `:view-is-open`)],
 })

--- a/packages/atom.io/realtime-client/src/realtime-client-stores/client-main-store.ts
+++ b/packages/atom.io/realtime-client/src/realtime-client-stores/client-main-store.ts
@@ -1,5 +1,5 @@
 import * as AtomIO from "atom.io"
-import { persistAtom } from "atom.io/react-devtools"
+import { persistSync } from "atom.io/web"
 
 export const myIdState__INTERNAL = AtomIO.atom<string | undefined>({
 	key: `mySocketId__INTERNAL`,
@@ -16,5 +16,5 @@ export const myUsernameState = AtomIO.atom<string | null>({
 	effects:
 		typeof window === `undefined`
 			? []
-			: [persistAtom(window.localStorage)(JSON)(`myUsername`)],
+			: [persistSync(window.localStorage)(JSON)(`myUsername`)],
 })

--- a/packages/atom.io/realtime-client/src/realtime-client-stores/client-main-store.ts
+++ b/packages/atom.io/realtime-client/src/realtime-client-stores/client-main-store.ts
@@ -1,6 +1,5 @@
 import * as AtomIO from "atom.io"
-
-import { lazyLocalStorageEffect } from "~/packages/atom.io/react-devtools/src/lazy-local-storage-effect"
+import { persistAtom } from "atom.io/react-devtools"
 
 export const myIdState__INTERNAL = AtomIO.atom<string | undefined>({
 	key: `mySocketId__INTERNAL`,
@@ -11,10 +10,11 @@ export const myIdState = AtomIO.selector<string | undefined>({
 	get: ({ get }) => get(myIdState__INTERNAL),
 })
 
-const usernameEffects =
-	typeof window === `undefined` ? [] : [lazyLocalStorageEffect(`myUsername`)]
 export const myUsernameState = AtomIO.atom<string | null>({
-	key: `myUsername`,
+	key: `myName`,
 	default: null,
-	effects: usernameEffects,
+	effects:
+		typeof window === `undefined`
+			? []
+			: [persistAtom(window.localStorage)(JSON)(`myUsername`)],
 })

--- a/packages/atom.io/realtime-client/src/sync-continuity.ts
+++ b/packages/atom.io/realtime-client/src/sync-continuity.ts
@@ -349,9 +349,9 @@ export function syncContinuity<F extends Func>(
 }
 
 function upsertState<T>(
+	store: Store,
 	token: AtomIO.WritableToken<T>,
 	value: T,
-	store: Store,
 ): void {
 	if (token.family) {
 		const family = store.families.get(token.family.key)
@@ -362,8 +362,8 @@ function upsertState<T>(
 			} else if (store.config.lifespan === `immortal`) {
 				throw new Error(`No molecule found for key "${token.family.subKey}"`)
 			}
-			initFamilyMemberInStore(family, parseJson(token.family.subKey), store)
+			initFamilyMemberInStore(store, family, parseJson(token.family.subKey))
 		}
 	}
-	setIntoStore(token, value, store)
+	setIntoStore(store, token, value)
 }

--- a/packages/atom.io/realtime-server/src/realtime-continuity-synchronizer.ts
+++ b/packages/atom.io/realtime-server/src/realtime-continuity-synchronizer.ts
@@ -5,6 +5,7 @@ import {
 	findInStore,
 	getFromStore,
 	getJsonToken,
+	getUpdateToken,
 	IMPLICIT,
 	isRootStore,
 	subscribeToState,
@@ -142,7 +143,8 @@ export function realtimeContinuitySynchronizer({
 			for (const atom of continuity.globals) {
 				const resourceToken =
 					atom.type === `mutable_atom` ? getJsonToken(store, atom) : atom
-				initialPayload.push(resourceToken, getFromStore(store, atom))
+				const resource = getFromStore(store, resourceToken)
+				initialPayload.push(resourceToken, resource)
 			}
 			for (const perspective of continuity.perspectives) {
 				const { viewAtoms, resourceAtoms } = perspective
@@ -176,7 +178,12 @@ export function realtimeContinuitySynchronizer({
 					(update) => {
 						try {
 							const visibleKeys = continuity.globals
-								.map((atom) => atom.key)
+								.map((atom) => {
+									if (atom.type === `atom`) {
+										return atom.key
+									}
+									return getUpdateToken(atom).key
+								})
 								.concat(
 									continuity.perspectives.flatMap((perspective) => {
 										const { viewAtoms } = perspective

--- a/packages/atom.io/realtime-testing/src/setup-realtime-test.tsx
+++ b/packages/atom.io/realtime-testing/src/setup-realtime-test.tsx
@@ -133,7 +133,7 @@ export const setupRealtimeTestServer = (
 				socket.id,
 				silo.store,
 			).userKeyOfSocket
-			const userKey = getFromStore(userKeyState, silo.store)
+			const userKey = getFromStore(silo.store, userKeyState)
 			prefixLogger(silo.store, `server`)
 			socket.onAny((event, ...args) => {
 				console.log(`🛰 `, userKey, event, ...args)

--- a/packages/atom.io/realtime-testing/src/setup-realtime-test.tsx
+++ b/packages/atom.io/realtime-testing/src/setup-realtime-test.tsx
@@ -3,7 +3,8 @@ import * as http from "node:http"
 import type { RenderResult } from "@testing-library/react"
 import { prettyDOM, render } from "@testing-library/react"
 import * as AtomIO from "atom.io"
-import { editRelationsInStore } from "atom.io/data"
+import { editRelationsInStore, findRelationsInStore } from "atom.io/data"
+import type { Store } from "atom.io/internal"
 import {
 	clearStore,
 	findInStore,
@@ -25,9 +26,27 @@ import { io } from "socket.io-client"
 
 let testNumber = 0
 
+function prefixLogger(store: Store, prefix: string) {
+	store.loggers[0] = new AtomIO.AtomIOLogger(`info`, undefined, {
+		info: (...args) => {
+			console.info(prefix, ...args)
+		},
+		warn: (...args) => {
+			console.warn(prefix, ...args)
+		},
+		error: (...args) => {
+			console.error(prefix, ...args)
+		},
+	})
+}
+
 export type TestSetupOptions = {
 	port: number
-	server: (tools: { socket: SocketIO.Socket; silo: AtomIO.Silo }) => void
+	server: (tools: {
+		socket: SocketIO.Socket
+		silo: AtomIO.Silo
+		enableLogging: () => void
+	}) => void
 }
 export type TestSetupOptions__SingleClient = TestSetupOptions & {
 	client: React.FC
@@ -46,6 +65,7 @@ export type RealtimeTestTools = {
 export type RealtimeTestClient = RealtimeTestTools & {
 	renderResult: RenderResult
 	prettyPrint: () => void
+	enableLogging: () => void
 	socket: ClientSocket
 }
 export type RealtimeTestClientBuilder = {
@@ -107,7 +127,22 @@ export const setupRealtimeTestServer = (
 	})
 
 	server.on(`connection`, (socket: SocketIO.Socket) => {
-		options.server({ socket, silo })
+		function enableLogging() {
+			const userKeyState = findRelationsInStore(
+				RTS.usersOfSockets,
+				socket.id,
+				silo.store,
+			).userKeyOfSocket
+			const userKey = getFromStore(userKeyState, silo.store)
+			prefixLogger(silo.store, `server`)
+			socket.onAny((event, ...args) => {
+				console.log(`🛰 `, userKey, event, ...args)
+			})
+			socket.onAnyOutgoing((event, ...args) => {
+				console.log(`🛰  >>`, userKey, event, ...args)
+			})
+		}
+		options.server({ socket, enableLogging, silo })
 	})
 
 	const dispose = () => {
@@ -165,6 +200,16 @@ export const setupRealtimeTestClient = (
 			console.log(prettyDOM(renderResult.container))
 		}
 
+		const enableLogging = () => {
+			prefixLogger(silo.store, name)
+			socket.onAny((event, ...args) => {
+				console.log(`📡 `, name, event, ...args)
+			})
+			socket.onAnyOutgoing((event, ...args) => {
+				console.log(`📡  >>`, name, event, ...args)
+			})
+		}
+
 		const dispose = () => {
 			renderResult.unmount()
 			socket.disconnect()
@@ -178,6 +223,7 @@ export const setupRealtimeTestClient = (
 			socket,
 			renderResult,
 			prettyPrint,
+			enableLogging,
 		}
 	}
 	return Object.assign(testClient, { init })

--- a/packages/atom.io/realtime-testing/src/setup-realtime-test.tsx
+++ b/packages/atom.io/realtime-testing/src/setup-realtime-test.tsx
@@ -76,6 +76,7 @@ export type RealtimeTestClientBuilder = {
 export type RealtimeTestServer = RealtimeTestTools & {
 	dispose: () => void
 	port: number
+	// enableLogging: () => void
 }
 
 export type RealtimeTestAPI = {
@@ -127,13 +128,14 @@ export const setupRealtimeTestServer = (
 	})
 
 	server.on(`connection`, (socket: SocketIO.Socket) => {
+		let userKey: string | null = null
 		function enableLogging() {
 			const userKeyState = findRelationsInStore(
 				RTS.usersOfSockets,
 				socket.id,
 				silo.store,
 			).userKeyOfSocket
-			const userKey = getFromStore(silo.store, userKeyState)
+			userKey = getFromStore(silo.store, userKeyState)
 			prefixLogger(silo.store, `server`)
 			socket.onAny((event, ...args) => {
 				console.log(`🛰 `, userKey, event, ...args)
@@ -143,6 +145,9 @@ export const setupRealtimeTestServer = (
 			})
 		}
 		options.server({ socket, enableLogging, silo })
+		socket.on(`disconnect`, () => {
+			console.log(`${userKey} disconnected`)
+		})
 	})
 
 	const dispose = () => {

--- a/packages/atom.io/src/silo.ts
+++ b/packages/atom.io/src/silo.ts
@@ -1,5 +1,7 @@
 import type { findState } from "atom.io/ephemeral"
 import {
+	actUponStore,
+	arbitrary,
 	createAtomFamily,
 	createMoleculeFamily,
 	createSelectorFamily,
@@ -30,7 +32,7 @@ import type {
 } from "."
 import type { atom, atomFamily } from "./atom"
 import type { selector, selectorFamily } from "./selector"
-import type { transaction } from "./transaction"
+import type { runTransaction, transaction } from "./transaction"
 
 export class Silo {
 	public store: Store
@@ -49,6 +51,7 @@ export class Silo {
 	public redo: typeof redo
 	public moleculeFamily: typeof moleculeFamily
 	public makeMolecule: typeof makeMolecule
+	public runTransaction: typeof runTransaction
 	public constructor(config: Store[`config`], fromStore: Store | null = null) {
 		const s = new Store(config, fromStore)
 		this.store = s
@@ -83,8 +86,9 @@ export class Silo {
 		this.moleculeFamily = ((options: Parameters<typeof moleculeFamily>[0]) => {
 			return createMoleculeFamily(s, options)
 		}) as typeof moleculeFamily
-		this.makeMolecule = ((...params: Parameters<typeof makeMolecule>) => {
+		this.makeMolecule = (...params: Parameters<typeof makeMolecule>) => {
 			return makeMoleculeInStore(s, ...params)
-		}) as typeof makeMolecule
+		}
+		this.runTransaction = (token, id = arbitrary()) => actUponStore(token, id, s)
 	}
 }

--- a/packages/atom.io/tsconfig.prod.json
+++ b/packages/atom.io/tsconfig.prod.json
@@ -56,7 +56,10 @@
 		"realtime-testing/src",
 		"transceivers/set-rtx/dist",
 		"transceivers/set-rtx/package.json",
-		"transceivers/set-rtx/src"
+		"transceivers/set-rtx/src",
+		"web/dist",
+		"web/package.json",
+		"web/src"
 	],
 	"exclude": ["src", "**/src"]
 }

--- a/packages/atom.io/tsup.config.ts
+++ b/packages/atom.io/tsup.config.ts
@@ -53,6 +53,7 @@ export const JS_OPTIONS: Options = {
 		"realtime-server/dist/index": `realtime-server/src/index.ts`,
 		"realtime-testing/dist/index": `realtime-testing/src/index.ts`,
 		"transceivers/set-rtx/dist/index": `transceivers/set-rtx/src/index.ts`,
+		"web/dist/index": `web/src/index.ts`,
 	},
 	outDir: `.`,
 }

--- a/packages/atom.io/web/package.json
+++ b/packages/atom.io/web/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "atom.io-web",
+	"type": "module",
+	"private": true,
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	}
+}

--- a/packages/atom.io/web/src/index.ts
+++ b/packages/atom.io/web/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./persist-sync"

--- a/packages/atom.io/web/src/persist-sync.ts
+++ b/packages/atom.io/web/src/persist-sync.ts
@@ -1,12 +1,11 @@
 import type { AtomEffect } from "atom.io"
-import type { Json } from "atom.io/json"
 
 export type StringInterface<T> = {
 	stringify: (t: T) => string
 	parse: (s: string) => T
 }
 
-export const persistAtom =
+export const persistSync =
 	<T>(storage: Storage) =>
 	({ stringify, parse }: StringInterface<T>) =>
 	(key: string): AtomEffect<T> =>

--- a/packages/atom.io/web/tsup.config.ts
+++ b/packages/atom.io/web/tsup.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "tsup"
+
+import { DTS_OPTIONS } from "~/packages/atom.io/tsup.config"
+
+export default defineConfig(DTS_OPTIONS)

--- a/packages/hamr/react-json-editor/src/default-components.tsx
+++ b/packages/hamr/react-json-editor/src/default-components.tsx
@@ -57,7 +57,9 @@ export const DEFAULT_JSON_EDITOR_COMPONENTS: JsonEditorComponents = {
 		</button>
 	),
 	EditorWrapper: ({ children, className }) => (
-		<div className={`json_editor` + ` ` + className}>{children}</div>
+		<div className={`json_editor` + (className ? ` ${className}` : ``)}>
+			{children}
+		</div>
 	),
 	EditorLayout: ({
 		DeleteButton,

--- a/packages/hamr/react-json-editor/src/editors-by-type/primitive-editors.tsx
+++ b/packages/hamr/react-json-editor/src/editors-by-type/primitive-editors.tsx
@@ -22,7 +22,7 @@ export const BooleanEditor = ({
 export const NullEditor = ({
 	Components,
 }: JsonEditorProps_INTERNAL<null>): ReactElement => (
-	<Components.NullWrapper>" "</Components.NullWrapper>
+	<Components.NullWrapper> </Components.NullWrapper>
 )
 
 export const NumberEditor = ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,79 +351,6 @@ importers:
         specifier: 5.5.4
         version: 5.5.4
 
-  apps/web/sample:
-    dependencies:
-      '@emotion/styled':
-        specifier: 11.13.0
-        version: 11.13.0(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1)
-      '@floating-ui/dom':
-        specifier: 1.6.10
-        version: 1.6.10
-      '@floating-ui/react':
-        specifier: 0.26.22
-        version: 0.26.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      corners:
-        specifier: 0.1.0
-        version: 0.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      fp-ts:
-        specifier: 2.16.9
-        version: 2.16.9
-      framer-motion:
-        specifier: 11.3.28
-        version: 11.3.28(@emotion/is-prop-valid@1.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      hamr:
-        specifier: workspace:*
-        version: link:../../../packages/hamr
-      io-ts:
-        specifier: 2.2.21
-        version: 2.2.21(fp-ts@2.16.9)
-      react:
-        specifier: 18.3.1
-        version: 18.3.1
-      react-dom:
-        specifier: 18.3.1
-        version: 18.3.1(react@18.3.1)
-      react-router-dom:
-        specifier: 6.26.1
-        version: 6.26.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      zod:
-        specifier: 3.23.8
-        version: 3.23.8
-    devDependencies:
-      '@testing-library/react':
-        specifier: 16.0.0
-        version: 16.0.0(@testing-library/dom@10.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/react':
-        specifier: 18.3.3
-        version: 18.3.3
-      '@vitejs/plugin-react':
-        specifier: 4.3.1
-        version: 4.3.1(vite@5.4.1(@types/node@20.16.1)(lightningcss@1.26.0)(sass@1.77.8)(terser@5.31.5))
-      cross-env:
-        specifier: 7.0.3
-        version: 7.0.3
-      eslint:
-        specifier: 9.9.0
-        version: 9.9.0(jiti@1.21.6)
-      happy-dom:
-        specifier: 14.12.3
-        version: 14.12.3
-      sass:
-        specifier: 1.77.8
-        version: 1.77.8
-      vite:
-        specifier: 5.4.1
-        version: 5.4.1(@types/node@20.16.1)(lightningcss@1.26.0)(sass@1.77.8)(terser@5.31.5)
-      vite-plugin-svgr:
-        specifier: 4.2.0
-        version: 4.2.0(rollup@4.20.0)(typescript@5.5.4)(vite@5.4.1(@types/node@20.16.1)(lightningcss@1.26.0)(sass@1.77.8)(terser@5.31.5))
-      vite-tsconfig-paths:
-        specifier: 5.0.1
-        version: 5.0.1(typescript@5.5.4)(vite@5.4.1(@types/node@20.16.1)(lightningcss@1.26.0)(sass@1.77.8)(terser@5.31.5))
-      vitest:
-        specifier: 2.0.5
-        version: 2.0.5(@types/node@20.16.1)(@vitest/ui@2.0.5)(happy-dom@14.12.3)(jsdom@24.1.1)(lightningcss@1.26.0)(sass@1.77.8)(terser@5.31.5)
-
   apps/web/shrine:
     dependencies:
       fp-ts:
@@ -11677,16 +11604,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@8.1.0(eslint@9.9.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint@9.9.0(jiti@1.21.6)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.1.0(eslint@9.9.0(jiti@1.21.6))(typescript@5.5.4)
-      eslint: 9.9.0(jiti@1.21.6)
-      eslint-import-resolver-node: 0.3.9
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-plugin-import-x@3.1.0(eslint@9.9.0(jiti@1.21.6))(typescript@5.5.4):
     dependencies:
       '@typescript-eslint/utils': 7.18.0(eslint@9.9.0(jiti@1.21.6))(typescript@5.5.4)
@@ -11714,7 +11631,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.9.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@8.1.0(eslint@9.9.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint@9.9.0(jiti@1.21.6))
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@9.9.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@9.9.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.9.0(jiti@1.21.6)))(eslint@9.9.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.0
       is-glob: 4.0.3


### PR DESCRIPTION
### **User description**
- **🚧**
- **✨ Silo.runTransaction**
- **🐛 handle mutable atoms better**
- **✅ test mutables in continuity**
- **🦋**


___

### **PR Type**
Enhancement, Bug fix, Tests, Configuration changes


___

### **Description**
- Added `exposeMutable` for `usersInRoomsAtoms` with `username`.
- Enhanced room component with username state and mutable atoms.
- Refactored `myRoomKeyState` selector logic for clarity.
- Added new test suite for mutable atoms in continuity.
- Improved handling of `undefined` and `null` data in `StateEditor`.
- Enhanced sync continuity with molecule and family member initialization.
- Improved initial payload handling in `realtimeContinuitySynchronizer`.
- Simplified `SyncGroup` class and `add` method logic.
- Added `runTransaction` method to `Silo` class.
- Fixed className handling in `EditorWrapper`.
- Fixed rendering of `NullEditor` component.
- Added changesets for new features and bug fixes.
- Added environment variables for development.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>system.server.ts</strong><dd><code>Expose mutable state for users in rooms.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/core.wayfarer.quest/src/system.server.ts

- Added `exposeMutable` for `usersInRoomsAtoms` with `username`.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2223/files#diff-6ec367858c982ba29a722c8bb86651414505a99e97dfb05d332a27d4ce3ecb24">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Room.tsx</strong><dd><code>Enhance room component with username state and mutable atoms.</code></dd></summary>
<hr>

apps/wayfarer.quest/src/app/Room.tsx

<li>Added <code>findState</code> and <code>myUsernameState</code> imports.<br> <li> Updated <code>myRoomKey</code> logic to use <code>findRelations</code>.<br> <li> Added <code>usePullMutableAtomFamilyMember</code> for <code>usersInRoomsInternal</code>.<br> <li> Updated button disable conditions and rendering logic.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2223/files#diff-3da64db6f6d61a90003ad559d41a216e2820abee387693fb9f470e86982ca302">+11/-8</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>my-room.ts</strong><dd><code>Refactor myRoomKeyState selector logic.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/wayfarer.quest/src/services/store/my-room.ts

- Refactored `myRoomKeyState` selector logic for clarity.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2223/files#diff-e1c334597bea2acbd94db025161ebfe6a3c373179584da658c2826482d61b866">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sync-continuity.ts</strong><dd><code>Enhance sync continuity with molecule and family member </code><br><code>initialization.</code></dd></summary>
<hr>

packages/atom.io/realtime-client/src/sync-continuity.ts

<li>Added <code>growMoleculeInStore</code> and <code>initFamilyMemberInStore</code> functions.<br> <li> Improved <code>initializeContinuity</code> and <code>reveal</code> event handling.<br> <li> Added <code>upsertState</code> function for state updates.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2223/files#diff-fe8f8fba41e3781bfd71d6a890bd07a6b8a1d79fceba2f83212715f92071e9d5">+28/-6</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>realtime-continuity-synchronizer.ts</strong><dd><code>Improve realtime continuity synchronizer initial payload and </code><br><code>transaction handling.</code></dd></summary>
<hr>

packages/atom.io/realtime-server/src/realtime-continuity-synchronizer.ts

<li>Improved initial payload handling in <code>realtimeContinuitySynchronizer</code>.<br> <li> Enhanced transaction subscription with visibility checks.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2223/files#diff-bfb1b12634f08ab8ca1e7001bfd724fa3c73ee30d7d8ccc4ea8a56035b6db666">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>realtime-continuity.ts</strong><dd><code>Simplify SyncGroup class and add method logic.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/realtime/src/realtime-continuity.ts

- Simplified `SyncGroup` class and `add` method logic.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2223/files#diff-e70533323503e2d08244f13189b2e9698dd8049f4dfb9a165f20dab8493697fe">+27/-33</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>silo.ts</strong><dd><code>Add runTransaction method to Silo class.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/silo.ts

- Added `runTransaction` method to `Silo` class.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2223/files#diff-1d80c9738cdb12feb9829201f08d0a4cc5daf4d3528fbca95e4cbaf7445689ac">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>realtime-continuity.test.tsx</strong><dd><code>Add tests for mutable atoms in continuity.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx

<li>Added new test suite for mutable atoms in continuity.<br> <li> Refactored existing test for synchronizing transactions.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2223/files#diff-4f1c176a31b9dff3ac3aea98ff0474ca2328dacd84a7821b215adbf33f198844">+133/-25</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>StateEditor.tsx</strong><dd><code>Improve StateEditor handling of undefined and null data.</code>&nbsp; </dd></summary>
<hr>

packages/atom.io/react-devtools/src/StateEditor.tsx

- Improved handling of `undefined` and `null` data in `StateEditor`.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2223/files#diff-dafe02d0d7e43f47e3e85e6897163198a77f511f788ed2557e108d42d70819e3">+11/-10</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>default-components.tsx</strong><dd><code>Fix className handling in EditorWrapper.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hamr/react-json-editor/src/default-components.tsx

- Fixed className handling in `EditorWrapper`.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2223/files#diff-3fb5e9ec5ea462befeb2afe2403bf6a8128230600faa4fd6fa0ca4c45b63debb">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>primitive-editors.tsx</strong><dd><code>Fix rendering of NullEditor component.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hamr/react-json-editor/src/editors-by-type/primitive-editors.tsx

- Fixed rendering of `NullEditor` component.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2223/files#diff-d0043f55c27bd0c80b4f339d3621ef6d0c155bdcec894fff0851f054859ef47a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>dry-news-dress.md</strong><dd><code>Add changeset for mutable atoms in realtime continuity.</code>&nbsp; &nbsp; </dd></summary>
<hr>

.changeset/dry-news-dress.md

<li>Added changeset for handling mutable atoms better in realtime <br>continuity.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2223/files#diff-f0e7f6db18ef60a8337ac0ff1bb6585ad106201bd973552ddf9a93929ac16590">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>long-dogs-wait.md</strong><dd><code>Add changeset for Silo runTransaction method.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/long-dogs-wait.md

- Added changeset for adding `runTransaction` method to `Silo`.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2223/files#diff-e5cdfadf9391aa0733d3bf76c10d4b648e023070d468a1503b8e7f6c15d68952">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>.env.dev</strong><dd><code>Add environment variables for development.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/core.wayfarer.quest/.env.dev

- Added environment variables for `PORT` and `CLIENT_ORIGINS`.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2223/files#diff-c7e5b95571551904ae8deaba0c6a142cd1a49df1bedec2dfbea8ab7e80c27504">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

