### PR TITLE
atom.io/no more calling families

### DIFF
--- a/.changeset/lemon-islands-train.md
+++ b/.changeset/lemon-islands-train.md
@@ -1,0 +1,5 @@
+---
+"atom.io": minor
+---
+
+💥 Calling an `atomFamily` or `selectorFamily` directly, a feature previously marked deprecated, now gives a TypeScript error.

--- a/apps/atom.io.fyi/package.json
+++ b/apps/atom.io.fyi/package.json
@@ -15,6 +15,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "echo no tests yet",
 		"test:coverage": "echo no test coverage yet",

--- a/apps/atom.io.fyi/src/app/docs/page.mdx
+++ b/apps/atom.io.fyi/src/app/docs/page.mdx
@@ -175,7 +175,7 @@ Keen readers may recognize that collections generally extend `Object`, and that 
 
 ## transaction
 
-import CallAFamilyInATransaction from "x/core/transaction/call-a-family-in-a-transaction.gen"
+import CallAFamilyInATransaction from "x/core/transaction/use-a-family-in-a-transaction.gen"
 import IterateThroughAnIndexChangingTheValueOfSomeAtoms from "x/core/transaction/iterate-through-an-index-changing-the-value-of-some-atoms.gen"
 import TryCatchAFailedTransaction from "x/core/transaction/try-catch-a-failed-transaction.gen"
 
@@ -183,7 +183,7 @@ Transactions allow you to batch multiple atom changes into a single update. This
 
 <CallAFamilyInATransaction />
 
-A common use case is creating some new state using a family function and adding it to an index tracking members of that family.
+A common use case is creating some new state using a family and adding it to an index tracking members of that family.
 
 <IterateThroughAnIndexChangingTheValueOfSomeAtoms />
 

--- a/apps/atom.io.fyi/src/exhibits/core/families/declare-a-family.tsx
+++ b/apps/atom.io.fyi/src/exhibits/core/families/declare-a-family.tsx
@@ -2,18 +2,16 @@ import type { RegularAtomToken } from "atom.io"
 import { atomFamily, getState } from "atom.io"
 import { useO } from "atom.io/react"
 
