### PR TITLE
atom.io proper globals

### DIFF
--- a/.changeset/two-birds-brush.md
+++ b/.changeset/two-birds-brush.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 Fixed bug in AtomIO's core that would occur in situations where a package manager like pnpm installed multiple AtomIO instances for purposes of version safety/intercompatibility. This could lead to different `IMPLICIT.STORE`s being used on adjacent lines, and as a result, bizarre errors would be thrown. Resolved this by making the `IMPLICIT.STORE` discoverable on `globalThis.

--- a/packages/atom.io/__tests__/public/silo.test.ts
+++ b/packages/atom.io/__tests__/public/silo.test.ts
@@ -1,11 +1,11 @@
 import type { RegularAtomFamilyOptions, RegularAtomOptions } from "atom.io"
-import { disposeState, getState, Silo } from "atom.io"
-import { IMPLICIT } from "atom.io/internal"
+import { getState, Silo } from "atom.io"
 
-const hasImplicitStoreBeenCreated = () => IMPLICIT.STORE_INTERNAL !== undefined
+const hasImplicitStoreBeenCreated = () =>
+	globalThis.ATOM_IO_IMPLICIT_STORE !== undefined
 
 afterEach(() => {
-	IMPLICIT.STORE_INTERNAL = undefined
+	globalThis.ATOM_IO_IMPLICIT_STORE = undefined
 })
 
 describe(`silo`, () => {

--- a/packages/atom.io/internal/src/store/store.ts
+++ b/packages/atom.io/internal/src/store/store.ts
@@ -195,15 +195,14 @@ export class Store implements Lineage {
 }
 
 export const IMPLICIT = {
-	STORE_INTERNAL: undefined as Store | undefined,
 	get STORE(): Store {
-		return (
-			this.STORE_INTERNAL ??
-			(this.STORE_INTERNAL = new Store({
+		if (!globalThis.ATOM_IO_IMPLICIT_STORE) {
+			globalThis.ATOM_IO_IMPLICIT_STORE = new Store({
 				name: `IMPLICIT_STORE`,
 				lifespan: `ephemeral`,
-			}))
-		)
+			})
+		}
+		return globalThis.ATOM_IO_IMPLICIT_STORE as Store
 	},
 }
 


### PR DESCRIPTION
### **User description**
- **🐛 fix bug that could occur with multiple atom.io installs**
- **🦋**


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fixed a bug in AtomIO core where multiple instances installed by package managers could lead to different `IMPLICIT.STORE`s being used, causing errors.
- Updated `IMPLICIT.STORE` to be discoverable on `globalThis` to ensure consistency.
- Added a changeset note documenting the bug fix and the issue it resolves.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>store.ts</strong><dd><code>Fix bug with multiple AtomIO installs using globalThis</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/store/store.ts

<li>Removed <code>STORE_INTERNAL</code> property from <code>IMPLICIT</code>.<br> <li> Modified <code>STORE</code> getter to use <code>globalThis.ATOM_IO_IMPLICIT_STORE</code>.<br> <li> Ensured <code>IMPLICIT.STORE</code> is discoverable on <code>globalThis</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2293/files#diff-395c42a09ae60d4c7488f4b4fb8921f4bfe2eb1f0f805c8d2531bcb46e23a2a3">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>two-birds-brush.md</strong><dd><code>Document bug fix for multiple AtomIO installs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/two-birds-brush.md

<li>Added changeset note for the bug fix in AtomIO core.<br> <li> Described the issue with multiple AtomIO instances and the fix <br>applied.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2293/files#diff-23422eb91c5011f6cad0dbca7d4b1e03a890192ccbde8b606a41e0a740bb5e15">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

