### PR TITLE
atom.io/eslint plugin synchronous selector dependencies ternaries

### DIFF
--- a/.changeset/curly-hounds-sell.md
+++ b/.changeset/curly-hounds-sell.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 `atom.io/eslint-plugin` previously wouldn't catch cases of a selector calling its `get` toolkit function after an `await`, if that `get` was nested in a ternary. Now, it will catch these cases.

--- a/packages/atom.io/__tests__/public/eslint-plugin/synchronous-selector-dependencies.test.ts
+++ b/packages/atom.io/__tests__/public/eslint-plugin/synchronous-selector-dependencies.test.ts
@@ -314,8 +314,8 @@ ruleTester.run(`synchronous-selector-dependencies (selectorFamily)`, rule, {
         const mySelector = selector<number>({
           key: "mySelector",
           get: async ({ get }) => {
-            const record = await get(myRecordState)
-            const result = record.foo ? await get(myRecordState).foo : 0
+            const record = await someAsyncFunction()
+            const result = record.foo ? get(myRecordState).foo : 0
             return result
           },
         })

--- a/packages/atom.io/__tests__/public/eslint-plugin/synchronous-selector-dependencies.test.ts
+++ b/packages/atom.io/__tests__/public/eslint-plugin/synchronous-selector-dependencies.test.ts
@@ -304,5 +304,23 @@ ruleTester.run(`synchronous-selector-dependencies (selectorFamily)`, rule, {
       `,
 			errors: 1,
 		},
+		{
+			name: `get in a ternary expression after an await`,
+			code: `
+        const myRecordState = atom<Record<string, number>>({
+          key: "myRecordState",
+          default: {},
+        })
+        const mySelector = selector<number>({
+          key: "mySelector",
+          get: async ({ get }) => {
+            const record = await get(myRecordState)
+            const result = record.foo ? await get(myRecordState).foo : 0
+            return result
+          },
+        })
+      `,
+			errors: 1,
+		},
 	],
 })

--- a/packages/atom.io/eslint-plugin/src/rules/synchronous-selector-dependencies.ts
+++ b/packages/atom.io/eslint-plugin/src/rules/synchronous-selector-dependencies.ts
@@ -77,7 +77,7 @@ export const synchronousSelectorDependencies = {
 					let awaited: number | undefined
 					let awaitNode: ESTree.AwaitExpression | undefined
 					walk(selectorComputation, (n, depth) => {
-						// console.log(`${`\t`.repeat(depth)}${n.type} ${n.name ?? ``}`)
+						console.log(`${`\t`.repeat(depth)}${n.type} ${n.name ?? ``}`)
 						if (typeof awaited === `number`) {
 							if (awaited > depth) {
 								awaited = undefined

--- a/packages/atom.io/eslint-plugin/src/rules/synchronous-selector-dependencies.ts
+++ b/packages/atom.io/eslint-plugin/src/rules/synchronous-selector-dependencies.ts
@@ -77,7 +77,7 @@ export const synchronousSelectorDependencies = {
 					let awaited: number | undefined
 					let awaitNode: ESTree.AwaitExpression | undefined
 					walk(selectorComputation, (n, depth) => {
-						console.log(`${`\t`.repeat(depth)}${n.type} ${n.name ?? ``}`)
+						// console.log(`${`\t`.repeat(depth)}${n.type} ${n.name ?? ``}`)
 						if (typeof awaited === `number`) {
 							if (awaited > depth) {
 								awaited = undefined

--- a/packages/atom.io/eslint-plugin/src/walk.ts
+++ b/packages/atom.io/eslint-plugin/src/walk.ts
@@ -8,6 +8,9 @@ export function walk(
 	callback(node, depth)
 
 	switch (node.type) {
+		case `AwaitExpression`:
+			walk(node.argument, callback, depth + 1)
+			break
 		case `FunctionDeclaration`:
 		case `FunctionExpression`:
 		case `ArrowFunctionExpression`:
@@ -58,6 +61,11 @@ export function walk(
 		case `BinaryExpression`:
 			walk(node.left, callback, depth)
 			walk(node.right, callback, depth)
+			break
+		case `ConditionalExpression`:
+			walk(node.test, callback, depth + 1)
+			walk(node.consequent, callback, depth + 1)
+			walk(node.alternate, callback, depth + 1)
 			break
 		case `MemberExpression`:
 			walk(node.object, callback, depth)


### PR DESCRIPTION
### **User description**
- **❌**
- **✅ traverse ternaries**
- **🦋**


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Added a new test case to cover ternary expressions after an await in `synchronous-selector-dependencies.test.ts`.
- Enhanced the `walk` function to handle `AwaitExpression` and `ConditionalExpression`.
- Uncommented a console log statement for debugging in `synchronous-selector-dependencies.ts`.
- Documented the bug fix in `.changeset/curly-hounds-sell.md`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>synchronous-selector-dependencies.test.ts</strong><dd><code>Add test case for ternary expressions after await</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/public/eslint-plugin/synchronous-selector-dependencies.test.ts

<li>Added a new test case to cover ternary expressions after an await.<br> <li> Ensured the test case checks for errors.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2399/files#diff-b8846cf3ed3bddcc2109972627cccaa27151d7d7b82ebb6de1d1af234f666001">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>synchronous-selector-dependencies.ts</strong><dd><code>Uncomment console log for debugging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/eslint-plugin/src/rules/synchronous-selector-dependencies.ts

- Uncommented a console log statement for debugging.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2399/files#diff-83b86d338b9300cfc605d326b63f5cc4742d5896dcc821645a1140505a838e8d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>walk.ts</strong><dd><code>Enhance walk function to handle Await and Conditional expressions</code></dd></summary>
<hr>

packages/atom.io/eslint-plugin/src/walk.ts

<li>Added handling for <code>AwaitExpression</code> in the walk function.<br> <li> Added handling for <code>ConditionalExpression</code> in the walk function.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2399/files#diff-5bdd14379a0ae7ae5cc18413c8808319eb0ab06459879c2c388c14c08f37da7e">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>curly-hounds-sell.md</strong><dd><code>Document bug fix for ternary expressions after await</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/curly-hounds-sell.md

<li>Documented the bug fix for handling selectors calling <code>get</code> after an <br><code>await</code> within a ternary.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2399/files#diff-fb15d80950115fbc9a40e15228875a360b9a50b6a44d8c99233d8fdbce19756e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