-export const findXState = atomFamily<number, string>({
+export const xAtoms = atomFamily<number, string>({
 	key: `x`,
 	default: 0,
 })
-export const findYState = atomFamily<number, string>({
+export const yAtoms = atomFamily<number, string>({
 	key: `y`,
 	default: 0,
 })
 
-const exampleXState = findXState(`example`)
-
-getState(exampleXState) // -> 0
+getState(xAtoms, `example`) // -> 0
 
 export function Point(props: {
 	xState: RegularAtomToken<number>

--- a/apps/atom.io.fyi/src/exhibits/core/families/use-an-index-to-track-family-members.tsx
+++ b/apps/atom.io.fyi/src/exhibits/core/families/use-an-index-to-track-family-members.tsx
@@ -1,7 +1,9 @@
 import { atom } from "atom.io"
 import { useO } from "atom.io/react"
 
-import { findXState, findYState, Point } from "./declare-a-family"
+import { findState } from "~/packages/atom.io/ephemeral/src"
+
+import { Point, xAtoms, yAtoms } from "./declare-a-family"
 
 export const pointIndex = atom<string[]>({
 	key: `pointIndex`,
@@ -13,9 +15,9 @@ export function AllPoints(): JSX.Element {
 	return (
 		<>
 			{pointIds.map((pointId) => {
-				const xState = findXState(pointId)
-				const yState = findYState(pointId)
-				return <Point key={pointId} xState={xState} yState={yState} />
+				const xAtom = findState(xAtoms, pointId)
+				const yAtom = findState(yAtoms, pointId)
+				return <Point key={pointId} xState={xAtom} yState={yAtom} />
 			})}
 		</>
 	)

--- a/apps/atom.io.fyi/src/exhibits/core/timeline/create-a-timeline.ts
+++ b/apps/atom.io.fyi/src/exhibits/core/timeline/create-a-timeline.ts
@@ -1,8 +1,8 @@
 import { timeline } from "atom.io"
 
-import { findXState, findYState } from "../families/declare-a-family"
+import { xAtoms, yAtoms } from "../families/declare-a-family"
 
 export const coordinatesTL = timeline({
 	key: `timeline`,
-	scope: [findXState, findYState],
+	scope: [xAtoms, yAtoms],
 })

--- a/apps/atom.io.fyi/src/exhibits/core/timeline/subscribe-to-a-timeline.ts
+++ b/apps/atom.io.fyi/src/exhibits/core/timeline/subscribe-to-a-timeline.ts
@@ -1,13 +1,13 @@
 import { setState, subscribe } from "atom.io"
 
-import { findXState } from "../families/declare-a-family"
+import { xAtoms } from "../families/declare-a-family"
 import { coordinatesTL } from "./create-a-timeline"
 
 subscribe(coordinatesTL, (value) => {
 	console.log(value)
 })
 
-setState(findXState(`sample_key`), 1)
+setState(xAtoms, `sample_key`, 1)
 /* {
   newValue: 1,
   oldValue: 0,

--- a/apps/atom.io.fyi/src/exhibits/core/timeline/undo-and-redo-changes.ts
+++ b/apps/atom.io.fyi/src/exhibits/core/timeline/undo-and-redo-changes.ts
@@ -1,17 +1,17 @@
 import { getState, redo, setState, subscribe, undo } from "atom.io"
 
-import { findXState } from "../families/declare-a-family"
+import { xAtoms } from "../families/declare-a-family"
 import { coordinatesTL } from "./create-a-timeline"
 
 subscribe(coordinatesTL, (value) => {
 	console.log(value)
 })
 
-setState(findXState(`sample_key`), 1)
-getState(findXState(`sample_key`)) // 1
-setState(findXState(`sample_key`), 2)
-getState(findXState(`sample_key`)) // 2
+setState(xAtoms, `sample_key`, 1)
+getState(xAtoms, `sample_key`) // 1
+setState(xAtoms, `sample_key`, 2)
+getState(xAtoms, `sample_key`) // 2
 undo(coordinatesTL)
-getState(findXState(`sample_key`)) // 1
+getState(xAtoms, `sample_key`) // 1
 redo(coordinatesTL)
-getState(findXState(`sample_key`)) // 2
+getState(xAtoms, `sample_key`) // 2

--- a/apps/atom.io.fyi/src/exhibits/core/transaction/iterate-through-an-index-changing-the-value-of-some-atoms.ts
+++ b/apps/atom.io.fyi/src/exhibits/core/transaction/iterate-through-an-index-changing-the-value-of-some-atoms.ts
@@ -34,8 +34,8 @@ const findTimerRemainingState = selectorFamily<number, string>({
 		(id) =>
 		({ get }) => {
 			const now = get(nowState)
-			const started = get(findTimerStartedState(id))
-			const length = get(findTimerLengthState(id))
+			const started = get(findTimerStartedState, id)
+			const length = get(findTimerLengthState, id)
 			return Math.max(0, length - (now - started))
 		},
 })
@@ -45,8 +45,8 @@ export const addOneMinuteToAllRunningTimersTX = transaction({
 	do: ({ get, set }) => {
 		const timerIds = get(timerIndex)
 		for (const timerId of timerIds) {
-			if (get(findTimerRemainingState(timerId)) > 0) {
-				set(findTimerLengthState(timerId), (current) => current + 60_000)
+			if (get(findTimerRemainingState, timerId) > 0) {
+				set(findTimerLengthState, timerId, (current) => current + 60_000)
 			}
 		}
 	},

--- a/apps/atom.io.fyi/src/exhibits/core/transaction/use-a-family-in-a-transaction.ts
+++ b/apps/atom.io.fyi/src/exhibits/core/transaction/use-a-family-in-a-transaction.ts
@@ -5,7 +5,7 @@ export type PublicUser = {
 	displayName: string
 }
 
-export const findPublicUserState = atomFamily<PublicUser, string>({
+export const publicUserAtoms = atomFamily<PublicUser, string>({
 	key: `publicUser`,
 	default: (id) => ({ id, displayName: `` }),
 })
@@ -18,8 +18,7 @@ export const userIndex = atom<string[]>({
 export const addUserTX = transaction<(user: PublicUser) => void>({
 	key: `addUser`,
 	do: ({ get, set }, user) => {
-		const userState = findPublicUserState(user.id)
-		set(userState, user)
+		set(publicUserAtoms, user.id, user)
 		if (!get(userIndex).includes(user.id)) {
 			set(userIndex, (current) => [...current, user.id])
 		}

--- a/apps/core.wayfarer.quest/package.json
+++ b/apps/core.wayfarer.quest/package.json
@@ -13,6 +13,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types"
 	},
 	"dependencies": {

--- a/apps/core.wayfarer.quest/src/store/game/transactions/spawn-trick.ts
+++ b/apps/core.wayfarer.quest/src/store/game/transactions/spawn-trick.ts
@@ -8,7 +8,7 @@ export const spawnTrickTX = transaction<
 	key: `spawnTrick`,
 	do: (transactors, gameId, trickId) => {
 		const { set, find } = transactors
-		set(CardGroups.trickStates(trickId), {
+		set(CardGroups.trickStates, trickId, {
 			type: `trick`,
 			name: ``,
 		})

--- a/apps/node/forge/package.json
+++ b/apps/node/forge/package.json
@@ -11,6 +11,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types"
 	},
 	"dependencies": {

--- a/apps/node/kite/package.json
+++ b/apps/node/kite/package.json
@@ -12,6 +12,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types"
 	},
 	"dependencies": {

--- a/apps/tempest.games/package.json
+++ b/apps/tempest.games/package.json
@@ -17,6 +17,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "bun run gen && eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"deploy": "fastly compute publish"
 	},

--- a/apps/wayfarer.quest/package.json
+++ b/apps/wayfarer.quest/package.json
@@ -13,6 +13,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "echo no tests yet",
 		"test:coverage": "echo no test coverage yet",

--- a/apps/wayfarer.quest/src/game/other-players/TheirHands.tsx
+++ b/apps/wayfarer.quest/src/game/other-players/TheirHands.tsx
@@ -1,15 +1,12 @@
 import { useO } from "atom.io/react"
-import { usePullMutableAtomFamilyMember } from "atom.io/realtime-react"
 import * as React from "react"
-import { findHandsOfPlayer } from "wayfarer.quest/services/store/player-hand"
-
-import { ownersOfGroups } from "~/apps/core.wayfarer.quest/src/store/game"
+import { handsOfPlayerSelectors } from "wayfarer.quest/services/store/player-hand"
 
 import { Hand } from "../game-pieces/Hand"
 import scss from "./TheirHands.module.scss"
 
 export const TheirHands: React.FC<{ playerId: string }> = ({ playerId }) => {
-	const theirHands = useO(findHandsOfPlayer(playerId))
+	const theirHands = useO(handsOfPlayerSelectors, playerId)
 
 	return (
 		<div className={scss.class}>

--- a/apps/wayfarer.quest/src/services/peripherals/mouse-position.ts
+++ b/apps/wayfarer.quest/src/services/peripherals/mouse-position.ts
@@ -2,7 +2,7 @@ import * as AtomIO from "atom.io"
 import type { Point2d } from "corners"
 import * as React from "react"
 
-import { findScrollPositionState } from "./scroll-position"
+import { scrollPositionAtoms } from "./scroll-position"
 
 let lastEmitTime = 0
 const throttleTime = 50 // milliseconds
@@ -29,20 +29,18 @@ export const windowMousePositionState = AtomIO.atom<Point2d>({
 	],
 })
 
-export const findMousePositionState = AtomIO.atomFamily<Point2d, string>({
+export const mousePositionAtoms = AtomIO.atomFamily<Point2d, string>({
 	key: `mousePosition`,
 	default: { x: 0, y: 0 },
 })
 
-export const findOffsetMouseSelector = AtomIO.selectorFamily<Point2d, string[]>({
+export const offsetMouseSelectors = AtomIO.selectorFamily<Point2d, string[]>({
 	key: `offsetMouse`,
 	get:
 		([mousePosKey, ...scrollPosKeys]) =>
 		({ get }) => {
-			const mousePosition = get(findMousePositionState(mousePosKey))
-			const offsets = scrollPosKeys.map((key) =>
-				get(findScrollPositionState(key)),
-			)
+			const mousePosition = get(mousePositionAtoms, mousePosKey)
+			const offsets = scrollPosKeys.map((key) => get(scrollPositionAtoms, key))
 			const totalOffset = offsets.reduce((tally, offset) => ({
 				x: tally.x + offset.x,
 				y: tally.y + offset.y,
@@ -66,7 +64,7 @@ export const useMousePosition = <T extends HTMLElement>(
 			}
 			debounceTimer.current = window.setTimeout(() => {
 				const pos: Point2d = { x: event.clientX, y: event.clientY }
-				AtomIO.setState(findMousePositionState(key), pos)
+				AtomIO.setState(mousePositionAtoms, key, pos)
 			}, 100) // debounce time
 		}
 

--- a/apps/wayfarer.quest/src/services/peripherals/scroll-position.ts
+++ b/apps/wayfarer.quest/src/services/peripherals/scroll-position.ts
@@ -28,7 +28,7 @@ export const windowScrollPositionState = AtomIO.atom<Point2d>({
 	],
 })
 
-export const findScrollPositionState = AtomIO.atomFamily<Point2d, string>({
+export const scrollPositionAtoms = AtomIO.atomFamily<Point2d, string>({
 	key: `scrollPosition`,
 	default: { x: 0, y: 0 },
 })
@@ -49,8 +49,10 @@ export const useScrollPosition = <T extends HTMLElement>(
 				if (now - lastEmitTime > throttleTime) {
 					emitTimes.set(key, now)
 					const { scrollLeft, scrollTop } = capturedRef.current
-					const scrollPositionState = findScrollPositionState(key)
-					AtomIO.setState(scrollPositionState, { x: scrollLeft, y: scrollTop })
+					AtomIO.setState(scrollPositionAtoms, key, {
+						x: scrollLeft,
+						y: scrollTop,
+					})
 				}
 			}
 

--- a/apps/wayfarer.quest/src/services/store/player-hand.ts
+++ b/apps/wayfarer.quest/src/services/store/player-hand.ts
@@ -3,8 +3,8 @@ import { findRelations } from "atom.io/data"
 
 import { ownersOfGroups } from "~/apps/core.wayfarer.quest/src/store/game"
 
-export const findHandsOfPlayer = selectorFamily<string[], string>({
-	key: `findHandsOfPlayer`,
+export const handsOfPlayerSelectors = selectorFamily<string[], string>({
+	key: `handsOfPlayer`,
 	get:
 		(playerId) =>
 		({ get }) =>

--- a/apps/web/strand/package.json
+++ b/apps/web/strand/package.json
@@ -12,6 +12,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"lint:eslint": "turbo run lint:eslint",
 		"lint:eslint:build": "turbo run lint:eslint:build",
 		"lint:types": "turbo run lint:types",
+		"lint:types:watch": "turbo run lint:types:watch --concurrency=20",
 		"lint:fix:biome": "biome check --write *",
 		"lint:fix:eslint": "eslint --fix .",
 		"fmt": "biome format .",
@@ -42,9 +43,7 @@
 		"notes": "changeset",
 		"nuke": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' + && rm pnpm-lock.yaml"
 	},
-	"trustedDependencies": [
-		"@biomejs/biome"
-	],
+	"trustedDependencies": ["@biomejs/biome"],
 	"devDependencies": {
 		"@biomejs/biome": "1.8.3",
 		"@changesets/cli": "2.27.7",

--- a/packages/anvl/package.json
+++ b/packages/anvl/package.json
@@ -25,6 +25,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "vitest",
 		"test:coverage": "echo no test coverage yet",

--- a/packages/atom.io/__tests__/experimental/realtime-ipc/game-store.ts
+++ b/packages/atom.io/__tests__/experimental/realtime-ipc/game-store.ts
@@ -1,5 +1,6 @@
 import type { RegularAtomToken } from "atom.io"
 import { atomFamily } from "atom.io"
+import { findState } from "atom.io/ephemeral"
 import { continuity } from "atom.io/realtime"
 
 export const letterAtoms = atomFamily<string | null, number>({
@@ -9,7 +10,7 @@ export const letterAtoms = atomFamily<string | null, number>({
 export const letterIndex = atomFamily<RegularAtomToken<string | null>[], string>(
 	{
 		key: `letterIndex`,
-		default: Array.from({ length: 5 }).map((_, i) => letterAtoms(i)),
+		default: Array.from({ length: 5 }).map((_, i) => findState(letterAtoms, i)),
 	},
 )
 

--- a/packages/atom.io/__tests__/private/async-data.test.ts
+++ b/packages/atom.io/__tests__/private/async-data.test.ts
@@ -136,13 +136,13 @@ describe(`complex async setup`, () => {
 			AtomIO.setState(letterIndex, Object.keys(letters))
 			AtomIO.setState(statusIndex, Object.keys(statuses))
 			for (const [key, value] of Object.entries(counts)) {
-				AtomIO.setState(findCountState(key), value)
+				AtomIO.setState(findCountState, key, value)
 			}
 			for (const [key, value] of Object.entries(letters)) {
-				AtomIO.setState(findLetterState(key), value)
+				AtomIO.setState(findLetterState, key, value)
 			}
 			for (const [key, value] of Object.entries(statuses)) {
-				AtomIO.setState(findStatusState(key), value)
+				AtomIO.setState(findStatusState, key, value)
 			}
 		})
 		const designDeltaState = AtomIO.selector<Loadable<Partial<Design>>>({
@@ -174,8 +174,8 @@ describe(`complex async setup`, () => {
 
 		const designDelta = await AtomIO.getState(designDeltaState)
 		expect(designDelta).toEqual({ id: DESIGN_ID })
-		AtomIO.setState(findCountState(`foo`), 4)
-		AtomIO.setState(findCountState(`bar`), 13)
+		AtomIO.setState(findCountState, `foo`, 4)
+		AtomIO.setState(findCountState, `bar`, 13)
 		const designDelta2 = await AtomIO.getState(designDeltaState)
 		expect(designDelta2).toEqual({
 			id: DESIGN_ID,

--- a/packages/atom.io/__tests__/private/grace.test.ts
+++ b/packages/atom.io/__tests__/private/grace.test.ts
@@ -170,7 +170,7 @@ describe(`recipes`, () => {
 			const ftl = (
 				key: string,
 			): [state: RegularAtomToken<number>, timeline: TimelineToken<any>] => {
-				const WritableToken = f(key)
+				const WritableToken = findState(f, key)
 				const timelineToken = timeline({
 					key: `timeline for ${WritableToken.key}`,
 					scope: [WritableToken],

--- a/packages/atom.io/__tests__/public/data/dict.test.ts
+++ b/packages/atom.io/__tests__/public/data/dict.test.ts
@@ -22,7 +22,7 @@ describe(`dict`, () => {
 		})
 		const userDict = dict(findUserState, userIndex)
 		setState(userIndex, [`1`, `2`, `3`])
-		setState(findUserState(`1`), { name: `Bob`, age: 42, email: `` })
+		setState(findUserState, `1`, { name: `Bob`, age: 42, email: `` })
 		const users = getState(userDict)
 		expect(users).toEqual({
 			"1": { name: `Bob`, age: 42, email: `` },

--- a/packages/atom.io/package.json
+++ b/packages/atom.io/package.json
@@ -40,6 +40,7 @@
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:eslint:build": "bun run build:main",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "vitest",
 		"test:coverage": "vitest run --coverage",

--- a/packages/atom.io/src/atom.ts
+++ b/packages/atom.io/src/atom.ts
@@ -75,17 +75,6 @@ export type RegularAtomFamilyToken<T, K extends Json.Serializable> = {
 	__K?: K
 }
 // biome-ignore format: intersection
-export type RegularAtomFamilyTokenWithCall<
-	T,
-	K extends Json.Serializable,
-> = 
-	& RegularAtomFamilyToken<T, K>
-	& {
-		/** @deprecated In ephemeral stores, prefer the `findState`, `findInStore`, or `find` functions. In immortal stores, prefer the `seekState`, `seekInStore`, or `seek` functions. */
-		/* eslint-disable-next-line @typescript-eslint/prefer-function-type */
-		(key: K): RegularAtomToken<T>
-	}
-// biome-ignore format: intersection
 export type RegularAtomFamily<T, K extends Json.Serializable> = 
 	& RegularAtomFamilyToken<T, K>
 	& {
@@ -120,18 +109,6 @@ export type MutableAtomFamilyToken<
 	__K?: K
 }
 // biome-ignore format: intersection
-export type MutableAtomFamilyTokenWithCall<
-	T extends Transceiver<any>,
-	J extends Json.Serializable,
-	K extends Json.Serializable,
-> = 
-	& MutableAtomFamilyToken<T, J, K>
-	& {
-		/** @deprecated In ephemeral stores, prefer the `findState`, `findInStore`, or `find` functions. In immortal stores, prefer the `seekState`, `seekInStore`, or `seek` functions. */
-		/* eslint-disable-next-line @typescript-eslint/prefer-function-type */	
-		(key: K): MutableAtomToken<T, J>
-	}
-// biome-ignore format: intersection
 export type MutableAtomFamily<
 	T extends Transceiver<any>,
 	J extends Json.Serializable,
@@ -156,18 +133,14 @@ export function atomFamily<
 	T extends Transceiver<any>,
 	J extends Json.Serializable,
 	K extends Json.Serializable,
->(
-	options: MutableAtomFamilyOptions<T, J, K>,
-): MutableAtomFamilyTokenWithCall<T, J, K>
+>(options: MutableAtomFamilyOptions<T, J, K>): MutableAtomFamilyToken<T, J, K>
 export function atomFamily<T, K extends Json.Serializable>(
 	options: RegularAtomFamilyOptions<T, K>,
-): RegularAtomFamilyTokenWithCall<T, K>
+): RegularAtomFamilyToken<T, K>
 export function atomFamily<T, K extends Json.Serializable>(
 	options:
 		| MutableAtomFamilyOptions<any, any, any>
 		| RegularAtomFamilyOptions<T, K>,
-):
-	| MutableAtomFamilyTokenWithCall<any, any, any>
-	| RegularAtomFamilyTokenWithCall<T, K> {
+): MutableAtomFamilyToken<any, any, any> | RegularAtomFamilyToken<T, K> {
 	return createAtomFamily(options, IMPLICIT.STORE)
 }

--- a/packages/atom.io/src/selector.ts
+++ b/packages/atom.io/src/selector.ts
@@ -47,17 +47,7 @@ export type WritableSelectorFamilyToken<T, K extends Json.Serializable> = {
 	__T?: T
 	__K?: K
 }
-// biome-ignore format: intersection
-export type WritableSelectorFamilyTokenWithCall<
-	T,
-	K extends Json.Serializable,
-> = 
-	& WritableSelectorFamilyToken<T, K>
-	& {
-		/** @deprecated In ephemeral stores, prefer the `findState`, `findInStore`, or `find` functions. In immortal stores, prefer the `seekState`, `seekInStore`, or `seek` functions. */
-		/* eslint-disable-next-line @typescript-eslint/prefer-function-type */
-		(key: K): WritableSelectorToken<T>
-	}
+
 // biome-ignore format: intersection
 export type WritableSelectorFamily<T, K extends Json.Serializable> = 
 	& WritableSelectorFamilyToken<T, K> 
@@ -73,17 +63,7 @@ export type ReadonlySelectorFamilyToken<T, K extends Json.Serializable> = {
 	__T?: T
 	__K?: K
 }
-// biome-ignore format: intersection
-export type ReadonlySelectorFamilyTokenWithCall<
-	T,
-	K extends Json.Serializable,
-> = 
-	& ReadonlySelectorFamilyToken<T, K>
-	& {
-		/** @deprecated In ephemeral stores, prefer the `findState`, `findInStore`, or `find` functions. In immortal stores, prefer the `seekState`, `seekInStore`, or `seek` functions. */
-		/* eslint-disable-next-line @typescript-eslint/prefer-function-type */
-		(key: K): ReadonlySelectorToken<T>
-	}
+
 // biome-ignore format: intersection
 export type ReadonlySelectorFamily<T, K extends Json.Serializable> = 
 	& ((key: K) => ReadonlySelectorToken<T>)
@@ -105,16 +85,14 @@ export type SelectorFamilyToken<T, K extends Json.Serializable> =
 
 export function selectorFamily<T, K extends Json.Serializable>(
 	options: WritableSelectorFamilyOptions<T, K>,
-): WritableSelectorFamilyTokenWithCall<T, K>
+): WritableSelectorFamilyToken<T, K>
 export function selectorFamily<T, K extends Json.Serializable>(
 	options: ReadonlySelectorFamilyOptions<T, K>,
-): ReadonlySelectorFamilyTokenWithCall<T, K>
+): ReadonlySelectorFamilyToken<T, K>
 export function selectorFamily<T, K extends Json.Serializable>(
 	options:
 		| ReadonlySelectorFamilyOptions<T, K>
 		| WritableSelectorFamilyOptions<T, K>,
-):
-	| ReadonlySelectorFamilyTokenWithCall<T, K>
-	| WritableSelectorFamilyTokenWithCall<T, K> {
+): ReadonlySelectorFamilyToken<T, K> | WritableSelectorFamilyToken<T, K> {
 	return createSelectorFamily(options, IMPLICIT.STORE)
 }

--- a/packages/break-check/package.json
+++ b/packages/break-check/package.json
@@ -31,7 +31,8 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
-		"lint": "bun run lint:biome && bun run lint:eslint",
+		"lint:types:watch": "tsc --watch --noEmit",
+		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "bun test --watch -- **/*.test.ts",
 		"test:once": "bun test -- **/*.test.ts",
 		"test:coverage": "echo no test coverage yet"

--- a/packages/comline/package.json
+++ b/packages/comline/package.json
@@ -24,6 +24,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "vitest",
 		"test:once": "vitest run",

--- a/packages/hamr/package.json
+++ b/packages/hamr/package.json
@@ -33,6 +33,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "vitest",
 		"test:coverage": "echo no test coverage yet",

--- a/packages/ingt/package.json
+++ b/packages/ingt/package.json
@@ -11,6 +11,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "vitest",
 		"test:coverage": "echo no test coverage yet",

--- a/packages/luum/package.json
+++ b/packages/luum/package.json
@@ -11,6 +11,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "vitest",
 		"test:coverage": "echo no test coverage yet",

--- a/packages/occlusion/package.json
+++ b/packages/occlusion/package.json
@@ -11,6 +11,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "vitest",
 		"test:coverage": "echo no test coverage yet",

--- a/packages/rel8/package.json
+++ b/packages/rel8/package.json
@@ -30,6 +30,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "vitest",
 		"test:coverage": "echo no test coverage yet",

--- a/packages/socket-io.filestore/package.json
+++ b/packages/socket-io.filestore/package.json
@@ -9,6 +9,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "vitest",
 		"test:coverage": "echo no test coverage yet",

--- a/packages/socket-io.git/package.json
+++ b/packages/socket-io.git/package.json
@@ -9,6 +9,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "vitest",
 		"test:coverage": "echo no test coverage yet",

--- a/packages/tsdoc.json/package.json
+++ b/packages/tsdoc.json/package.json
@@ -38,7 +38,8 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
-		"lint": "bun run lint:biome && bun run lint:eslint",
+		"lint:types:watch": "tsc --watch --noEmit",
+		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "bun test --watch -- **/*.test.ts",
 		"test:once": "bun test -- **/*.test.ts",
 		"test:coverage": "echo no test coverage yet"

--- a/packages/varmint/package.json
+++ b/packages/varmint/package.json
@@ -21,6 +21,7 @@
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",
 		"lint:types": "tsc --noEmit",
+		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "vitest",
 		"test:once": "vitest run",

--- a/turbo.json
+++ b/turbo.json
@@ -73,6 +73,18 @@
 				"__scripts__/**"
 			]
 		},
+		"lint:types:watch": {
+			"persistent": true,
+			"dependsOn": ["gen"],
+			"inputs": [
+				"**/package.json",
+				"tsconfig.json",
+				"src/**",
+				"**/src/**",
+				"__tests__/**",
+				"__scripts__/**"
+			]
+		},
 		"lint": {
 			"dependsOn": ["lint:biome", "lint:eslint", "lint:types"]
 		},


### PR DESCRIPTION
### **User description**
- **🏷️ atom/selectorFamily do not return function type**
- **🦋**


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Updated various test files to use the `findState` function instead of direct function calls.
- Removed deprecated `RegularAtomFamilyTokenWithCall`, `MutableAtomFamilyTokenWithCall`, `WritableSelectorFamilyTokenWithCall`, and `ReadonlySelectorFamilyTokenWithCall` types.
- Updated `atomFamily` and `selectorFamily` function signatures to remove deprecated types.
- Added a changeset note indicating that calling `atomFamily` or `selectorFamily` directly now results in a TypeScript error.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>game-store.ts</strong><dd><code>Update `letterIndex` to use `findState` function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/experimental/realtime-ipc/game-store.ts

<li>Imported <code>findState</code> from <code>atom.io/ephemeral</code>.<br> <li> Updated <code>letterIndex</code> to use <code>findState</code> instead of direct function call.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2383/files#diff-6177f840254c0f6bfeea6f352c1e95828e7ae19409c2fa4ac8d52aeff0db1180">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>atom.ts</strong><dd><code>Remove deprecated <code>RegularAtomFamilyTokenWithCall</code> and <br><code>MutableAtomFamilyTokenWithCall</code> types</code></dd></summary>
<hr>

packages/atom.io/src/atom.ts

<li>Removed deprecated <code>RegularAtomFamilyTokenWithCall</code> and <br><code>MutableAtomFamilyTokenWithCall</code> types.<br> <li> Updated <code>atomFamily</code> function signatures to remove deprecated types.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2383/files#diff-1b18eaa66e66bd13d179fb4e02295c11376b9d25b3be22812b2d6e1993e46f16">+3/-30</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>selector.ts</strong><dd><code>Remove deprecated <code>WritableSelectorFamilyTokenWithCall</code> and <br><code>ReadonlySelectorFamilyTokenWithCall</code> types</code></dd></summary>
<hr>

packages/atom.io/src/selector.ts

<li>Removed deprecated <code>WritableSelectorFamilyTokenWithCall</code> and <br><code>ReadonlySelectorFamilyTokenWithCall</code> types.<br> <li> Updated <code>selectorFamily</code> function signatures to remove deprecated types.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2383/files#diff-5a6b3bc499ec325f1fdea52698e73b551742a2d4f748332d27475c171f815e47">+5/-27</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>async-data.test.ts</strong><dd><code>Refactor `AtomIO.setState` calls to use `findState`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/private/async-data.test.ts

<li>Modified <code>AtomIO.setState</code> calls to use <code>findState</code> functions with <br>separate key and value parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2383/files#diff-b29932023d2ca6f7e4dcb801a6946c6d11465f155ae363650fad8998cb1eddd0">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>grace.test.ts</strong><dd><code>Use `findState` in `ftl` function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/private/grace.test.ts

<li>Updated <code>ftl</code> function to use <code>findState</code> instead of direct function call.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2383/files#diff-704681e68b526dd6ec35340de49c6e296c5f461e7ad23fc3c7bb75e249506176">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dict.test.ts</strong><dd><code>Refactor `setState` call to use `findState`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/public/data/dict.test.ts

<li>Modified <code>setState</code> call to use <code>findState</code> with separate key and value <br>parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2383/files#diff-8ddadf98add9004c7674eaddc17e34f749b4b2958745630f2914e54dfe1a1450">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lemon-islands-train.md</strong><dd><code>Document TypeScript error for direct <code>atomFamily</code> or <code>selectorFamily</code> <br>calls</code></dd></summary>
<hr>

.changeset/lemon-islands-train.md

<li>Added changeset note indicating that calling <code>atomFamily</code> or <br><code>selectorFamily</code> directly now results in a TypeScript error.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2383/files#diff-e05ecd7ea2ee477609518846c5a0b12a6c1ba2b5ff736d56f68b5c54477d3e89">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

