### PR TITLE
atom.io defaults

### DIFF
--- a/.changeset/fuzzy-moles-smoke.md
+++ b/.changeset/fuzzy-moles-smoke.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+✨ `atom.io/immortal` No longer throws when a state can't be found.

--- a/packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
+++ b/packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
@@ -86,18 +86,47 @@ describe(`immortal mode`, () => {
 			default: 0,
 		})
 
-		expect(() => getState(countStates, `nonexistent`)).toThrowError(
-			`Atom Family "count" member "nonexistent" not found in store "IMPLICIT_STORE".`,
+		expect(getState(countStates, `nonexistent`)).toBe(0)
+		expect(logger.error).toHaveBeenLastCalledWith(
+			`❗`,
+			`atom_family`,
+			`count`,
+			`tried to get member`,
+			`"nonexistent"`,
+			`but it was not found in store`,
+			`IMPLICIT_STORE`,
 		)
-		expect(() => {
-			setState(countStates, `nonexistent`, 1)
-		}).toThrowError(
-			`Atom Family "count" member "nonexistent" not found in store "IMPLICIT_STORE".`,
+		setState(countStates, `nonexistent`, 1)
+		expect(logger.error).toHaveBeenLastCalledWith(
+			`❗`,
+			`atom_family`,
+			`count`,
+			`tried to set member`,
+			`"nonexistent"`,
+			`to`,
+			1,
+			`but it was not found in store`,
+			`IMPLICIT_STORE`,
 		)
-		expect(() => {
-			disposeState(countStates, `nonexistent`)
-		}).toThrowError(
-			`Atom Family "count" member "nonexistent" not found in store "IMPLICIT_STORE".`,
+		expect(getState(countStates, `nonexistent`)).toBe(0)
+		expect(logger.error).toHaveBeenLastCalledWith(
+			`❗`,
+			`atom_family`,
+			`count`,
+			`tried to get member`,
+			`"nonexistent"`,
+			`but it was not found in store`,
+			`IMPLICIT_STORE`,
+		)
+		disposeState(countStates, `nonexistent`)
+		expect(logger.error).toHaveBeenLastCalledWith(
+			`❗`,
+			`atom_family`,
+			`count`,
+			`tried to dispose of member`,
+			`"nonexistent"`,
+			`but it was not found in store`,
+			`IMPLICIT_STORE`,
 		)
 
 		const counterMolecules = moleculeFamily({
@@ -116,10 +145,15 @@ describe(`immortal mode`, () => {
 		expect(() => getState(counterMolecules, `nonexistent`)).toThrowError(
 			`Molecule Family "counter" member "nonexistent" not found in store "IMPLICIT_STORE".`,
 		)
-		expect(() => {
-			disposeState(counterMolecules, `nonexistent`)
-		}).toThrowError(
-			`Molecule Family "counter" member "nonexistent" not found in store "IMPLICIT_STORE".`,
+		disposeState(counterMolecules, `nonexistent`)
+		expect(logger.error).toHaveBeenLastCalledWith(
+			`❗`,
+			`molecule_family`,
+			`counter`,
+			`tried to dispose of member`,
+			`"nonexistent"`,
+			`but it was not found in store`,
+			`IMPLICIT_STORE`,
 		)
 
 		const root = makeRootMolecule(`root`)

--- a/packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
+++ b/packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
@@ -6,6 +6,7 @@ import {
 	makeMolecule,
 	makeRootMolecule,
 	moleculeFamily,
+	selectorFamily,
 	setState,
 } from "atom.io"
 import { editRelations, findRelations, getJoin, join } from "atom.io/data"
@@ -123,6 +124,75 @@ describe(`immortal mode`, () => {
 			`❗`,
 			`atom_family`,
 			`count`,
+			`tried to dispose of member`,
+			`"nonexistent"`,
+			`but it was not found in store`,
+			`IMPLICIT_STORE`,
+		)
+
+		const doubleStates = selectorFamily<number, string>({
+			key: `double`,
+			get:
+				(key) =>
+				({ get }) =>
+					get(countStates, key) * 2,
+			set:
+				(key) =>
+				({ set }, newValue) => {
+					set(countStates, key, newValue / 2)
+				},
+		})
+
+		expect(getState(doubleStates, `nonexistent`)).toBe(0)
+		expect(logger.error).toHaveBeenCalledWith(
+			`❗`,
+			`selector_family`,
+			`double`,
+			`tried to get member`,
+			`"nonexistent"`,
+			`but it was not found in store`,
+			`IMPLICIT_STORE`,
+		)
+		disposeState(doubleStates, `nonexistent`)
+		expect(logger.error).toHaveBeenLastCalledWith(
+			`❗`,
+			`selector_family`,
+			`double`,
+			`tried to dispose of member`,
+			`"nonexistent"`,
+			`but it was not found in store`,
+			`IMPLICIT_STORE`,
+		)
+
+		const factorialStates = selectorFamily<number, string>({
+			key: `factorial`,
+			get:
+				(key) =>
+				({ get }) => {
+					const count = get(countStates, key)
+					let factorial = 1
+					for (let i = 1; i <= count; i++) {
+						factorial *= i
+					}
+					return factorial
+				},
+		})
+
+		expect(getState(factorialStates, `nonexistent`)).toBe(1)
+		expect(logger.error).toHaveBeenCalledWith(
+			`❗`,
+			`readonly_selector_family`,
+			`factorial`,
+			`tried to get member`,
+			`"nonexistent"`,
+			`but it was not found in store`,
+			`IMPLICIT_STORE`,
+		)
+		disposeState(factorialStates, `nonexistent`)
+		expect(logger.error).toHaveBeenLastCalledWith(
+			`❗`,
+			`readonly_selector_family`,
+			`factorial`,
 			`tried to dispose of member`,
 			`"nonexistent"`,
 			`but it was not found in store`,

--- a/packages/atom.io/internal/src/families/create-regular-atom-family.ts
+++ b/packages/atom.io/internal/src/families/create-regular-atom-family.ts
@@ -61,5 +61,6 @@ export function createRegularAtomFamily<T, K extends Canonical>(
 	}) satisfies RegularAtomFamily<T, K>
 
 	store.families.set(options.key, atomFamily)
+	store.defaults.set(options.key, options.default)
 	return familyToken
 }

--- a/packages/atom.io/internal/src/families/create-writable-selector-family.ts
+++ b/packages/atom.io/internal/src/families/create-writable-selector-family.ts
@@ -6,10 +6,18 @@ import type {
 	WritableSelectorFamilyToken,
 	WritableSelectorToken,
 } from "atom.io"
+import type { findState } from "atom.io/ephemeral"
+import type { seekState } from "atom.io/immortal"
 import type { Canonical } from "atom.io/json"
 import { stringifyJson } from "atom.io/json"
 
-import type { WritableSelectorFamily } from ".."
+import {
+	findInStore,
+	getFromStore,
+	getJsonToken,
+	seekInStore,
+	type WritableSelectorFamily,
+} from ".."
 import { newest } from "../lineage"
 import { createWritableSelector } from "../selector"
 import type { Store } from "../store"
@@ -54,9 +62,18 @@ export function createWritableSelectorFamily<T, K extends Canonical>(
 	}
 
 	const selectorFamily = Object.assign(familyFunction, familyToken, {
+		internalRoles,
 		subject,
 		install: (s: Store) => createWritableSelectorFamily(options, s),
-		internalRoles,
+		default: (key: K) => {
+			const getFn = options.get(key)
+			return getFn({
+				get: (token) => getFromStore(token, store),
+				find: ((token, k) => findInStore(token, k, store)) as typeof findState,
+				seek: ((token, k) => seekInStore(token, k, store)) as typeof seekState,
+				json: (token) => getJsonToken(token, store),
+			})
+		},
 	}) satisfies WritableSelectorFamily<T, K>
 
 	store.families.set(options.key, selectorFamily)

--- a/packages/atom.io/internal/src/families/create-writable-selector-family.ts
+++ b/packages/atom.io/internal/src/families/create-writable-selector-family.ts
@@ -68,7 +68,7 @@ export function createWritableSelectorFamily<T, K extends Canonical>(
 		default: (key: K) => {
 			const getFn = options.get(key)
 			return getFn({
-				get: (token) => getFromStore(token, store),
+				get: (...params: [any]) => getFromStore(...params, store), // TODO: make store zero-arg
 				find: ((token, k) => findInStore(token, k, store)) as typeof findState,
 				seek: ((token, k) => seekInStore(token, k, store)) as typeof seekState,
 				json: (token) => getJsonToken(token, store),

--- a/packages/atom.io/internal/src/families/dispose-from-store.ts
+++ b/packages/atom.io/internal/src/families/dispose-from-store.ts
@@ -6,7 +6,7 @@ import type {
 	ReadableFamilyToken,
 	ReadableToken,
 } from "atom.io"
-import type { Canonical } from "atom.io/json"
+import { type Canonical, stringifyJson } from "atom.io/json"
 
 import { disposeAtom } from "../atom"
 import { disposeMolecule } from "../molecule/dispose-molecule"
@@ -55,7 +55,16 @@ export function disposeFromStore(
 					? seekInStore(family, key, store)
 					: findInStore(family, key, store)
 		if (!maybeToken) {
-			throw new NotFoundError(family, key, store)
+			store.logger.error(
+				`❗`,
+				family.type,
+				family.key,
+				`tried to dispose of member`,
+				stringifyJson(key),
+				`but it was not found in store`,
+				store.config.name,
+			)
+			return
 		}
 		token = maybeToken
 	}

--- a/packages/atom.io/internal/src/families/seek-in-store.ts
+++ b/packages/atom.io/internal/src/families/seek-in-store.ts
@@ -109,9 +109,6 @@ export function seekInStore(
 			break
 		case `molecule_family`:
 			state = target.molecules.get(stringifyJson(key))
-			if (state) {
-				return deposit(state)
-			}
 	}
 	if (state) {
 		return deposit(state)

--- a/packages/atom.io/internal/src/get-state/read-or-compute-value.ts
+++ b/packages/atom.io/internal/src/get-state/read-or-compute-value.ts
@@ -10,7 +10,7 @@ export const readOrComputeValue = <T>(
 		target.logger.info(`📖`, state.type, state.key, `reading cached value`)
 		return readCachedValue(state, target)
 	}
-	if (state.type !== `atom` && state.type !== `mutable_atom`) {
+	if (state.type === `selector` || state.type === `readonly_selector`) {
 		target.logger.info(`🧮`, state.type, state.key, `computing value`)
 		return state.get()
 	}

--- a/packages/atom.io/internal/src/index.ts
+++ b/packages/atom.io/internal/src/index.ts
@@ -3,6 +3,7 @@ import type {
 	FamilyMetadata,
 	MutableAtomFamilyToken,
 	MutableAtomToken,
+	ReadonlySelectorFamilyToken,
 	ReadonlySelectorToken,
 	RegularAtomFamilyToken,
 	RegularAtomToken,
@@ -113,8 +114,9 @@ export type AtomFamily<T, K extends Canonical = Canonical> =
 // biome-ignore format: intersection
 export type WritableSelectorFamily<T, K extends Canonical> = 
 	& WritableSelectorFamilyToken<T, K> 
+	& ((key: K) => WritableSelectorToken<T>)
 	& {
-		(key: K): WritableSelectorToken<T>
+		default: (key: K) => T,
 		subject: Subject<StateCreation<WritableSelectorToken<T>> | StateDisposal<WritableSelectorToken<T>>>
 		install: (store: Store) => void
 		internalRoles : string[] | undefined
@@ -122,10 +124,10 @@ export type WritableSelectorFamily<T, K extends Canonical> =
 
 // biome-ignore format: intersection
 export type ReadonlySelectorFamily<T, K extends Canonical> = 
+	& ReadonlySelectorFamilyToken<T, K>
 	& ((key: K) => ReadonlySelectorToken<T>)
 	& {
-		key: string
-		type: `readonly_selector_family`
+		default: (key: K) => T,
 		subject: Subject<StateCreation<ReadonlySelectorToken<T>> | StateDisposal<ReadonlySelectorToken<T>>>
 		install: (store: Store) => void
 		internalRoles : string[] | undefined

--- a/packages/atom.io/internal/src/selector/create-writable-selector.ts
+++ b/packages/atom.io/internal/src/selector/create-writable-selector.ts
@@ -22,12 +22,12 @@ export const createWritableSelector = <T>(
 	const target = newest(store)
 	const subject = new Subject<{ newValue: T; oldValue: T }>()
 	const covered = new Set<string>()
-	const toolkit = registerSelector(options.key, covered, target)
-	const { find, get, seek, json } = toolkit
+	const setterToolkit = registerSelector(options.key, covered, target)
+	const { find, get, seek, json } = setterToolkit
 	const getterToolkit = { find, get, seek, json }
 
-	const getSelf = (innerTarget = newest(store)): T => {
-		const value = options.get(getterToolkit)
+	const getSelf = (getFn = options.get, innerTarget = newest(store)): T => {
+		const value = getFn(getterToolkit)
 		cacheValue(options.key, value, subject, innerTarget)
 		covered.clear()
 		return value
@@ -35,7 +35,7 @@ export const createWritableSelector = <T>(
 
 	const setSelf = (next: T | ((oldValue: T) => T)): void => {
 		const innerTarget = newest(store)
-		const oldValue = getSelf(innerTarget)
+		const oldValue = getSelf(options.get, innerTarget)
 		const newValue = become(next)(oldValue)
 		store.logger.info(
 			`📝`,
@@ -52,7 +52,7 @@ export const createWritableSelector = <T>(
 		if (isRootStore(innerTarget)) {
 			subject.next({ newValue, oldValue })
 		}
-		options.set(toolkit, newValue)
+		options.set(setterToolkit, newValue)
 	}
 	const mySelector: WritableSelector<T> = {
 		...options,

--- a/packages/atom.io/internal/src/set-state/set-into-store.ts
+++ b/packages/atom.io/internal/src/set-state/set-into-store.ts
@@ -1,5 +1,5 @@
 import type { WritableFamilyToken, WritableToken } from "atom.io"
-import type { Canonical } from "atom.io/json"
+import { type Canonical, stringifyJson } from "atom.io/json"
 
 import { findInStore, seekInStore } from "../families"
 import { NotFoundError } from "../not-found-error"
@@ -52,7 +52,18 @@ export function setIntoStore<T, New extends T>(
 				? findInStore(family, key, store)
 				: seekInStore(family, key, store)
 		if (!maybeToken) {
-			throw new NotFoundError(family, key, store)
+			store.logger.error(
+				`❗`,
+				family.type,
+				family.key,
+				`tried to set member`,
+				stringifyJson(key),
+				`to`,
+				value,
+				`but it was not found in store`,
+				store.config.name,
+			)
+			return
 		}
 		token = maybeToken
 	}

--- a/packages/atom.io/internal/src/store/deposit.ts
+++ b/packages/atom.io/internal/src/store/deposit.ts
@@ -1,5 +1,6 @@
 import type {
 	AtomToken,
+	MoleculeConstructor,
 	MoleculeFamily,
 	MoleculeFamilyToken,
 	MoleculeToken,
@@ -38,20 +39,20 @@ export function deposit<T>(state: WritableSelector<T>): WritableSelectorToken<T>
 export function deposit<T>(state: ReadonlySelector<T>): ReadonlySelectorToken<T>
 export function deposit<T>(state: Selector<T>): SelectorToken<T>
 export function deposit<T>(state: WritableState<T>): WritableToken<T>
-export function deposit<
-	K extends Canonical,
-	S extends { [key: string]: any },
-	P extends any[],
->(state: Molecule<any>): MoleculeToken<any>
-export function deposit<
-	K extends Canonical,
-	S extends { [key: string]: any },
-	P extends any[],
->(state: MoleculeFamily<any>): MoleculeFamilyToken<any>
+export function deposit<M extends MoleculeConstructor>(
+	state: MoleculeFamily<M>,
+): MoleculeFamilyToken<M>
+export function deposit<M extends MoleculeConstructor>(
+	state: Molecule<M>,
+): MoleculeToken<M>
 export function deposit<T extends Func>(
 	state: Transaction<T>,
 ): TransactionToken<T>
 export function deposit<T>(state: ReadableState<T>): ReadableToken<T>
+export function deposit(
+	state: Molecule<any> | ReadableState<any>,
+): MoleculeToken<any> | ReadableToken<any>
+
 export function deposit<T>(
 	state:
 		| Molecule<any>

--- a/packages/atom.io/internal/src/store/store.ts
+++ b/packages/atom.io/internal/src/store/store.ts
@@ -42,6 +42,7 @@ export class Store implements Lineage {
 	public child: Store | null = null
 
 	public valueMap = new Map<string, any>()
+	public defaults = new Map<string, any>()
 
 	public atoms = new Map<string, Atom<any>>()
 	public selectors = new Map<string, WritableSelector<any>>()

--- a/packages/atom.io/internal/src/transaction/build-transaction.ts
+++ b/packages/atom.io/internal/src/transaction/build-transaction.ts
@@ -48,6 +48,7 @@ export const buildTransaction = (
 		}),
 		selectors: new LazyMap(parent.selectors),
 		valueMap: new LazyMap(parent.valueMap),
+		defaults: parent.defaults,
 		molecules: new LazyMap(parent.molecules),
 		moleculeFamilies: new LazyMap(parent.moleculeFamilies),
 		moleculeInProgress: parent.moleculeInProgress,

--- a/packages/atom.io/src/logger.ts
+++ b/packages/atom.io/src/logger.ts
@@ -52,12 +52,16 @@ const LoggerIconDictionary = {
 } as const
 export type LoggerIcon = keyof typeof LoggerIconDictionary
 export type TokenDenomination =
+	| `atom_family`
 	| `atom`
 	| `continuity`
 	| `molecule_family`
 	| `molecule`
+	| `mutable_atom_family`
 	| `mutable_atom`
+	| `readonly_selector_family`
 	| `readonly_selector`
+	| `selector_family`
 	| `selector`
 	| `state`
 	| `timeline`


### PR DESCRIPTION
### **User description**
- **✨ don't throw when state can't be found**
- **🦋**


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Updated tests to handle missing state without throwing errors and added logging.
- Added default state retrieval and handling for various family types.
- Replaced error throwing with logging for missing state retrieval, setting, and disposal.
- Enhanced toolkit usage for getter and setter in writable selectors.
- Added defaults map to store and transaction building for default state handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>immortal.test.ts</strong><dd><code>Update tests for state retrieval and disposal without errors</code></dd></summary>
<hr>

packages/atom.io/__tests__/experimental/immortal/immortal.test.ts

<li>Updated tests to handle missing state without throwing errors.<br> <li> Added logging for missing state retrieval and disposal.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2407/files#diff-07f4bcf7cde881144c4d396d2b1b2c345ae79bf0dc9e2ebfbb924625f7af8d99">+48/-14</a>&nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>create-readonly-selector-family.ts</strong><dd><code>Add default state retrieval for readonly selector families</code></dd></summary>
<hr>

packages/atom.io/internal/src/families/create-readonly-selector-family.ts

<li>Added default state retrieval for readonly selector families.<br> <li> Enhanced internal roles and subject handling.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2407/files#diff-4004c8ac06cc3ab834c8412bed9efb4f49c1c3ac6b3049d851081b19368595c9">+19/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create-regular-atom-family.ts</strong><dd><code>Add default state handling for regular atom families</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/families/create-regular-atom-family.ts

- Added default state handling for regular atom families.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2407/files#diff-1534b05697a5730de7721e61a41b1061226b23b32e4a8b8d80d5a5e6bb2caf9a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create-writable-selector-family.ts</strong><dd><code>Add default state retrieval for writable selector families</code></dd></summary>
<hr>

packages/atom.io/internal/src/families/create-writable-selector-family.ts

<li>Added default state retrieval for writable selector families.<br> <li> Enhanced internal roles and subject handling.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2407/files#diff-cb43db3aca301de32b560837206d9ab8d7e46ea942867973aea122a720c31052">+19/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dispose-from-store.ts</strong><dd><code>Log missing state disposal instead of throwing errors</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/families/dispose-from-store.ts

- Replaced error throwing with logging for missing state disposal.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2407/files#diff-f86854992abef68242dbc7fd4725a72e20fd9992f4097f931b36e633b5abf792">+11/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>seek-in-store.ts</strong><dd><code>Remove redundant state check in molecule family seeking</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/families/seek-in-store.ts

- Removed redundant state check in molecule family seeking.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2407/files#diff-199e321d47d17eb17a2862f6d58c6d2a8a5bb53c7acbd9234ce2bbb0b201c172">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>get-from-store.ts</strong><dd><code>Log missing state retrieval and add default state handling</code></dd></summary>
<hr>

packages/atom.io/internal/src/get-state/get-from-store.ts

<li>Replaced error throwing with logging for missing state retrieval.<br> <li> Added default state handling for various family types.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2407/files#diff-135c02462cc277a6e2619cb01e9780522ace6122893402d79ea70e3a0eb0380d">+26/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>read-or-compute-value.ts</strong><dd><code>Simplify condition for computing selector values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/get-state/read-or-compute-value.ts

- Simplified condition for computing selector values.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2407/files#diff-71c209ed66cd84f3cab8dd8eb52fa3de1dcbbf1abab7cbeccf4b6e69a695408c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add default state retrieval to selector family types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/index.ts

- Added default state retrieval to selector family types.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2407/files#diff-144f9d30bcc35f5acc9a29cddb926fda18c4bd059daa1f863ff167a16111dd3d">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create-writable-selector.ts</strong><dd><code>Enhance toolkit usage in writable selectors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/selector/create-writable-selector.ts

<li>Enhanced toolkit usage for getter and setter in writable selectors.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2407/files#diff-af49088a062b5257f3cdf35976e88cbb1da6576bd2f3723e0e11174b5d8cf9e2">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>set-into-store.ts</strong><dd><code>Log missing state setting instead of throwing errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/set-state/set-into-store.ts

- Replaced error throwing with logging for missing state setting.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2407/files#diff-57e5d076356ff8fdd80da1f26bb40baf03de821e36e28df6db760f2697ba9d3e">+13/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deposit.ts</strong><dd><code>Refactor deposit function for molecule and readable state</code></dd></summary>
<hr>

packages/atom.io/internal/src/store/deposit.ts

<li>Refactored deposit function for molecule and readable state handling.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2407/files#diff-9998e70928845ae3f801e6b1337c818566c6bb36a0ac006629c3f1fb437c8f1f">+11/-10</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>store.ts</strong><dd><code>Add defaults map to store for default state handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/store/store.ts

- Added defaults map to store for default state handling.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2407/files#diff-395c42a09ae60d4c7488f4b4fb8921f4bfe2eb1f0f805c8d2531bcb46e23a2a3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>build-transaction.ts</strong><dd><code>Add defaults map to transaction building</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/transaction/build-transaction.ts

<li>Added defaults map to transaction building for default state handling.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2407/files#diff-33c8f8ec504a3beeea3f59ddd82c0b222594050ea6f0003ccde768452f7aaa4f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>logger.ts</strong><dd><code>Add new token denominations for logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/logger.ts

- Added new token denominations for logging.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2407/files#diff-f2d95c39203c617eb5dc522d7b25f0336f303a1561df113186299023a8ea0dcd">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>fuzzy-moles-smoke.md</strong><dd><code>Add changeset for patch update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/fuzzy-moles-smoke.md

- Added changeset for patch update.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2407/files#diff-f5944c6afc3fcbfb1583cb4bf4f3ed569b6ea528b58646193cb687ddcda19a80">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

