### PR TITLE
atom.io register selector may find

### DIFF
--- a/.changeset/ninety-fans-tickle.md
+++ b/.changeset/ninety-fans-tickle.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 Fixed issue with the `get` function in `SelectorToolkit` where, if getting a state that's not present in an ephemeral store, the state would not be initialized but an error would be thrown instead.

--- a/.changeset/tame-maps-listen.md
+++ b/.changeset/tame-maps-listen.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+✨ `Silo` adds the `moleculeFamily` and `makeMolecule` methods.

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
@@ -161,7 +161,7 @@ describe(`synchronizing transactions`, () => {
 		})
 
 		await waitFor(() => jane.renderResult.getByTestId(`2`))
-		await waitFor(() => dave.renderResult.getByTestId(`2`), { timeout: 3000 })
+		await waitFor(() => dave.renderResult.getByTestId(`2`), { timeout: 7000 })
 		teardown()
 	})
 })

--- a/packages/atom.io/internal/src/selector/register-selector.ts
+++ b/packages/atom.io/internal/src/selector/register-selector.ts
@@ -46,9 +46,14 @@ export const registerSelector = (
 					return getFromStore(family, key, store)
 				default:
 					if (store.config.lifespan === `ephemeral`) {
-						dependency = findInStore(family, key, store) as any
+						dependency = findInStore(family, key, store)
 					} else {
-						dependency = seekInStore(family, key, store) as any
+						const maybeDependency = seekInStore(family, key, store)
+						if (maybeDependency) {
+							dependency = maybeDependency
+						} else {
+							throw new NotFoundError(family, key, store)
+						}
 					}
 			}
 		} else {

--- a/packages/atom.io/internal/src/selector/register-selector.ts
+++ b/packages/atom.io/internal/src/selector/register-selector.ts
@@ -45,7 +45,11 @@ export const registerSelector = (
 				case `molecule_family`:
 					return getFromStore(family, key, store)
 				default:
-					dependency = seekInStore(family, key, store) as any
+					if (store.config.lifespan === `ephemeral`) {
+						dependency = findInStore(family, key, store) as any
+					} else {
+						dependency = seekInStore(family, key, store) as any
+					}
 			}
 		} else {
 			;[dependency] = params

--- a/packages/atom.io/src/silo.ts
+++ b/packages/atom.io/src/silo.ts
@@ -2,6 +2,7 @@ import type { findState } from "atom.io/ephemeral"
 import type { Transceiver } from "atom.io/internal"
 import {
 	createAtomFamily,
+	createMoleculeFamily,
 	createSelectorFamily,
 	createStandaloneAtom,
 	createStandaloneSelector,
@@ -10,6 +11,7 @@ import {
 	disposeFromStore,
 	findInStore,
 	getFromStore,
+	makeMoleculeInStore,
 	setIntoStore,
 	Store,
 	timeTravel,
@@ -20,6 +22,8 @@ import type {
 	AtomToken,
 	disposeState,
 	getState,
+	makeMolecule,
+	moleculeFamily,
 	MutableAtomFamily,
 	MutableAtomFamilyOptions,
 	MutableAtomOptions,
@@ -53,6 +57,8 @@ export class Silo {
 	public subscribe: typeof subscribe
 	public undo: typeof undo
 	public redo: typeof redo
+	public moleculeFamily: typeof moleculeFamily
+	public makeMolecule: typeof makeMolecule
 	public constructor(config: Store[`config`], fromStore: Store | null = null) {
 		const s = new Store(config, fromStore)
 		function _atom<T>(options: RegularAtomOptions<T>): RegularAtomToken<T>
@@ -102,5 +108,11 @@ export class Silo {
 		this.redo = (token) => {
 			timeTravel(`redo`, token, s)
 		}
+		this.moleculeFamily = ((...params: Parameters<typeof moleculeFamily>) => {
+			return createMoleculeFamily(...params, s)
+		}) as any
+		this.makeMolecule = ((...params: Parameters<typeof makeMolecule>) => {
+			return makeMoleculeInStore(s, ...params)
+		}) as any
 	}
 }

--- a/turbo.json
+++ b/turbo.json
@@ -4,39 +4,31 @@
 		"build": {
 			"dependsOn": ["^build"],
 			"outputs": ["dist/**", "**/dist/*", "**/dist/**/*", "bin/**"],
-			"inputs": [
-				"**/package.json",
-				"src/**/*.{ts,tsx,scss,mdx}",
-				"**/src/**/*.{ts,tsx,scss,mdx}"
-			]
+			"inputs": ["**/package.json", "src/**", "**/src/**"]
 		},
 		"atom.io.fyi#build": {
 			"dependsOn": ["atom.io#build"],
 			"outputs": ["dist/**"],
-			"inputs": [
-				"**/package.json",
-				"src/**/*.{ts,tsx,scss,mdx}",
-				"**/src/**/*.{ts,tsx,scss,mdx}"
-			]
+			"inputs": ["**/package.json", "src/**"]
 		},
 		"test:once": {
 			"dependsOn": ["build"],
 			"inputs": [
 				"**/package.json",
-				"src/**/*.{ts,tsx,scss,mdx}",
-				"**/src/**/*.{ts,tsx,scss,mdx}",
-				"__tests__/**/*.{ts?x}",
-				"__scripts__/**/*.ts"
+				"src/**",
+				"**/src/**",
+				"__tests__/**",
+				"__scripts__/**"
 			]
 		},
 		"test:coverage": {
-			"outputs": ["coverage/**", "**/coverage/*", "**/coverage/**/*"],
+			"outputs": ["coverage/**", "**/coverage/**"],
 			"inputs": [
 				"**/package.json",
-				"src/**/*.{ts,tsx,scss,mdx}",
-				"**/src/**/*.{ts,tsx,scss,mdx}",
-				"__tests__/**/*.{ts,tsx}",
-				"__scripts__/**/*.ts"
+				"src/**/*",
+				"**/src/**",
+				"__tests__/**",
+				"__scripts__/**"
 			]
 		},
 		"test:semver": {
@@ -63,10 +55,10 @@
 			"inputs": [
 				"**/package.json",
 				"tsconfig.json",
-				"src/**/*.{ts,tsx}",
-				"**/src/**/*.{ts,tsx}",
-				"__tests__/**/*.{ts?x}",
-				"__scripts__/**/*.{ts?x}",
+				"src/**",
+				"**/src/**",
+				"__tests__/**",
+				"__scripts__/**",
 				"../../eslint.config.js"
 			]
 		},
@@ -75,10 +67,10 @@
 			"inputs": [
 				"**/package.json",
 				"tsconfig.json",
-				"src/**/*.{ts,tsx}",
-				"**/src/**/*.{ts,tsx}",
-				"__tests__/**/*.{ts?x}",
-				"__scripts__/**/*.{ts?x}"
+				"src/**",
+				"**/src/**",
+				"__tests__/**",
+				"__scripts__/**"
 			]
 		},
 		"lint": {
@@ -89,10 +81,10 @@
 			"inputs": [
 				"**/package.json",
 				"tsconfig.json",
-				"src/**/*.{ts,tsx}",
-				"**/src/**/*.{ts,tsx}",
-				"__tests__/**/*.{ts?x}",
-				"__scripts__/**/*.{ts?x}"
+				"src/**",
+				"**/src/**",
+				"__tests__/**",
+				"__scripts__/**"
 			]
 		},
 		"globalDependencies": {


### PR DESCRIPTION
### **User description**
- **🐛 fix bug where a SelectorToolkit's get function could throw in ephemeral store on a nonexistent state**
- **♻️ improve error in immortal stores for now**
- **🦋**


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed a bug where the `get` function in `SelectorToolkit` could throw an error in an ephemeral store when the state was nonexistent.
- Improved error handling in `registerSelector` by adding a `NotFoundError` for missing dependencies in non-ephemeral stores.
- Updated the changeset to document the bug fix.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>register-selector.ts</strong><dd><code>Improve error handling for selector registration in stores</code></dd></summary>
<hr>

packages/atom.io/internal/src/selector/register-selector.ts

<li>Added conditional logic to handle ephemeral store lifespan.<br> <li> Introduced <code>NotFoundError</code> for missing dependencies in non-ephemeral <br>stores.<br> <li> Modified <code>registerSelector</code> to differentiate between <code>findInStore</code> and <br><code>seekInStore</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2311/files#diff-613871cd6ba651c13a86c399ea124efccbe8c472497ff20a6226c7e8fd9222e6">+10/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ninety-fans-tickle.md</strong><dd><code>Document bug fix for SelectorToolkit's get function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/ninety-fans-tickle.md

<li>Added a changeset entry describing the bug fix for <code>SelectorToolkit</code>'s <br><code>get</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2311/files#diff-6e833eb651508ab852610f4cd6e9ae05860f0c966ccf25abbf5c00fdb3a96456">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

