### PR TITLE
atom.io/internal zero arg store

### DIFF
--- a/.changeset/cool-wolves-learn.md
+++ b/.changeset/cool-wolves-learn.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+♻️ `atom.io/internal` refactors many internal store functions to place `Store` as the zeroth param.

--- a/packages/atom.io/__tests__/experimental/realtime-ipc/game-servers.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime-ipc/game-servers.test.tsx
@@ -53,7 +53,7 @@ describe(`multi-process realtime server`, () => {
 			`room-1`,
 			server.silo.store,
 		)
-		const roomSocket = await getFromStore(roomSocketState, server.silo.store)
+		const roomSocket = await getFromStore(server.silo.store, roomSocketState)
 
 		teardown()
 

--- a/packages/atom.io/__tests__/experimental/realtime-ipc/game-servers.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime-ipc/game-servers.test.tsx
@@ -49,9 +49,9 @@ describe(`multi-process realtime server`, () => {
 		await app.renderResult.findByTestId(`join-room-1`)
 
 		const roomSocketState = findInStore(
+			server.silo.store,
 			roomSelectors,
 			`room-1`,
-			server.silo.store,
 		)
 		const roomSocket = await getFromStore(server.silo.store, roomSocketState)
 

--- a/packages/atom.io/__tests__/experimental/realtime-ipc/system-server.node.ts
+++ b/packages/atom.io/__tests__/experimental/realtime-ipc/system-server.node.ts
@@ -56,7 +56,7 @@ export const SystemServer = ({
 
 	socket.on(`delete-room`, async (roomId) => {
 		const roomState = findInStore(RTS.roomSelectors, roomId, store)
-		const roomSocket = await getFromStore(roomState, store)
+		const roomSocket = await getFromStore(store, roomState)
 		logger.info(`[${shortId}]:${username}`, `deleting room "${roomId}"`)
 		roomSocket.emit(`exit`, username)
 		setIntoStore(RT.roomIndex, (index) => (index.delete(roomId), index), store)
@@ -77,7 +77,7 @@ export const SystemServer = ({
 		actUponStore(RTS.joinRoomTX, arbitrary(), store)(roomId, username, 0)
 
 		const roomSocketState = findInStore(RTS.roomSelectors, roomId, store)
-		const roomSocket = await getFromStore(roomSocketState, store)
+		const roomSocket = await getFromStore(store, roomSocketState)
 		roomSocket.onAny((...payload) => socket.emit(...payload))
 		roomSocket.emit(`user-joins`, username)
 
@@ -114,12 +114,12 @@ export const SystemServer = ({
 			username,
 			store,
 		).roomKeyOfUser
-		const roomKey = getFromStore(roomKeyState, store)
+		const roomKey = getFromStore(store, roomKeyState)
 		if (!roomKey) {
 			return
 		}
 		const roomSocketState = findInStore(RTS.roomSelectors, roomKey, store)
-		const roomSocket = await getFromStore(roomSocketState, store)
+		const roomSocket = await getFromStore(store, roomSocketState)
 		roomSocket?.emit(`leave-room`, username)
 		actUponStore(RTS.leaveRoomTX, arbitrary(), store)(`*`, username)
 		logger.info(`[${shortId}]:${username}`, `disconnected`)

--- a/packages/atom.io/__tests__/experimental/realtime-ipc/system-server.node.ts
+++ b/packages/atom.io/__tests__/experimental/realtime-ipc/system-server.node.ts
@@ -45,7 +45,7 @@ export const SystemServer = ({
 	)
 	const usersInRoomsAtoms = getInternalRelationsFromStore(RT.usersInRooms, store)
 	exposeMutableFamily(usersOfSocketsAtoms, RTS.socketIndex)
-	exposeMutable(findInStore(usersInRoomsAtoms, username, store))
+	exposeMutable(findInStore(store, usersInRoomsAtoms, username))
 
 	socket.on(`create-room`, async (roomId) => {
 		await actUponStore(RTS.createRoomTX, arbitrary(), store)(roomId, `bun`, [
@@ -55,7 +55,7 @@ export const SystemServer = ({
 	})
 
 	socket.on(`delete-room`, async (roomId) => {
-		const roomState = findInStore(RTS.roomSelectors, roomId, store)
+		const roomState = findInStore(store, RTS.roomSelectors, roomId)
 		const roomSocket = await getFromStore(store, roomState)
 		logger.info(`[${shortId}]:${username}`, `deleting room "${roomId}"`)
 		roomSocket.emit(`exit`, username)
@@ -76,7 +76,7 @@ export const SystemServer = ({
 
 		actUponStore(RTS.joinRoomTX, arbitrary(), store)(roomId, username, 0)
 
-		const roomSocketState = findInStore(RTS.roomSelectors, roomId, store)
+		const roomSocketState = findInStore(store, RTS.roomSelectors, roomId)
 		const roomSocket = await getFromStore(store, roomSocketState)
 		roomSocket.onAny((...payload) => socket.emit(...payload))
 		roomSocket.emit(`user-joins`, username)
@@ -118,7 +118,7 @@ export const SystemServer = ({
 		if (!roomKey) {
 			return
 		}
-		const roomSocketState = findInStore(RTS.roomSelectors, roomKey, store)
+		const roomSocketState = findInStore(store, RTS.roomSelectors, roomKey)
 		const roomSocket = await getFromStore(store, roomSocketState)
 		roomSocket?.emit(`leave-room`, username)
 		actUponStore(RTS.leaveRoomTX, arbitrary(), store)(`*`, username)

--- a/packages/atom.io/__tests__/experimental/realtime-ipc/system-server.node.ts
+++ b/packages/atom.io/__tests__/experimental/realtime-ipc/system-server.node.ts
@@ -59,7 +59,7 @@ export const SystemServer = ({
 		const roomSocket = await getFromStore(store, roomState)
 		logger.info(`[${shortId}]:${username}`, `deleting room "${roomId}"`)
 		roomSocket.emit(`exit`, username)
-		setIntoStore(RT.roomIndex, (index) => (index.delete(roomId), index), store)
+		setIntoStore(store, RT.roomIndex, (index) => (index.delete(roomId), index))
 	})
 
 	socket.on(`join-room`, async (roomId) => {

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-mutable-family.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-mutable-family.test.tsx
@@ -50,7 +50,7 @@ describe(`running transactions`, () => {
 		RTTest.multiClient({
 			port: 2775,
 			server: ({ socket, silo: { store } }) => {
-				setIntoStore(storeState, store, store)
+				setIntoStore(store, storeState, store)
 				const exposeMutableFamily = RTS.realtimeMutableFamilyProvider({
 					socket,
 					store,
@@ -66,7 +66,7 @@ describe(`running transactions`, () => {
 						addToNumbersCollectionTX,
 					)
 					const store = React.useContext(AR.StoreContext)
-					setIntoStore(storeState, store, store)
+					setIntoStore(store, storeState, store)
 
 					return (
 						<button

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-pull-regular-atom-family.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-pull-regular-atom-family.test.tsx
@@ -65,7 +65,7 @@ describe(`running transactions`, () => {
 		RTTest.multiClient({
 			port: 4915,
 			server: ({ socket, silo: { store } }) => {
-				setIntoStore(storeState, store, store)
+				setIntoStore(store, storeState, store)
 				const exposeFamily = RTS.realtimeAtomFamilyProvider({
 					socket,
 					store,
@@ -81,7 +81,7 @@ describe(`running transactions`, () => {
 						addToNumbersCollectionTX,
 					)
 					const store = React.useContext(AR.StoreContext)
-					setIntoStore(storeState, store, store)
+					setIntoStore(store, storeState, store)
 
 					return (
 						<button

--- a/packages/atom.io/__tests__/public/mutability/mutable-atom.test.ts
+++ b/packages/atom.io/__tests__/public/mutability/mutable-atom.test.ts
@@ -87,16 +87,13 @@ describe(`mutable atomic state`, () => {
 			SetRTX<string>,
 			SetRTXJson<string>,
 			string
-		>(
-			{
-				key: `flagsByUserId::mutable`,
-				mutable: true,
-				default: () => new SetRTX(),
-				toJson: (set) => set.toJSON(),
-				fromJson: (array) => SetRTX.fromJSON(array),
-			},
-			Internal.IMPLICIT.STORE,
-		)
+		>(Internal.IMPLICIT.STORE, {
+			key: `flagsByUserId::mutable`,
+			mutable: true,
+			default: () => new SetRTX(),
+			toJson: (set) => set.toJSON(),
+			fromJson: (array) => SetRTX.fromJSON(array),
+		})
 
 		const myFlagsState = findState(findFlagsStateByUserId, `my-user-id`)
 		const findFlagsByUserIdJSON = Internal.getJsonToken(

--- a/packages/atom.io/__tests__/public/mutability/mutable-atom.test.ts
+++ b/packages/atom.io/__tests__/public/mutability/mutable-atom.test.ts
@@ -48,8 +48,8 @@ describe(`mutable atomic state`, () => {
 			fromJson: (json) => SetRTX.fromJSON(json),
 		})
 		const myJsonState = Internal.getJsonToken(
-			myMutableState,
 			Internal.IMPLICIT.STORE,
+			myMutableState,
 		)
 		const myTrackerState = Internal.getUpdateToken(myMutableState)
 		subscribe(myMutableState, Utils.stdout0)
@@ -100,8 +100,8 @@ describe(`mutable atomic state`, () => {
 
 		const myFlagsState = findState(findFlagsStateByUserId, `my-user-id`)
 		const findFlagsByUserIdJSON = Internal.getJsonToken(
-			myFlagsState,
 			Internal.IMPLICIT.STORE,
+			myFlagsState,
 		)
 		const findFlagsByUserIdTracker = Internal.getUpdateToken(myFlagsState)
 
@@ -163,8 +163,8 @@ describe(`mutable atomic state`, () => {
 		})
 
 		const myJsonState = Internal.getJsonToken(
-			myMutableState,
 			Internal.IMPLICIT.STORE,
+			myMutableState,
 		)
 		subscribe(myJsonState, Utils.stdout)
 
@@ -203,8 +203,8 @@ describe(`mutable time traveling`, () => {
 			scope: [myMutableStates],
 		})
 		const myJsonState = Internal.getJsonToken(
-			myMutableState,
 			Internal.IMPLICIT.STORE,
+			myMutableState,
 		)
 		const myTrackerState = Internal.getUpdateToken(myMutableState)
 		subscribe(myMutableState, Utils.stdout0)
@@ -245,8 +245,8 @@ describe(`mutable time traveling`, () => {
 		})
 
 		const myJsonState = Internal.getJsonToken(
-			myMutableState,
 			Internal.IMPLICIT.STORE,
+			myMutableState,
 		)
 		const myTrackerState = Internal.getUpdateToken(myMutableState)
 		subscribe(myMutableState, Utils.stdout0)

--- a/packages/atom.io/data/src/dict.ts
+++ b/packages/atom.io/data/src/dict.ts
@@ -24,7 +24,7 @@ export function dict<State, Key extends Canonical>(
 			get: ({ get }) => {
 				const keys = get(index)
 				return keys.reduce((acc, key) => {
-					acc[key] = get(findInStore(family, key, store))
+					acc[key] = get(findInStore(store, family, key))
 					return acc
 				}, {} as any)
 			},

--- a/packages/atom.io/data/src/dict.ts
+++ b/packages/atom.io/data/src/dict.ts
@@ -18,17 +18,14 @@ export function dict<State, Key extends Canonical>(
 		| AtomIO.WritableSelectorToken<Key[]>,
 	store: Store = IMPLICIT.STORE,
 ): AtomIO.ReadonlySelectorToken<{ [K in stringified<Key>]: State }> {
-	return createStandaloneSelector(
-		{
-			key: `${family.key}Dict`,
-			get: ({ get }) => {
-				const keys = get(index)
-				return keys.reduce((acc, key) => {
-					acc[key] = get(findInStore(store, family, key))
-					return acc
-				}, {} as any)
-			},
+	return createStandaloneSelector(store, {
+		key: `${family.key}Dict`,
+		get: ({ get }) => {
+			const keys = get(index)
+			return keys.reduce((acc, key) => {
+				acc[key] = get(findInStore(store, family, key))
+				return acc
+			}, {} as any)
 		},
-		store,
-	)
+	})
 }

--- a/packages/atom.io/data/src/join.ts
+++ b/packages/atom.io/data/src/join.ts
@@ -235,6 +235,7 @@ export class Join<
 			SetRTXJson<string>,
 			string
 		>(
+			store,
 			{
 				key: `${options.key}/relatedKeys`,
 				default: () => new SetRTX(),
@@ -242,7 +243,6 @@ export class Join<
 				fromJson: (json) => SetRTX.fromJSON(json),
 				toJson: (set) => set.toJSON(),
 			},
-			store,
 			[`join`, `relations`],
 		)
 		this.core = { findRelatedKeysState: relatedKeysAtoms }
@@ -398,11 +398,11 @@ export class Join<
 		>
 		if (defaultContent) {
 			contentAtoms = createRegularAtomFamily<Content, string>(
+				store,
 				{
 					key: `${options.key}/content`,
 					default: defaultContent,
 				},
-				store,
 				[`join`, `content`],
 			)
 			const joinToken = {

--- a/packages/atom.io/data/src/join.ts
+++ b/packages/atom.io/data/src/join.ts
@@ -201,9 +201,9 @@ export class Join<
 			set: ((...ps: Parameters<typeof setState>) => {
 				setIntoStore(store, ...ps)
 			}) as typeof setState,
-			find: ((token, key) => findInStore(token, key, store)) as typeof findState,
-			seek: ((token, key) => seekInStore(token, key, store)) as typeof seekState,
-			json: (token) => getJsonToken(token, store),
+			find: ((token, key) => findInStore(store, token, key)) as typeof findState,
+			seek: ((token, key) => seekInStore(store, token, key)) as typeof seekState,
+			json: (token) => getJsonToken(store, token),
 			dispose: ((...ps: Parameters<typeof disposeState>) => {
 				disposeFromStore(...ps, store)
 			}) as typeof disposeState,
@@ -224,7 +224,7 @@ export class Join<
 			if (store.config.lifespan === `immortal`) {
 				throw new NotFoundError(token, key, store)
 			}
-			return initFamilyMemberInStore(token, key, store)
+			return initFamilyMemberInStore(store, token, key)
 		}) as typeof findState
 		const aSide: ASide = options.between[0]
 		const bSide: BSide = options.between[1]

--- a/packages/atom.io/data/src/join.ts
+++ b/packages/atom.io/data/src/join.ts
@@ -199,7 +199,7 @@ export class Join<
 			get: ((...ps: Parameters<typeof getState>) =>
 				getFromStore(store, ...ps)) as typeof getState,
 			set: ((...ps: Parameters<typeof setState>) => {
-				setIntoStore(...ps, store)
+				setIntoStore(store, ...ps)
 			}) as typeof setState,
 			find: ((token, key) => findInStore(token, key, store)) as typeof findState,
 			seek: ((token, key) => seekInStore(token, key, store)) as typeof seekState,

--- a/packages/atom.io/data/src/join.ts
+++ b/packages/atom.io/data/src/join.ts
@@ -201,11 +201,13 @@ export class Join<
 			set: ((...ps: Parameters<typeof setState>) => {
 				setIntoStore(store, ...ps)
 			}) as typeof setState,
-			find: ((token, key) => findInStore(store, token, key)) as typeof findState,
-			seek: ((token, key) => seekInStore(store, token, key)) as typeof seekState,
+			find: ((...ps: Parameters<typeof findState>) =>
+				findInStore(store, ...ps)) as typeof findState,
+			seek: ((...ps: Parameters<typeof seekState>) =>
+				seekInStore(store, ...ps)) as typeof seekState,
 			json: (token) => getJsonToken(store, token),
 			dispose: ((...ps: Parameters<typeof disposeState>) => {
-				disposeFromStore(...ps, store)
+				disposeFromStore(store, ...ps)
 			}) as typeof disposeState,
 		}
 		this.retrieve = ((

--- a/packages/atom.io/data/src/join.ts
+++ b/packages/atom.io/data/src/join.ts
@@ -197,7 +197,7 @@ export class Join<
 
 		this.toolkit = {
 			get: ((...ps: Parameters<typeof getState>) =>
-				getFromStore(...ps, store)) as typeof getState,
+				getFromStore(store, ...ps)) as typeof getState,
 			set: ((...ps: Parameters<typeof setState>) => {
 				setIntoStore(...ps, store)
 			}) as typeof setState,

--- a/packages/atom.io/data/src/join.ts
+++ b/packages/atom.io/data/src/join.ts
@@ -412,20 +412,17 @@ export class Join<
 				b: options.between[1],
 				cardinality: options.cardinality,
 			} as const satisfies JoinToken<ASide, BSide, Cardinality, Content>
-			contentMolecules = createMoleculeFamily(
-				{
-					key: `${options.key}/content-molecules`,
-					new: class ContentMolecule {
-						public constructor(
-							toolkit: CtorToolkit<string>,
-							public key: string,
-						) {
-							toolkit.bond(joinToken, { as: null } as any)
-						}
-					},
+			contentMolecules = createMoleculeFamily(store, {
+				key: `${options.key}/content-molecules`,
+				new: class ContentMolecule {
+					public constructor(
+						toolkit: CtorToolkit<string>,
+						public key: string,
+					) {
+						toolkit.bond(joinToken, { as: null } as any)
+					}
 				},
-				store,
-			)
+			})
 			const getContent: Read<(key: string) => Content | null> = ({ get }, key) =>
 				get(this.retrieve(contentAtoms, key))
 			const setContent: Write<(key: string, content: Content) => void> = (
@@ -492,6 +489,7 @@ export class Join<
 
 		const createSingleKeyStateFamily = () =>
 			createReadonlySelectorFamily<string | null, string>(
+				store,
 				{
 					key: `${options.key}/singleRelatedKey`,
 					get:
@@ -505,11 +503,11 @@ export class Join<
 							return null
 						},
 				},
-				store,
 				[`join`, `keys`],
 			)
 		const getMultipleKeyStateFamily = () => {
 			return createReadonlySelectorFamily<string[], string>(
+				store,
 				{
 					key: `${options.key}/multipleRelatedKeys`,
 					get:
@@ -521,12 +519,12 @@ export class Join<
 							return json.members
 						},
 				},
-				store,
 				[`join`, `keys`],
 			)
 		}
 		const createSingleEntryStateFamily = () =>
 			createReadonlySelectorFamily<[string, Content] | null, string>(
+				store,
 				{
 					key: `${options.key}/singleRelatedEntry`,
 					get:
@@ -543,11 +541,11 @@ export class Join<
 							return null
 						},
 				},
-				store,
 				[`join`, `entries`],
 			)
 		const getMultipleEntryStateFamily = () =>
 			createReadonlySelectorFamily<[string, Content][], string>(
+				store,
 				{
 					key: `${options.key}/multipleRelatedEntries`,
 					get:
@@ -564,7 +562,6 @@ export class Join<
 							})
 						},
 				},
-				store,
 				[`join`, `entries`],
 			)
 

--- a/packages/atom.io/data/src/struct-family.ts
+++ b/packages/atom.io/data/src/struct-family.ts
@@ -29,13 +29,10 @@ export function structFamily<
 		>}State`]: AtomIO.RegularAtomFamilyToken<Struct[K], string>
 	} = Object.keys(options.default).reduce((acc, subKey) => {
 		const atomFamilyName = nameFamily(options.key, subKey)
-		acc[atomFamilyName] = createRegularAtomFamily(
-			{
-				key: `${options.key}.${subKey}`,
-				default: (options.default as any)[subKey],
-			},
-			IMPLICIT.STORE,
-		)
+		acc[atomFamilyName] = createRegularAtomFamily(IMPLICIT.STORE, {
+			key: `${options.key}.${subKey}`,
+			default: (options.default as any)[subKey],
+		})
 		return acc
 	}, {} as any)
 	const findStructState: AtomIO.ReadonlySelectorFamilyToken<Struct, string> =

--- a/packages/atom.io/data/src/struct-family.ts
+++ b/packages/atom.io/data/src/struct-family.ts
@@ -36,21 +36,18 @@ export function structFamily<
 		return acc
 	}, {} as any)
 	const findStructState: AtomIO.ReadonlySelectorFamilyToken<Struct, string> =
-		createSelectorFamily(
-			{
-				key: options.key,
-				get:
-					(id) =>
-					({ find, get }) => {
-						return Object.keys(options.default).reduce((acc, subKey) => {
-							acc[subKey] = get(
-								find((atoms as any)[nameFamily(options.key, subKey)], id),
-							)
-							return acc
-						}, {} as any)
-					},
-			},
-			IMPLICIT.STORE,
-		)
+		createSelectorFamily(IMPLICIT.STORE, {
+			key: options.key,
+			get:
+				(id) =>
+				({ find, get }) => {
+					return Object.keys(options.default).reduce((acc, subKey) => {
+						acc[subKey] = get(
+							find((atoms as any)[nameFamily(options.key, subKey)], id),
+						)
+						return acc
+					}, {} as any)
+				},
+		})
 	return [atoms, findStructState]
 }

--- a/packages/atom.io/data/src/struct.ts
+++ b/packages/atom.io/data/src/struct.ts
@@ -41,17 +41,14 @@ export function struct<
 		)
 		return acc
 	}, {} as any)
-	const structState = createStandaloneSelector(
-		{
-			key: options.key,
-			get: ({ get }) => {
-				return Object.keys(options.default).reduce((acc, key) => {
-					acc[key] = get(atoms[options.key + capitalize(key) + `State`])
-					return acc
-				}, {} as any)
-			},
+	const structState = createStandaloneSelector(store, {
+		key: options.key,
+		get: ({ get }) => {
+			return Object.keys(options.default).reduce((acc, key) => {
+				acc[key] = get(atoms[options.key + capitalize(key) + `State`])
+				return acc
+			}, {} as any)
 		},
-		store,
-	)
+	})
 	return [atoms, structState]
 }

--- a/packages/atom.io/data/src/struct.ts
+++ b/packages/atom.io/data/src/struct.ts
@@ -32,12 +32,12 @@ export function struct<
 	} = Object.keys(options.default).reduce((acc, key) => {
 		const atomName = options.key + capitalize(key) + `State`
 		acc[atomName] = createRegularAtom(
+			store,
 			{
 				key: `${options.key}.${key}`,
 				default: options.default[key],
 			},
 			undefined,
-			store,
 		)
 		return acc
 	}, {} as any)

--- a/packages/atom.io/ephemeral/src/find-state.ts
+++ b/packages/atom.io/ephemeral/src/find-state.ts
@@ -92,6 +92,6 @@ export function findState(
 	token: ReadableFamilyToken<any, any>,
 	key: Json.Serializable,
 ): ReadableToken<any> {
-	const state = findInStore(token, key, IMPLICIT.STORE)
+	const state = findInStore(IMPLICIT.STORE, token, key)
 	return state
 }

--- a/packages/atom.io/immortal/src/seek-state.ts
+++ b/packages/atom.io/immortal/src/seek-state.ts
@@ -65,8 +65,8 @@ export function seekState(
 	key: Canonical,
 ): MoleculeToken<any> | ReadableToken<any> | undefined {
 	if (token.type === `molecule_family`) {
-		return seekInStore(token, key, IMPLICIT.STORE)
+		return seekInStore(IMPLICIT.STORE, token, key)
 	}
-	const state = seekInStore(token, key, IMPLICIT.STORE)
+	const state = seekInStore(IMPLICIT.STORE, token, key)
 	return state
 }

--- a/packages/atom.io/internal/src/atom/create-regular-atom.ts
+++ b/packages/atom.io/internal/src/atom/create-regular-atom.ts
@@ -15,9 +15,9 @@ import { subscribeToState } from "../subscribe"
 import { markAtomAsDefault } from "./is-default"
 
 export function createRegularAtom<T>(
+	store: Store,
 	options: RegularAtomOptions<T>,
 	family: FamilyMetadata | undefined,
-	store: Store,
 ): RegularAtomToken<T> {
 	store.logger.info(
 		`🔨`,
@@ -47,7 +47,7 @@ export function createRegularAtom<T>(
 				options.key,
 				`installing in store "${s.config.name}"`,
 			)
-			return createRegularAtom(options, family, s)
+			return createRegularAtom(s, options, family)
 		},
 		subject,
 	} as const

--- a/packages/atom.io/internal/src/atom/create-regular-atom.ts
+++ b/packages/atom.io/internal/src/atom/create-regular-atom.ts
@@ -68,7 +68,7 @@ export function createRegularAtom<T>(
 		for (const effect of options.effects) {
 			const cleanup = effect({
 				setSelf: (next) => {
-					setIntoStore(token, next, store)
+					setIntoStore(store, token, next)
 				},
 				onSet: (handle: UpdateHandler<T>) =>
 					subscribeToState(token, handle, `effect[${effectIndex}]`, store),

--- a/packages/atom.io/internal/src/atom/create-standalone-atom.ts
+++ b/packages/atom.io/internal/src/atom/create-standalone-atom.ts
@@ -13,25 +13,27 @@ import type { Store } from "../store"
 import { createRegularAtom } from "./create-regular-atom"
 
 export function createStandaloneAtom<T>(
-	options: RegularAtomOptions<T>,
 	store: Store,
+	options: RegularAtomOptions<T>,
 ): RegularAtomToken<T>
+
 export function createStandaloneAtom<
 	T extends Transceiver<any>,
 	J extends Json.Serializable,
->(options: MutableAtomOptions<T, J>, store: Store): MutableAtomToken<T, J>
+>(store: Store, options: MutableAtomOptions<T, J>): MutableAtomToken<T, J>
+
 export function createStandaloneAtom<T>(
-	options: MutableAtomOptions<any, any> | RegularAtomOptions<T>,
 	store: Store,
+	options: MutableAtomOptions<any, any> | RegularAtomOptions<T>,
 ): AtomToken<T> {
 	const isMutable = `mutable` in options
 
 	if (isMutable) {
-		const state = createMutableAtom(options, undefined, store)
+		const state = createMutableAtom(store, options, undefined)
 		store.on.atomCreation.next(state)
 		return state
 	}
-	const state = createRegularAtom(options, undefined, store)
+	const state = createRegularAtom(store, options, undefined)
 	store.on.atomCreation.next(state)
 	return state
 }

--- a/packages/atom.io/internal/src/families/create-atom-family.ts
+++ b/packages/atom.io/internal/src/families/create-atom-family.ts
@@ -16,23 +16,23 @@ export function createAtomFamily<
 	J extends Json.Serializable,
 	K extends Canonical,
 >(
-	options: MutableAtomFamilyOptions<T, J, K>,
 	store: Store,
+	options: MutableAtomFamilyOptions<T, J, K>,
 ): MutableAtomFamilyToken<T, J, K>
 export function createAtomFamily<T, K extends Canonical>(
-	options: RegularAtomFamilyOptions<T, K>,
 	store: Store,
+	options: RegularAtomFamilyOptions<T, K>,
 ): RegularAtomFamilyToken<T, K>
 export function createAtomFamily<T, K extends Canonical>(
+	store: Store,
 	options:
 		| MutableAtomFamilyOptions<any, any, any>
 		| RegularAtomFamilyOptions<T, K>,
-	store: Store,
 ): AtomFamilyToken<any, any> {
 	const isMutable = `mutable` in options
 
 	if (isMutable) {
-		return createMutableAtomFamily(options, store)
+		return createMutableAtomFamily(store, options)
 	}
-	return createRegularAtomFamily<T, K>(options, store)
+	return createRegularAtomFamily<T, K>(store, options)
 }

--- a/packages/atom.io/internal/src/families/create-readonly-selector-family.ts
+++ b/packages/atom.io/internal/src/families/create-readonly-selector-family.ts
@@ -1,5 +1,6 @@
 import type {
 	FamilyMetadata,
+	getState,
 	ReadonlySelectorFamilyOptions,
 	ReadonlySelectorFamilyToken,
 	ReadonlySelectorToken,
@@ -67,10 +68,10 @@ export function createReadonlySelectorFamily<T, K extends Canonical>(
 		default: (key: K) => {
 			const getFn = options.get(key)
 			return getFn({
-				get: (...args: [any]) => getFromStore(store, ...args),
-				find: ((token, k) => findInStore(token, k, store)) as typeof findState,
-				seek: ((token, k) => seekInStore(token, k, store)) as typeof seekState,
-				json: (token) => getJsonToken(token, store),
+				get: ((...ps: [any]) => getFromStore(store, ...ps)) as typeof getState,
+				find: ((token, k) => findInStore(store, token, k)) as typeof findState,
+				seek: ((token, k) => seekInStore(store, token, k)) as typeof seekState,
+				json: (token) => getJsonToken(store, token),
 			})
 		},
 	}) satisfies ReadonlySelectorFamily<T, K>

--- a/packages/atom.io/internal/src/families/create-readonly-selector-family.ts
+++ b/packages/atom.io/internal/src/families/create-readonly-selector-family.ts
@@ -26,8 +26,8 @@ import { Subject } from "../subject"
 import { throwInCaseOfConflictingFamily } from "./throw-in-case-of-conflicting-family"
 
 export function createReadonlySelectorFamily<T, K extends Canonical>(
-	options: ReadonlySelectorFamilyOptions<T, K>,
 	store: Store,
+	options: ReadonlySelectorFamilyOptions<T, K>,
 	internalRoles?: string[],
 ): ReadonlySelectorFamilyToken<T, K> {
 	const familyToken = {
@@ -49,12 +49,12 @@ export function createReadonlySelectorFamily<T, K extends Canonical>(
 		const target = newest(store)
 
 		const token = createReadonlySelector(
+			target,
 			{
 				key: fullKey,
 				get: options.get(key),
 			},
 			family,
-			target,
 		)
 
 		subject.next({ type: `state_creation`, token })
@@ -64,7 +64,7 @@ export function createReadonlySelectorFamily<T, K extends Canonical>(
 	const readonlySelectorFamily = Object.assign(familyFunction, familyToken, {
 		internalRoles,
 		subject,
-		install: (s: Store) => createReadonlySelectorFamily(options, s),
+		install: (s: Store) => createReadonlySelectorFamily(s, options),
 		default: (key: K) => {
 			const getFn = options.get(key)
 			return getFn({

--- a/packages/atom.io/internal/src/families/create-readonly-selector-family.ts
+++ b/packages/atom.io/internal/src/families/create-readonly-selector-family.ts
@@ -67,7 +67,7 @@ export function createReadonlySelectorFamily<T, K extends Canonical>(
 		default: (key: K) => {
 			const getFn = options.get(key)
 			return getFn({
-				get: (token) => getFromStore(token, store),
+				get: (...args: [any]) => getFromStore(store, ...args),
 				find: ((token, k) => findInStore(token, k, store)) as typeof findState,
 				seek: ((token, k) => seekInStore(token, k, store)) as typeof seekState,
 				json: (token) => getJsonToken(token, store),

--- a/packages/atom.io/internal/src/families/create-regular-atom-family.ts
+++ b/packages/atom.io/internal/src/families/create-regular-atom-family.ts
@@ -18,8 +18,8 @@ import { Subject } from "../subject"
 import { throwInCaseOfConflictingFamily } from "./throw-in-case-of-conflicting-family"
 
 export function createRegularAtomFamily<T, K extends Canonical>(
-	options: RegularAtomFamilyOptions<T, K>,
 	store: Store,
+	options: RegularAtomFamilyOptions<T, K>,
 	internalRoles?: string[],
 ): RegularAtomFamilyToken<T, K> {
 	const familyToken = {
@@ -48,7 +48,7 @@ export function createRegularAtomFamily<T, K extends Canonical>(
 			individualOptions.effects = options.effects(key)
 		}
 
-		const token = createRegularAtom(individualOptions, family, target)
+		const token = createRegularAtom(target, individualOptions, family)
 
 		subject.next({ type: `state_creation`, token })
 		return token
@@ -56,7 +56,7 @@ export function createRegularAtomFamily<T, K extends Canonical>(
 
 	const atomFamily = Object.assign(familyFunction, familyToken, {
 		subject,
-		install: (s: Store) => createRegularAtomFamily(options, s),
+		install: (s: Store) => createRegularAtomFamily(s, options),
 		internalRoles,
 	}) satisfies RegularAtomFamily<T, K>
 

--- a/packages/atom.io/internal/src/families/create-selector-family.ts
+++ b/packages/atom.io/internal/src/families/create-selector-family.ts
@@ -12,23 +12,23 @@ import { createReadonlySelectorFamily } from "./create-readonly-selector-family"
 import { createWritableSelectorFamily } from "./create-writable-selector-family"
 
 export function createSelectorFamily<T, K extends Canonical>(
-	options: WritableSelectorFamilyOptions<T, K>,
 	store: Store,
+	options: WritableSelectorFamilyOptions<T, K>,
 ): WritableSelectorFamilyToken<T, K>
 export function createSelectorFamily<T, K extends Canonical>(
-	options: ReadonlySelectorFamilyOptions<T, K>,
 	store: Store,
+	options: ReadonlySelectorFamilyOptions<T, K>,
 ): ReadonlySelectorFamilyToken<T, K>
 export function createSelectorFamily<T, K extends Canonical>(
+	store: Store,
 	options:
 		| ReadonlySelectorFamilyOptions<T, K>
 		| WritableSelectorFamilyOptions<T, K>,
-	store: Store,
 ): SelectorFamilyToken<T, K> {
 	const isWritable = `set` in options
 
 	if (isWritable) {
-		return createWritableSelectorFamily(options, store)
+		return createWritableSelectorFamily(store, options)
 	}
-	return createReadonlySelectorFamily(options, store)
+	return createReadonlySelectorFamily(store, options)
 }

--- a/packages/atom.io/internal/src/families/create-writable-selector-family.ts
+++ b/packages/atom.io/internal/src/families/create-writable-selector-family.ts
@@ -1,5 +1,6 @@
 import type {
 	FamilyMetadata,
+	getState,
 	StateCreation,
 	StateDisposal,
 	WritableSelectorFamilyOptions,
@@ -68,10 +69,10 @@ export function createWritableSelectorFamily<T, K extends Canonical>(
 		default: (key: K) => {
 			const getFn = options.get(key)
 			return getFn({
-				get: (...params: [any]) => getFromStore(store, ...params), // TODO: make store zero-arg
-				find: ((token, k) => findInStore(token, k, store)) as typeof findState,
-				seek: ((token, k) => seekInStore(token, k, store)) as typeof seekState,
-				json: (token) => getJsonToken(token, store),
+				get: ((...ps: [any]) => getFromStore(store, ...ps)) as typeof getState,
+				find: ((token, k) => findInStore(store, token, k)) as typeof findState,
+				seek: ((token, k) => seekInStore(store, token, k)) as typeof seekState,
+				json: (token) => getJsonToken(store, token),
 			})
 		},
 	}) satisfies WritableSelectorFamily<T, K>

--- a/packages/atom.io/internal/src/families/create-writable-selector-family.ts
+++ b/packages/atom.io/internal/src/families/create-writable-selector-family.ts
@@ -26,8 +26,8 @@ import { Subject } from "../subject"
 import { throwInCaseOfConflictingFamily } from "./throw-in-case-of-conflicting-family"
 
 export function createWritableSelectorFamily<T, K extends Canonical>(
-	options: WritableSelectorFamilyOptions<T, K>,
 	store: Store,
+	options: WritableSelectorFamilyOptions<T, K>,
 	internalRoles?: string[],
 ): WritableSelectorFamilyToken<T, K> {
 	const familyToken = {
@@ -49,13 +49,13 @@ export function createWritableSelectorFamily<T, K extends Canonical>(
 		const target = newest(store)
 
 		const token = createWritableSelector(
+			target,
 			{
 				key: fullKey,
 				get: options.get(key),
 				set: options.set(key),
 			},
 			family,
-			target,
 		)
 
 		subject.next({ type: `state_creation`, token })
@@ -65,7 +65,7 @@ export function createWritableSelectorFamily<T, K extends Canonical>(
 	const selectorFamily = Object.assign(familyFunction, familyToken, {
 		internalRoles,
 		subject,
-		install: (s: Store) => createWritableSelectorFamily(options, s),
+		install: (s: Store) => createWritableSelectorFamily(s, options),
 		default: (key: K) => {
 			const getFn = options.get(key)
 			return getFn({

--- a/packages/atom.io/internal/src/families/create-writable-selector-family.ts
+++ b/packages/atom.io/internal/src/families/create-writable-selector-family.ts
@@ -68,7 +68,7 @@ export function createWritableSelectorFamily<T, K extends Canonical>(
 		default: (key: K) => {
 			const getFn = options.get(key)
 			return getFn({
-				get: (...params: [any]) => getFromStore(...params, store), // TODO: make store zero-arg
+				get: (...params: [any]) => getFromStore(store, ...params), // TODO: make store zero-arg
 				find: ((token, k) => findInStore(token, k, store)) as typeof findState,
 				seek: ((token, k) => seekInStore(token, k, store)) as typeof seekState,
 				json: (token) => getJsonToken(token, store),

--- a/packages/atom.io/internal/src/families/dispose-from-store.ts
+++ b/packages/atom.io/internal/src/families/dispose-from-store.ts
@@ -10,44 +10,41 @@ import { type Canonical, stringifyJson } from "atom.io/json"
 
 import { disposeAtom } from "../atom"
 import { disposeMolecule } from "../molecule/dispose-molecule"
-import { NotFoundError } from "../not-found-error"
 import { disposeSelector } from "../selector"
 import type { Store } from "../store"
 import { findInStore } from "./find-in-store"
 import { seekInStore } from "./seek-in-store"
 
 export function disposeFromStore(
-	token: MoleculeToken<any> | ReadableToken<any>,
 	store: Store,
+	token: MoleculeToken<any> | ReadableToken<any>,
 ): void
 
 export function disposeFromStore<K extends Canonical>(
+	store: Store,
 	token: ReadableFamilyToken<any, K>,
 	key: K,
-	store: Store,
 ): void
 
 export function disposeFromStore<M extends MoleculeConstructor>(
+	store: Store,
 	token: MoleculeFamilyToken<M>,
 	key: MoleculeKey<M>,
-	store: Store,
 ): void
 
 export function disposeFromStore(
+	store: Store,
 	...params:
-		| [token: MoleculeFamilyToken<any>, key: MoleculeKey<any>, store: Store]
-		| [token: MoleculeToken<any> | ReadableToken<any>, store: Store]
-		| [token: ReadableFamilyToken<any, any>, key: Canonical, store: Store]
+		| [token: MoleculeFamilyToken<any>, key: MoleculeKey<any>]
+		| [token: MoleculeToken<any> | ReadableToken<any>]
+		| [token: ReadableFamilyToken<any, any>, key: Canonical]
 ): void {
 	let token: MoleculeToken<any> | ReadableToken<any>
-	let store: Store
-	if (params.length === 2) {
+	if (params.length === 1) {
 		token = params[0]
-		store = params[1]
 	} else {
 		const family = params[0]
 		const key = params[1]
-		store = params[2]
 		const maybeToken =
 			family.type === `molecule_family`
 				? seekInStore(store, family, key)

--- a/packages/atom.io/internal/src/families/dispose-from-store.ts
+++ b/packages/atom.io/internal/src/families/dispose-from-store.ts
@@ -50,10 +50,10 @@ export function disposeFromStore(
 		store = params[2]
 		const maybeToken =
 			family.type === `molecule_family`
-				? seekInStore(family, key, store)
+				? seekInStore(store, family, key)
 				: store.config.lifespan === `immortal`
-					? seekInStore(family, key, store)
-					: findInStore(family, key, store)
+					? seekInStore(store, family, key)
+					: findInStore(store, family, key)
 		if (!maybeToken) {
 			store.logger.error(
 				`❗`,

--- a/packages/atom.io/internal/src/families/find-in-store.ts
+++ b/packages/atom.io/internal/src/families/find-in-store.ts
@@ -29,67 +29,67 @@ export function findInStore<
 	K extends Canonical,
 	Key extends K,
 >(
+	store: Store,
 	token: MutableAtomFamilyToken<T, J, K>,
 	key: Key,
-	store: Store,
 ): MutableAtomToken<T, J>
 
 export function findInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: RegularAtomFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): RegularAtomToken<T>
 
 export function findInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: AtomFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): AtomToken<T>
 
 export function findInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: WritableSelectorFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): WritableSelectorToken<T>
 
 export function findInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: ReadonlySelectorFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): ReadonlySelectorToken<T>
 
 export function findInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: SelectorFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): SelectorToken<T>
 
 export function findInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: WritableFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): WritableToken<T>
 
 export function findInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: ReadableFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): ReadableToken<T>
 
 export function findInStore(
+	store: Store,
 	token: ReadableFamilyToken<any, any>,
 	key: Json.Serializable,
-	store: Store,
 ): ReadableToken<any> {
 	if (store.config.lifespan === `immortal`) {
 		throw new Error(
 			`Do not use \`find\` or \`findState\` in an immortal store. Prefer \`seek\` or \`seekState\`.`,
 		)
 	}
-	let state = seekInStore(token, key, store)
+	let state = seekInStore(store, token, key)
 	if (state) {
 		return state
 	}
-	state = initFamilyMemberInStore(token, key, store)
+	state = initFamilyMemberInStore(store, token, key)
 	return state
 }

--- a/packages/atom.io/internal/src/families/init-family-member.ts
+++ b/packages/atom.io/internal/src/families/init-family-member.ts
@@ -30,57 +30,57 @@ export function initFamilyMemberInStore<
 	K extends Canonical,
 	Key extends K,
 >(
+	store: Store,
 	token: MutableAtomFamilyToken<T, J, K>,
 	key: Key,
-	store: Store,
 ): MutableAtomToken<T, J>
 
 export function initFamilyMemberInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: RegularAtomFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): RegularAtomToken<T>
 
 export function initFamilyMemberInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: AtomFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): AtomToken<T>
 
 export function initFamilyMemberInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: WritableSelectorFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): WritableSelectorToken<T>
 
 export function initFamilyMemberInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: ReadonlySelectorFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): ReadonlySelectorToken<T>
 
 export function initFamilyMemberInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: SelectorFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): SelectorToken<T>
 
 export function initFamilyMemberInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: WritableFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): WritableToken<T>
 
 export function initFamilyMemberInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: ReadableFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): ReadableToken<T>
 
 export function initFamilyMemberInStore(
+	store: Store,
 	token: ReadableFamilyToken<any, any>,
 	key: Json.Serializable,
-	store: Store,
 ): ReadableToken<any> {
 	const familyKey = token.key
 	const family = store.families.get(familyKey)

--- a/packages/atom.io/internal/src/families/seek-in-store.ts
+++ b/packages/atom.io/internal/src/families/seek-in-store.ts
@@ -34,63 +34,63 @@ export function seekInStore<
 	K extends Canonical,
 	Key extends K,
 >(
+	store: Store,
 	token: MutableAtomFamilyToken<T, J, K>,
 	key: Key,
-	store: Store,
 ): MutableAtomToken<T, J> | undefined
 
 export function seekInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: RegularAtomFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): RegularAtomToken<T> | undefined
 
 export function seekInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: AtomFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): AtomToken<T> | undefined
 
 export function seekInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: WritableSelectorFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): WritableSelectorToken<T> | undefined
 
 export function seekInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: ReadonlySelectorFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): ReadonlySelectorToken<T> | undefined
 
 export function seekInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: SelectorFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): SelectorToken<T> | undefined
 
 export function seekInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: WritableFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): WritableToken<T> | undefined
 
 export function seekInStore<T, K extends Canonical, Key extends K>(
+	store: Store,
 	token: ReadableFamilyToken<T, K>,
 	key: Key,
-	store: Store,
 ): ReadableToken<T> | undefined
 
 export function seekInStore<M extends MoleculeConstructor>(
+	store: Store,
 	token: MoleculeFamilyToken<M>,
 	key: MoleculeKey<M>,
-	store: Store,
 ): MoleculeKey<M> | undefined
 
 export function seekInStore(
+	store: Store,
 	token: MoleculeFamilyToken<any> | ReadableFamilyToken<any, any>,
 	key: Canonical,
-	store: Store,
 ): MoleculeToken<any> | ReadableToken<any> | undefined {
 	const subKey = stringifyJson(key)
 	const fullKey = `${token.key}(${subKey})`

--- a/packages/atom.io/internal/src/get-state/get-from-store.ts
+++ b/packages/atom.io/internal/src/get-state/get-from-store.ts
@@ -19,7 +19,7 @@ export function getFromStore<T>(store: Store, token: ReadableToken<T>): T
 export function getFromStore<M extends MoleculeConstructor>(
 	store: Store,
 	token: MoleculeToken<M>,
-): InstanceType<M> | undefined
+): InstanceType<M>
 
 export function getFromStore<T, K extends Canonical>(
 	store: Store,
@@ -49,10 +49,10 @@ export function getFromStore<T>(
 		const key = params[1]
 		const maybeToken =
 			family.type === `molecule_family`
-				? seekInStore(family, key, store)
+				? seekInStore(store, family, key)
 				: store.config.lifespan === `immortal`
-					? seekInStore(family, key, store)
-					: findInStore(family, key, store)
+					? seekInStore(store, family, key)
+					: findInStore(store, family, key)
 		if (!maybeToken) {
 			store.logger.error(
 				`❗`,

--- a/packages/atom.io/internal/src/get-state/get-from-store.ts
+++ b/packages/atom.io/internal/src/get-state/get-from-store.ts
@@ -14,41 +14,39 @@ import type { Store } from "../store"
 import { withdraw } from "../store"
 import { readOrComputeValue } from "./read-or-compute-value"
 
-export function getFromStore<T>(token: ReadableToken<T>, store: Store): T
+export function getFromStore<T>(store: Store, token: ReadableToken<T>): T
 
 export function getFromStore<M extends MoleculeConstructor>(
-	token: MoleculeToken<M>,
 	store: Store,
+	token: MoleculeToken<M>,
 ): InstanceType<M> | undefined
 
 export function getFromStore<T, K extends Canonical>(
+	store: Store,
 	token: ReadableFamilyToken<T, K>,
 	key: K,
-	store: Store,
 ): T
 
 export function getFromStore<M extends MoleculeConstructor>(
+	store: Store,
 	token: MoleculeFamilyToken<M>,
 	key: MoleculeKey<M>,
-	store: Store,
 ): InstanceType<M>
 
 export function getFromStore<T>(
+	store: Store,
 	...params:
-		| [token: MoleculeFamilyToken<any>, key: MoleculeKey<any>, store: Store]
-		| [token: MoleculeToken<any>, store: Store]
-		| [token: ReadableFamilyToken<T, any>, key: Canonical, store: Store]
-		| [token: ReadableToken<T>, store: Store]
+		| [token: MoleculeFamilyToken<any>, key: MoleculeKey<any>]
+		| [token: MoleculeToken<any>]
+		| [token: ReadableFamilyToken<T, any>, key: Canonical]
+		| [token: ReadableToken<T>]
 ): any {
 	let token: MoleculeToken<any> | ReadableToken<T>
-	let store: Store
-	if (params.length === 2) {
+	if (params.length === 1) {
 		token = params[0]
-		store = params[1]
 	} else {
 		const family = params[0]
 		const key = params[1]
-		store = params[2]
 		const maybeToken =
 			family.type === `molecule_family`
 				? seekInStore(family, key, store)

--- a/packages/atom.io/internal/src/get-state/get-from-store.ts
+++ b/packages/atom.io/internal/src/get-state/get-from-store.ts
@@ -33,15 +33,31 @@ export function getFromStore<M extends MoleculeConstructor>(
 	key: MoleculeKey<M>,
 ): InstanceType<M>
 
-export function getFromStore<T>(
+export function getFromStore(
+	store: Store,
+	token: MoleculeToken<any> | ReadableToken<any>,
+): any
+
+export function getFromStore(
+	store: Store,
+	token: MoleculeFamilyToken<any> | ReadableFamilyToken<any, any>,
+	key: Canonical,
+): any
+
+export function getFromStore(
 	store: Store,
 	...params:
+		| [
+				token: MoleculeFamilyToken<any> | ReadableFamilyToken<any, any>,
+				key: Canonical,
+		  ]
 		| [token: MoleculeFamilyToken<any>, key: MoleculeKey<any>]
+		| [token: MoleculeToken<any> | ReadableToken<any>]
 		| [token: MoleculeToken<any>]
-		| [token: ReadableFamilyToken<T, any>, key: Canonical]
-		| [token: ReadableToken<T>]
+		| [token: ReadableFamilyToken<any, any>, key: Canonical]
+		| [token: ReadableToken<any>]
 ): any {
-	let token: MoleculeToken<any> | ReadableToken<T>
+	let token: MoleculeToken<any> | ReadableToken<any>
 	if (params.length === 1) {
 		token = params[0]
 	} else {

--- a/packages/atom.io/internal/src/ingest-updates/ingest-atom-update.ts
+++ b/packages/atom.io/internal/src/ingest-updates/ingest-atom-update.ts
@@ -14,5 +14,5 @@ export function ingestAtomUpdate(
 	if (atomUpdate.family) {
 		Object.assign(token, { family: atomUpdate.family })
 	}
-	setIntoStore(token, value, store)
+	setIntoStore(store, token, value)
 }

--- a/packages/atom.io/internal/src/ingest-updates/ingest-creation-disposal.ts
+++ b/packages/atom.io/internal/src/ingest-updates/ingest-creation-disposal.ts
@@ -22,7 +22,7 @@ export function ingestCreationEvent(
 			break
 		}
 		case `oldValue`: {
-			disposeFromStore(update.token, store)
+			disposeFromStore(store, update.token)
 			break
 		}
 	}
@@ -35,7 +35,7 @@ export function ingestDisposalEvent(
 ): void {
 	switch (applying) {
 		case `newValue`: {
-			disposeFromStore(update.token, store)
+			disposeFromStore(store, update.token)
 			break
 		}
 		case `oldValue`: {
@@ -79,7 +79,7 @@ export function ingestMoleculeCreationEvent(
 			)
 			break
 		case `oldValue`:
-			disposeFromStore(update.token, store)
+			disposeFromStore(store, update.token)
 			break
 	}
 }
@@ -90,7 +90,7 @@ export function ingestMoleculeDisposalEvent(
 ): void {
 	switch (applying) {
 		case `newValue`:
-			disposeFromStore(update.token, store)
+			disposeFromStore(store, update.token)
 			break
 		case `oldValue`:
 			{

--- a/packages/atom.io/internal/src/ingest-updates/ingest-creation-disposal.ts
+++ b/packages/atom.io/internal/src/ingest-updates/ingest-creation-disposal.ts
@@ -58,7 +58,7 @@ function createInStore(token: ReadableToken<any>, store: Store): void {
 			if (store.config.lifespan === `immortal`) {
 				throw new Error(`No molecule found for key "${token.family.subKey}"`)
 			}
-			initFamilyMemberInStore(family, parseJson(token.family.subKey), store)
+			initFamilyMemberInStore(store, family, parseJson(token.family.subKey))
 		}
 	}
 }

--- a/packages/atom.io/internal/src/molecule/create-molecule-family.ts
+++ b/packages/atom.io/internal/src/molecule/create-molecule-family.ts
@@ -10,8 +10,8 @@ import type { Store } from "../store"
 import { Subject } from "../subject"
 
 export function createMoleculeFamily<M extends MoleculeConstructor>(
-	options: MoleculeFamilyOptions<M>,
 	store: Store,
+	options: MoleculeFamilyOptions<M>,
 ): MoleculeFamilyToken<M> {
 	const subject = new Subject<MoleculeCreation<M>>()
 

--- a/packages/atom.io/internal/src/molecule/dispose-molecule.ts
+++ b/packages/atom.io/internal/src/molecule/dispose-molecule.ts
@@ -55,7 +55,7 @@ export function disposeMolecule<M extends MoleculeConstructor>(
 			disposalEvent.family = token.family
 		}
 		for (const state of molecule.tokens.values()) {
-			disposeFromStore(state, store)
+			disposeFromStore(store, state)
 		}
 		for (const child of molecule.below.values()) {
 			if (child.family?.dependsOn === `all`) {

--- a/packages/atom.io/internal/src/molecule/grow-molecule-in-store.ts
+++ b/packages/atom.io/internal/src/molecule/grow-molecule-in-store.ts
@@ -83,7 +83,7 @@ export function growMoleculeInStore(
 	family: ReadableFamilyToken<any, any>,
 	store: Store,
 ): ReadableToken<any> {
-	const stateToken = initFamilyMemberInStore(family, molecule.key, store)
+	const stateToken = initFamilyMemberInStore(store, family, molecule.key)
 	molecule.tokens.set(stateToken.key, stateToken)
 	const isTransaction =
 		isChildStore(store) && store.transactionMeta.phase === `building`

--- a/packages/atom.io/internal/src/molecule/make-molecule-in-store.ts
+++ b/packages/atom.io/internal/src/molecule/make-molecule-in-store.ts
@@ -78,7 +78,7 @@ export function makeMoleculeInStore<M extends MoleculeConstructor>(
 		make: (ctx, f, k, ...args) =>
 			makeMoleculeInStore(newest(rootStore), ctx, f, k, ...args),
 		dispose: (t) => {
-			disposeFromStore(t, newest(rootStore))
+			disposeFromStore(newest(rootStore), t)
 		},
 		env: () => getEnvironmentData(newest(rootStore)),
 		bond: ((

--- a/packages/atom.io/internal/src/molecule/make-molecule-in-store.ts
+++ b/packages/atom.io/internal/src/molecule/make-molecule-in-store.ts
@@ -68,7 +68,7 @@ export function makeMoleculeInStore<M extends MoleculeConstructor>(
 
 	const toolkit = {
 		get: ((...ps: Parameters<typeof getState>) =>
-			getFromStore(...ps, newest(rootStore))) as typeof getState,
+			getFromStore(newest(rootStore), ...ps)) as typeof getState,
 		set: ((...ps: Parameters<typeof setState>) => {
 			setIntoStore(...ps, newest(rootStore))
 		}) as typeof setState,

--- a/packages/atom.io/internal/src/molecule/make-molecule-in-store.ts
+++ b/packages/atom.io/internal/src/molecule/make-molecule-in-store.ts
@@ -70,7 +70,7 @@ export function makeMoleculeInStore<M extends MoleculeConstructor>(
 		get: ((...ps: Parameters<typeof getState>) =>
 			getFromStore(newest(rootStore), ...ps)) as typeof getState,
 		set: ((...ps: Parameters<typeof setState>) => {
-			setIntoStore(...ps, newest(rootStore))
+			setIntoStore(newest(rootStore), ...ps)
 		}) as typeof setState,
 		seek: ((t, k) => seekInStore(t, k, newest(rootStore))) as typeof seekState,
 		json: (t) => getJsonToken(t, newest(rootStore)),

--- a/packages/atom.io/internal/src/molecule/make-molecule-in-store.ts
+++ b/packages/atom.io/internal/src/molecule/make-molecule-in-store.ts
@@ -72,8 +72,8 @@ export function makeMoleculeInStore<M extends MoleculeConstructor>(
 		set: ((...ps: Parameters<typeof setState>) => {
 			setIntoStore(newest(rootStore), ...ps)
 		}) as typeof setState,
-		seek: ((t, k) => seekInStore(t, k, newest(rootStore))) as typeof seekState,
-		json: (t) => getJsonToken(t, newest(rootStore)),
+		seek: ((t, k) => seekInStore(newest(rootStore), t, k)) as typeof seekState,
+		json: (t) => getJsonToken(newest(rootStore), t),
 		run: (t, i = arbitrary()) => actUponStore(t, i, newest(store)),
 		make: (ctx, f, k, ...args) =>
 			makeMoleculeInStore(newest(rootStore), ctx, f, k, ...args),

--- a/packages/atom.io/internal/src/mutable/create-mutable-atom-family.ts
+++ b/packages/atom.io/internal/src/mutable/create-mutable-atom-family.ts
@@ -24,8 +24,8 @@ export function createMutableAtomFamily<
 	J extends Json.Serializable,
 	K extends string,
 >(
-	options: MutableAtomFamilyOptions<T, J, K>,
 	store: Store,
+	options: MutableAtomFamilyOptions<T, J, K>,
 	internalRoles?: string[],
 ): MutableAtomFamilyToken<T, J, K> {
 	const familyToken = {
@@ -56,7 +56,7 @@ export function createMutableAtomFamily<
 			individualOptions.effects = options.effects(key)
 		}
 
-		const token = createMutableAtom(individualOptions, family, target)
+		const token = createMutableAtom(target, individualOptions, family)
 
 		subject.next({ type: `state_creation`, token })
 		return token
@@ -64,7 +64,7 @@ export function createMutableAtomFamily<
 
 	const atomFamily = Object.assign(familyFunction, familyToken, {
 		subject,
-		install: (s: Store) => createMutableAtomFamily(options, s),
+		install: (s: Store) => createMutableAtomFamily(s, options),
 		toJson: options.toJson,
 		fromJson: options.fromJson,
 		internalRoles,

--- a/packages/atom.io/internal/src/mutable/create-mutable-atom.ts
+++ b/packages/atom.io/internal/src/mutable/create-mutable-atom.ts
@@ -20,9 +20,9 @@ export function createMutableAtom<
 	T extends Transceiver<any>,
 	J extends Json.Serializable,
 >(
+	store: Store,
 	options: MutableAtomOptions<T, J>,
 	family: FamilyMetadata | undefined,
-	store: Store,
 ): MutableAtomToken<T, J> {
 	store.logger.info(
 		`🔨`,
@@ -52,7 +52,7 @@ export function createMutableAtom<
 				options.key,
 				`installing in store "${s.config.name}"`,
 			)
-			return createMutableAtom(options, family, s)
+			return createMutableAtom(s, options, family)
 		},
 		subject,
 	} as const

--- a/packages/atom.io/internal/src/mutable/create-mutable-atom.ts
+++ b/packages/atom.io/internal/src/mutable/create-mutable-atom.ts
@@ -70,7 +70,7 @@ export function createMutableAtom<
 		for (const effect of options.effects) {
 			const cleanup = effect({
 				setSelf: (next) => {
-					setIntoStore(token, next, store)
+					setIntoStore(store, token, next)
 				},
 				onSet: (handle: UpdateHandler<T>) =>
 					subscribeToState(token, handle, `effect[${effectIndex}]`, store),

--- a/packages/atom.io/internal/src/mutable/get-json-token.ts
+++ b/packages/atom.io/internal/src/mutable/get-json-token.ts
@@ -14,8 +14,8 @@ export const getJsonToken = <
 	Core extends Transceiver<any>,
 	SerializableCore extends Json.Serializable,
 >(
-	mutableAtomToken: MutableAtomToken<Core, SerializableCore>,
 	store: Store,
+	mutableAtomToken: MutableAtomToken<Core, SerializableCore>,
 ): WritableSelectorToken<SerializableCore> => {
 	if (mutableAtomToken.family) {
 		const target = newest(store)
@@ -29,7 +29,7 @@ export const getJsonToken = <
 		}
 		const family = withdraw(jsonFamilyToken, target)
 		const subKey = JSON.parse(mutableAtomToken.family.subKey)
-		const jsonToken = findInStore(family, subKey, store)
+		const jsonToken = findInStore(store, family, subKey)
 		return jsonToken
 	}
 	const token: WritableSelectorToken<SerializableCore> = {

--- a/packages/atom.io/internal/src/mutable/tracker-family.ts
+++ b/packages/atom.io/internal/src/mutable/tracker-family.ts
@@ -43,7 +43,7 @@ export class FamilyTracker<
 			(event) => {
 				if (event.token.family) {
 					const key = parseJson(event.token.family.subKey) as FamilyMemberKey
-					seekInStore(this.latestUpdateAtoms, key, store)
+					seekInStore(store, this.latestUpdateAtoms, key)
 					new Tracker<Core>(event.token, store)
 				}
 			},
@@ -53,7 +53,7 @@ export class FamilyTracker<
 			(event) => {
 				if (event.token.family) {
 					const key = parseJson(event.token.family.subKey) as FamilyMemberKey
-					const mutableAtomToken = seekInStore(this.mutableAtoms, key, store)
+					const mutableAtomToken = seekInStore(store, this.mutableAtoms, key)
 					if (mutableAtomToken) {
 						new Tracker<Core>(mutableAtomToken, store)
 					}

--- a/packages/atom.io/internal/src/mutable/tracker-family.ts
+++ b/packages/atom.io/internal/src/mutable/tracker-family.ts
@@ -29,11 +29,11 @@ export class FamilyTracker<
 			typeof this.Update | null,
 			FamilyMemberKey
 		>(
+			store,
 			{
 				key: `*${mutableAtoms.key}`,
 				default: null,
 			},
-			store,
 			[`mutable`, `updates`],
 		)
 		this.latestUpdateAtoms = withdraw(updateAtoms, store)

--- a/packages/atom.io/internal/src/mutable/tracker.ts
+++ b/packages/atom.io/internal/src/mutable/tracker.ts
@@ -37,12 +37,12 @@ export class Tracker<Mutable extends Transceiver<any>> {
 		const latestUpdateState = createRegularAtom<
 			(Mutable extends Transceiver<infer Signal> ? Signal : never) | null
 		>(
+			store,
 			{
 				key: latestUpdateStateKey,
 				default: null,
 			},
 			familyMetaData,
-			store,
 		)
 		if (store.parent?.valueMap.has(latestUpdateStateKey)) {
 			const parentValue = store.parent.valueMap.get(latestUpdateStateKey)

--- a/packages/atom.io/internal/src/mutable/tracker.ts
+++ b/packages/atom.io/internal/src/mutable/tracker.ts
@@ -62,7 +62,7 @@ export class Tracker<Mutable extends Transceiver<any>> {
 		const subscriptionKey = `tracker:${target.config.name}:${
 			isChildStore(target) ? target.transactionMeta.update.key : `main`
 		}:${mutableState.key}`
-		const originalInnerValue = getFromStore(mutableState, target)
+		const originalInnerValue = getFromStore(target, mutableState)
 		this.unsubscribeFromInnerValue = originalInnerValue.subscribe(
 			subscriptionKey,
 			(update) => {
@@ -133,7 +133,7 @@ export class Tracker<Mutable extends Transceiver<any>> {
 					subscriptionKey,
 					() => {
 						unsubscribe()
-						const mutable = getFromStore(mutableState, target)
+						const mutable = getFromStore(target, mutableState)
 						const updateNumber =
 							newValue === null ? -1 : mutable.getUpdateNumber(newValue)
 						const eventOffset = updateNumber - mutable.cacheUpdateNumber

--- a/packages/atom.io/internal/src/mutable/tracker.ts
+++ b/packages/atom.io/internal/src/mutable/tracker.ts
@@ -66,7 +66,7 @@ export class Tracker<Mutable extends Transceiver<any>> {
 		this.unsubscribeFromInnerValue = originalInnerValue.subscribe(
 			subscriptionKey,
 			(update) => {
-				setIntoStore(latestUpdateState, update, target)
+				setIntoStore(target, latestUpdateState, update)
 			},
 		)
 		this.unsubscribeFromState = subscribeToState(
@@ -77,7 +77,7 @@ export class Tracker<Mutable extends Transceiver<any>> {
 					this.unsubscribeFromInnerValue = update.newValue.subscribe(
 						subscriptionKey,
 						(transceiverUpdate) => {
-							setIntoStore(latestUpdateState, transceiverUpdate, target)
+							setIntoStore(target, latestUpdateState, transceiverUpdate)
 						},
 					)
 				}
@@ -109,18 +109,14 @@ export class Tracker<Mutable extends Transceiver<any>> {
 							{ key: timelineId, type: `timeline` },
 							(update) => {
 								unsubscribe()
-								setIntoStore(
-									mutableState,
-									(transceiver) => {
-										if (update === `redo` && newValue) {
-											transceiver.do(newValue)
-										} else if (update === `undo` && oldValue) {
-											transceiver.undo(oldValue)
-										}
-										return transceiver
-									},
-									target,
-								)
+								setIntoStore(target, mutableState, (transceiver) => {
+									if (update === `redo` && newValue) {
+										transceiver.do(newValue)
+									} else if (update === `undo` && oldValue) {
+										transceiver.undo(oldValue)
+									}
+									return transceiver
+								})
 							},
 							subscriptionKey,
 							target,
@@ -139,9 +135,9 @@ export class Tracker<Mutable extends Transceiver<any>> {
 						const eventOffset = updateNumber - mutable.cacheUpdateNumber
 						if (newValue && eventOffset === 1) {
 							setIntoStore(
+								target,
 								mutableState,
 								(transceiver) => (transceiver.do(newValue), transceiver),
-								target,
 							)
 						} else {
 							target.logger.info(

--- a/packages/atom.io/internal/src/selector/create-readonly-selector.ts
+++ b/packages/atom.io/internal/src/selector/create-readonly-selector.ts
@@ -12,9 +12,9 @@ import { Subject } from "../subject"
 import { registerSelector } from "./register-selector"
 
 export const createReadonlySelector = <T>(
+	store: Store,
 	options: ReadonlySelectorOptions<T>,
 	family: FamilyMetadata | undefined,
-	store: Store,
 ): ReadonlySelectorToken<T> => {
 	const target = newest(store)
 	const subject = new Subject<{ newValue: T; oldValue: T }>()
@@ -34,7 +34,7 @@ export const createReadonlySelector = <T>(
 	const readonlySelector: ReadonlySelector<T> = {
 		...options,
 		subject,
-		install: (s: Store) => createReadonlySelector(options, family, s),
+		install: (s: Store) => createReadonlySelector(s, options, family),
 		get: getSelf,
 		type: `readonly_selector`,
 		...(family && { family }),

--- a/packages/atom.io/internal/src/selector/create-standalone-selector.ts
+++ b/packages/atom.io/internal/src/selector/create-standalone-selector.ts
@@ -10,25 +10,25 @@ import { createReadonlySelector } from "./create-readonly-selector"
 import { createWritableSelector } from "./create-writable-selector"
 
 export function createStandaloneSelector<T>(
-	options: WritableSelectorOptions<T>,
 	store: Store,
+	options: WritableSelectorOptions<T>,
 ): WritableSelectorToken<T>
 export function createStandaloneSelector<T>(
-	options: ReadonlySelectorOptions<T>,
 	store: Store,
+	options: ReadonlySelectorOptions<T>,
 ): ReadonlySelectorToken<T>
 export function createStandaloneSelector<T>(
-	options: ReadonlySelectorOptions<T> | WritableSelectorOptions<T>,
 	store: Store,
+	options: ReadonlySelectorOptions<T> | WritableSelectorOptions<T>,
 ): ReadonlySelectorToken<T> | WritableSelectorToken<T> {
 	const isWritable = `set` in options
 
 	if (isWritable) {
-		const state = createWritableSelector(options, undefined, store)
+		const state = createWritableSelector(store, options, undefined)
 		store.on.selectorCreation.next(state)
 		return state
 	}
-	const state = createReadonlySelector(options, undefined, store)
+	const state = createReadonlySelector(store, options, undefined)
 	store.on.selectorCreation.next(state)
 	return state
 }

--- a/packages/atom.io/internal/src/selector/create-writable-selector.ts
+++ b/packages/atom.io/internal/src/selector/create-writable-selector.ts
@@ -15,9 +15,9 @@ import { isRootStore } from "../transaction"
 import { registerSelector } from "./register-selector"
 
 export const createWritableSelector = <T>(
+	store: Store,
 	options: WritableSelectorOptions<T>,
 	family: FamilyMetadata | undefined,
-	store: Store,
 ): WritableSelectorToken<T> => {
 	const target = newest(store)
 	const subject = new Subject<{ newValue: T; oldValue: T }>()
@@ -57,7 +57,7 @@ export const createWritableSelector = <T>(
 	const mySelector: WritableSelector<T> = {
 		...options,
 		subject,
-		install: (s: Store) => createWritableSelector(options, family, s),
+		install: (s: Store) => createWritableSelector(s, options, family),
 		get: getSelf,
 		set: setSelf,
 		type: `selector`,

--- a/packages/atom.io/internal/src/selector/register-selector.ts
+++ b/packages/atom.io/internal/src/selector/register-selector.ts
@@ -46,9 +46,9 @@ export const registerSelector = (
 					return getFromStore(store, family, key)
 				default:
 					if (store.config.lifespan === `ephemeral`) {
-						dependency = findInStore(family, key, store)
+						dependency = findInStore(store, family, key)
 					} else {
-						const maybeDependency = seekInStore(family, key, store)
+						const maybeDependency = seekInStore(store, family, key)
 						if (maybeDependency) {
 							dependency = maybeDependency
 						} else {
@@ -108,8 +108,8 @@ export const registerSelector = (
 			value = params[2]
 			const maybeToken =
 				store.config.lifespan === `ephemeral`
-					? findInStore(family, key, store)
-					: seekInStore(family, key, store)
+					? findInStore(store, family, key)
+					: seekInStore(store, family, key)
 			if (!maybeToken) {
 				throw new NotFoundError(family, key, store)
 			}
@@ -119,7 +119,7 @@ export const registerSelector = (
 		const state = withdraw(token, target)
 		setAtomOrSelector(state, value, target)
 	}) as typeof setState,
-	find: ((token, key) => findInStore(token, key, store)) as typeof findState,
-	seek: ((token, key) => seekInStore(token, key, store)) as typeof seekState,
-	json: (token) => getJsonToken(token, store),
+	find: ((token, key) => findInStore(store, token, key)) as typeof findState,
+	seek: ((token, key) => seekInStore(store, token, key)) as typeof seekState,
+	json: (token) => getJsonToken(store, token),
 })

--- a/packages/atom.io/internal/src/selector/register-selector.ts
+++ b/packages/atom.io/internal/src/selector/register-selector.ts
@@ -43,7 +43,7 @@ export const registerSelector = (
 			const [family, key] = params
 			switch (family.type) {
 				case `molecule_family`:
-					return getFromStore(family, key, store)
+					return getFromStore(store, family, key)
 				default:
 					if (store.config.lifespan === `ephemeral`) {
 						dependency = findInStore(family, key, store)
@@ -61,7 +61,7 @@ export const registerSelector = (
 		}
 
 		if (dependency.type === `molecule`) {
-			return getFromStore(dependency, store)
+			return getFromStore(store, dependency)
 		}
 
 		const dependencyState = withdraw(dependency, store)

--- a/packages/atom.io/internal/src/set-state/set-into-store.ts
+++ b/packages/atom.io/internal/src/set-state/set-into-store.ts
@@ -41,8 +41,8 @@ export function setIntoStore<T, New extends T>(
 		value = params[2]
 		const maybeToken =
 			store.config.lifespan === `ephemeral`
-				? findInStore(family, key, store)
-				: seekInStore(family, key, store)
+				? findInStore(store, family, key)
+				: seekInStore(store, family, key)
 		if (!maybeToken) {
 			store.logger.error(
 				`❗`,

--- a/packages/atom.io/internal/src/set-state/set-into-store.ts
+++ b/packages/atom.io/internal/src/set-state/set-into-store.ts
@@ -2,51 +2,43 @@ import type { WritableFamilyToken, WritableToken } from "atom.io"
 import { type Canonical, stringifyJson } from "atom.io/json"
 
 import { findInStore, seekInStore } from "../families"
-import { NotFoundError } from "../not-found-error"
 import { closeOperation, openOperation } from "../operation"
 import type { Store } from "../store"
 import { withdraw } from "../store"
 import { setAtomOrSelector } from "./set-atom-or-selector"
 
 export function setIntoStore<T, New extends T>(
+	store: Store,
 	token: WritableToken<T>,
 	value: New | ((oldValue: T) => New),
-	store: Store,
 ): void
 
 export function setIntoStore<T, K extends Canonical, New extends T>(
+	store: Store,
 	token: WritableFamilyToken<T, K>,
 	key: K,
 	value: New | ((oldValue: T) => New),
-	store: Store,
 ): void
 
 export function setIntoStore<T, New extends T>(
+	store: Store,
 	...params:
 		| [
 				token: WritableFamilyToken<T, Canonical>,
 				key: Canonical,
 				value: New | ((oldValue: T) => New),
-				store: Store,
 		  ]
-		| [
-				token: WritableToken<T>,
-				value: New | ((oldValue: T) => New),
-				store: Store,
-		  ]
+		| [token: WritableToken<T>, value: New | ((oldValue: T) => New)]
 ): void {
 	let token: WritableToken<T>
 	let value: New | ((oldValue: T) => New)
-	let store: Store
-	if (params.length === 3) {
+	if (params.length === 2) {
 		token = params[0]
 		value = params[1]
-		store = params[2]
 	} else {
 		const family = params[0]
 		const key = params[1]
 		value = params[2]
-		store = params[3]
 		const maybeToken =
 			store.config.lifespan === `ephemeral`
 				? findInStore(family, key, store)
@@ -80,7 +72,7 @@ export function setIntoStore<T, New extends T>(
 					token.key,
 					`resuming deferred setState from T-${rejectionTime}`,
 				)
-				setIntoStore(token, value, store)
+				setIntoStore(store, token, value)
 			},
 		)
 		return

--- a/packages/atom.io/internal/src/store/store.ts
+++ b/packages/atom.io/internal/src/store/store.ts
@@ -176,7 +176,7 @@ export class Store implements Lineage {
 				}
 				atom.install(this)
 				if (atom.type === `mutable_atom`) {
-					const originalJsonToken = getJsonToken(atom, store)
+					const originalJsonToken = getJsonToken(store, atom)
 					const originalUpdateToken = getUpdateToken(atom)
 					mutableHelpers.add(originalJsonToken.key)
 					mutableHelpers.add(originalUpdateToken.key)

--- a/packages/atom.io/internal/src/subscribe/index.ts
+++ b/packages/atom.io/internal/src/subscribe/index.ts
@@ -1,3 +1,5 @@
+export * from "./recall-state"
+export * from "./subscribe-in-store"
 export * from "./subscribe-to-root-atoms"
 export * from "./subscribe-to-state"
 export * from "./subscribe-to-timeline"

--- a/packages/atom.io/internal/src/subscribe/subscribe-in-store.ts
+++ b/packages/atom.io/internal/src/subscribe/subscribe-in-store.ts
@@ -1,0 +1,62 @@
+import type {
+	ReadableToken,
+	TimelineManageable,
+	TimelineToken,
+	TimelineUpdate,
+	TransactionToken,
+	TransactionUpdateHandler,
+	UpdateHandler,
+} from "atom.io"
+import type { Func, Store } from "atom.io/internal"
+import {
+	arbitrary,
+	subscribeToState,
+	subscribeToTimeline,
+	subscribeToTransaction,
+} from "atom.io/internal"
+
+export function subscribeInStore<T>(
+	store: Store,
+	token: ReadableToken<T>,
+	handleUpdate: UpdateHandler<T>,
+	key?: string,
+): () => void
+export function subscribeInStore<F extends Func>(
+	store: Store,
+	token: TransactionToken<F>,
+	handleUpdate: TransactionUpdateHandler<F>,
+	key?: string,
+): () => void
+export function subscribeInStore<M extends TimelineManageable>(
+	store: Store,
+	token: TimelineToken<M>,
+	handleUpdate: (update: TimelineUpdate<M> | `redo` | `undo`) => void,
+	key?: string,
+): () => void
+export function subscribeInStore<M extends TimelineManageable>(
+	store: Store,
+	token: ReadableToken<any> | TimelineToken<M> | TransactionToken<any>,
+	handleUpdate:
+		| TransactionUpdateHandler<any>
+		| UpdateHandler<any>
+		| ((update: TimelineUpdate<M> | `redo` | `undo`) => void),
+	key?: string,
+): () => void
+export function subscribeInStore(
+	store: Store,
+	token: ReadableToken<any> | TimelineToken<any> | TransactionToken<any>,
+	handleUpdate: (update: any) => void,
+	key: string = arbitrary(),
+): () => void {
+	switch (token.type) {
+		case `atom`:
+		case `mutable_atom`:
+		case `readonly_selector`:
+		case `selector`:
+			return subscribeToState(token, handleUpdate, key, store)
+		case `transaction`:
+			return subscribeToTransaction(token, handleUpdate, key, store)
+		case `timeline`:
+			return subscribeToTimeline(token, handleUpdate, key, store)
+	}
+}

--- a/packages/atom.io/internal/src/timeline/time-travel.ts
+++ b/packages/atom.io/internal/src/timeline/time-travel.ts
@@ -12,9 +12,9 @@ import {
 import type { Store } from "../store"
 
 export const timeTravel = (
+	store: Store,
 	action: `redo` | `undo`,
 	token: TimelineToken<any>,
-	store: Store,
 ): void => {
 	store.logger.info(
 		action === `redo` ? `⏩` : `⏪`,

--- a/packages/atom.io/internal/src/transaction/build-transaction.ts
+++ b/packages/atom.io/internal/src/transaction/build-transaction.ts
@@ -80,7 +80,7 @@ export const buildTransaction = (
 			make: (context, family, k, ...args) =>
 				makeMoleculeInStore(child, context, family, k, ...args),
 			dispose: ((...ps: Parameters<typeof disposeState>) => {
-				disposeFromStore(...ps, child)
+				disposeFromStore(child, ...ps)
 			}) as typeof disposeState,
 			env: () => getEnvironmentData(child),
 		},

--- a/packages/atom.io/internal/src/transaction/build-transaction.ts
+++ b/packages/atom.io/internal/src/transaction/build-transaction.ts
@@ -68,7 +68,7 @@ export const buildTransaction = (
 		},
 		toolkit: {
 			get: ((...ps: Parameters<typeof getState>) =>
-				getFromStore(...ps, child)) as typeof getState,
+				getFromStore(child, ...ps)) as typeof getState,
 			set: ((...ps: Parameters<typeof setState>) => {
 				setIntoStore(...ps, child)
 			}) as typeof setState,

--- a/packages/atom.io/internal/src/transaction/build-transaction.ts
+++ b/packages/atom.io/internal/src/transaction/build-transaction.ts
@@ -70,7 +70,7 @@ export const buildTransaction = (
 			get: ((...ps: Parameters<typeof getState>) =>
 				getFromStore(child, ...ps)) as typeof getState,
 			set: ((...ps: Parameters<typeof setState>) => {
-				setIntoStore(...ps, child)
+				setIntoStore(child, ...ps)
 			}) as typeof setState,
 			run: (token, identifier = arbitrary()) =>
 				actUponStore(token, identifier, child),

--- a/packages/atom.io/internal/src/transaction/build-transaction.ts
+++ b/packages/atom.io/internal/src/transaction/build-transaction.ts
@@ -74,9 +74,9 @@ export const buildTransaction = (
 			}) as typeof setState,
 			run: (token, identifier = arbitrary()) =>
 				actUponStore(token, identifier, child),
-			find: ((token, k) => findInStore(token, k, child)) as typeof findState,
-			seek: ((token, k) => seekInStore(token, k, child)) as typeof seekState,
-			json: (token) => getJsonToken(token, child),
+			find: ((token, k) => findInStore(child, token, k)) as typeof findState,
+			seek: ((token, k) => seekInStore(child, token, k)) as typeof seekState,
+			json: (token) => getJsonToken(child, token),
 			make: (context, family, k, ...args) =>
 				makeMoleculeInStore(child, context, family, k, ...args),
 			dispose: ((...ps: Parameters<typeof disposeState>) => {

--- a/packages/atom.io/introspection/src/attach-atom-index.ts
+++ b/packages/atom.io/introspection/src/attach-atom-index.ts
@@ -90,11 +90,8 @@ export const attachAtomIndex = (
 		},
 		undefined,
 	)
-	return createStandaloneSelector(
-		{
-			key: `👁‍🗨 Atom Token Index`,
-			get: ({ get }) => get(atomTokenIndexState__INTERNAL),
-		},
-		store,
-	)
+	return createStandaloneSelector(store, {
+		key: `👁‍🗨 Atom Token Index`,
+		get: ({ get }) => get(atomTokenIndexState__INTERNAL),
+	})
 }

--- a/packages/atom.io/introspection/src/attach-atom-index.ts
+++ b/packages/atom.io/introspection/src/attach-atom-index.ts
@@ -15,6 +15,7 @@ export const attachAtomIndex = (
 	store: Store = IMPLICIT.STORE,
 ): ReadonlySelectorToken<AtomTokenIndex> => {
 	const atomTokenIndexState__INTERNAL = createRegularAtom<AtomTokenIndex>(
+		store,
 		{
 			key: `👁‍🗨 Atom Token Index (Internal)`,
 			default: () => {
@@ -88,7 +89,6 @@ export const attachAtomIndex = (
 			],
 		},
 		undefined,
-		store,
 	)
 	return createStandaloneSelector(
 		{

--- a/packages/atom.io/introspection/src/attach-selector-index.ts
+++ b/packages/atom.io/introspection/src/attach-selector-index.ts
@@ -16,6 +16,8 @@ export const attachSelectorIndex = (
 ): ReadonlySelectorToken<SelectorTokenIndex> => {
 	const readonlySelectorTokenIndexState__INTERNAL =
 		createRegularAtom<SelectorTokenIndex>(
+			store,
+
 			{
 				key: `👁‍🗨 Selector Token Index (Internal)`,
 				default: () => {
@@ -98,7 +100,6 @@ export const attachSelectorIndex = (
 				],
 			},
 			undefined,
-			store,
 		)
 	return createStandaloneSelector(
 		{

--- a/packages/atom.io/introspection/src/attach-selector-index.ts
+++ b/packages/atom.io/introspection/src/attach-selector-index.ts
@@ -101,11 +101,8 @@ export const attachSelectorIndex = (
 			},
 			undefined,
 		)
-	return createStandaloneSelector(
-		{
-			key: `👁‍🗨 Selector Token Index`,
-			get: ({ get }) => get(readonlySelectorTokenIndexState__INTERNAL),
-		},
-		IMPLICIT.STORE,
-	)
+	return createStandaloneSelector(IMPLICIT.STORE, {
+		key: `👁‍🗨 Selector Token Index`,
+		get: ({ get }) => get(readonlySelectorTokenIndexState__INTERNAL),
+	})
 }

--- a/packages/atom.io/introspection/src/attach-timeline-family.ts
+++ b/packages/atom.io/introspection/src/attach-timeline-family.ts
@@ -13,33 +13,30 @@ export const attachTimelineFamily = (
 	const findTimelineLogState__INTERNAL = createRegularAtomFamily<
 		Timeline<any>,
 		string
-	>(
-		{
-			key: `👁‍🗨 Timeline Update Log (Internal)`,
-			default: (key) =>
-				store.timelines.get(key) ?? {
-					type: `timeline`,
-					key: ``,
-					at: 0,
-					timeTraveling: null,
-					history: [],
-					selectorTime: null,
-					transactionKey: null,
-					install: () => {},
-					subject: new Subject(),
-					subscriptions: new Map(),
-				},
-			effects: (key) => [
-				({ setSelf }) => {
-					const tl = store.timelines.get(key)
-					tl?.subject.subscribe(`introspection`, (_) => {
-						setSelf({ ...tl })
-					})
-				},
-			],
-		},
-		store,
-	)
+	>(store, {
+		key: `👁‍🗨 Timeline Update Log (Internal)`,
+		default: (key) =>
+			store.timelines.get(key) ?? {
+				type: `timeline`,
+				key: ``,
+				at: 0,
+				timeTraveling: null,
+				history: [],
+				selectorTime: null,
+				transactionKey: null,
+				install: () => {},
+				subject: new Subject(),
+				subscriptions: new Map(),
+			},
+		effects: (key) => [
+			({ setSelf }) => {
+				const tl = store.timelines.get(key)
+				tl?.subject.subscribe(`introspection`, (_) => {
+					setSelf({ ...tl })
+				})
+			},
+		],
+	})
 	const findTimelineLogState = createSelectorFamily<Timeline<any>, string>(
 		{
 			key: `👁‍🗨 Timeline Update Log`,

--- a/packages/atom.io/introspection/src/attach-timeline-family.ts
+++ b/packages/atom.io/introspection/src/attach-timeline-family.ts
@@ -38,6 +38,7 @@ export const attachTimelineFamily = (
 		],
 	})
 	const findTimelineLogState = createSelectorFamily<Timeline<any>, string>(
+		store,
 		{
 			key: `👁‍🗨 Timeline Update Log`,
 			get:
@@ -45,7 +46,6 @@ export const attachTimelineFamily = (
 				({ get }) =>
 					get(findTimelineLogState__INTERNAL, key),
 		},
-		store,
 	)
 	return findTimelineLogState
 }

--- a/packages/atom.io/introspection/src/attach-timeline-index.ts
+++ b/packages/atom.io/introspection/src/attach-timeline-index.ts
@@ -32,12 +32,9 @@ export const attachTimelineIndex = (
 		},
 		undefined,
 	)
-	const timelineTokenIndex = createStandaloneSelector(
-		{
-			key: `👁‍🗨 Timeline Token Index`,
-			get: ({ get }) => get(timelineTokenIndexState__INTERNAL),
-		},
-		store,
-	)
+	const timelineTokenIndex = createStandaloneSelector(store, {
+		key: `👁‍🗨 Timeline Token Index`,
+		get: ({ get }) => get(timelineTokenIndexState__INTERNAL),
+	})
 	return timelineTokenIndex
 }

--- a/packages/atom.io/introspection/src/attach-timeline-index.ts
+++ b/packages/atom.io/introspection/src/attach-timeline-index.ts
@@ -12,6 +12,7 @@ export const attachTimelineIndex = (
 	const timelineTokenIndexState__INTERNAL = createRegularAtom<
 		TimelineToken<any>[]
 	>(
+		store,
 		{
 			key: `👁‍🗨 Timeline Token Index (Internal)`,
 			default: () =>
@@ -30,7 +31,6 @@ export const attachTimelineIndex = (
 			],
 		},
 		undefined,
-		store,
 	)
 	const timelineTokenIndex = createStandaloneSelector(
 		{

--- a/packages/atom.io/introspection/src/attach-transaction-index.ts
+++ b/packages/atom.io/introspection/src/attach-transaction-index.ts
@@ -32,12 +32,9 @@ export const attachTransactionIndex = (
 		},
 		undefined,
 	)
-	const transactionTokenIndex = createStandaloneSelector(
-		{
-			key: `👁‍🗨 Transaction Token Index`,
-			get: ({ get }) => get(transactionTokenIndexState__INTERNAL),
-		},
-		store,
-	)
+	const transactionTokenIndex = createStandaloneSelector(store, {
+		key: `👁‍🗨 Transaction Token Index`,
+		get: ({ get }) => get(transactionTokenIndexState__INTERNAL),
+	})
 	return transactionTokenIndex
 }

--- a/packages/atom.io/introspection/src/attach-transaction-index.ts
+++ b/packages/atom.io/introspection/src/attach-transaction-index.ts
@@ -12,6 +12,7 @@ export const attachTransactionIndex = (
 	const transactionTokenIndexState__INTERNAL = createRegularAtom<
 		TransactionToken<Func>[]
 	>(
+		store,
 		{
 			key: `👁‍🗨 Transaction Token Index (Internal)`,
 			default: () =>
@@ -30,7 +31,6 @@ export const attachTransactionIndex = (
 			],
 		},
 		undefined,
-		store,
 	)
 	const transactionTokenIndex = createStandaloneSelector(
 		{

--- a/packages/atom.io/introspection/src/attach-transaction-logs.ts
+++ b/packages/atom.io/introspection/src/attach-transaction-logs.ts
@@ -12,23 +12,20 @@ export const attachTransactionLogs = (
 	const transactionUpdateLogAtoms = createRegularAtomFamily<
 		TransactionUpdate<Func>[],
 		string
-	>(
-		{
-			key: `👁‍🗨 Transaction Update Log (Internal)`,
-			default: () => [],
-			effects: (key) => [
-				({ setSelf }) => {
-					const tx = store.transactions.get(key)
-					tx?.subject.subscribe(`introspection`, (transactionUpdate) => {
-						if (transactionUpdate.key === key) {
-							setSelf((state) => [...state, transactionUpdate])
-						}
-					})
-				},
-			],
-		},
-		store,
-	)
+	>(store, {
+		key: `👁‍🗨 Transaction Update Log (Internal)`,
+		default: () => [],
+		effects: (key) => [
+			({ setSelf }) => {
+				const tx = store.transactions.get(key)
+				tx?.subject.subscribe(`introspection`, (transactionUpdate) => {
+					if (transactionUpdate.key === key) {
+						setSelf((state) => [...state, transactionUpdate])
+					}
+				})
+			},
+		],
+	})
 	const findTransactionUpdateLogState = createSelectorFamily<
 		TransactionUpdate<Func>[],
 		string

--- a/packages/atom.io/introspection/src/attach-transaction-logs.ts
+++ b/packages/atom.io/introspection/src/attach-transaction-logs.ts
@@ -29,15 +29,12 @@ export const attachTransactionLogs = (
 	const findTransactionUpdateLogState = createSelectorFamily<
 		TransactionUpdate<Func>[],
 		string
-	>(
-		{
-			key: `👁‍🗨 Transaction Update Log`,
-			get:
-				(key) =>
-				({ get }) =>
-					get(transactionUpdateLogAtoms, key),
-		},
-		store,
-	)
+	>(store, {
+		key: `👁‍🗨 Transaction Update Log`,
+		get:
+			(key) =>
+			({ get }) =>
+				get(transactionUpdateLogAtoms, key),
+	})
 	return findTransactionUpdateLogState
 }

--- a/packages/atom.io/json/src/select-json-family.ts
+++ b/packages/atom.io/json/src/select-json-family.ts
@@ -42,6 +42,7 @@ export function selectJsonFamily<
 	store: Store = IMPLICIT.STORE,
 ): AtomIO.WritableSelectorFamilyToken<J, K> {
 	const jsonFamily = createWritableSelectorFamily<J, K>(
+		store,
 		{
 			key: `${atomFamilyToken.key}:JSON`,
 			get:
@@ -87,7 +88,6 @@ export function selectJsonFamily<
 					}
 				},
 		},
-		store,
 		[`mutable`, `json`],
 	)
 	const atomFamily = withdraw(atomFamilyToken, store)

--- a/packages/atom.io/json/src/select-json-family.ts
+++ b/packages/atom.io/json/src/select-json-family.ts
@@ -60,7 +60,7 @@ export function selectJsonFamily<
 					if (store.config.lifespan === `immortal`) {
 						throw new Error(`No molecule found for key "${stringKey}"`)
 					}
-					const newToken = initFamilyMemberInStore(atomFamilyToken, key, store)
+					const newToken = initFamilyMemberInStore(store, atomFamilyToken, key)
 					return transform.toJson(get(newToken))
 				},
 			set:
@@ -80,7 +80,7 @@ export function selectJsonFamily<
 								throw new Error(`No molecule found for key "${stringKey}"`)
 							}
 							set(
-								initFamilyMemberInStore(atomFamilyToken, key, store),
+								initFamilyMemberInStore(store, atomFamilyToken, key),
 								transform.fromJson(newValue),
 							)
 						}
@@ -95,7 +95,7 @@ export function selectJsonFamily<
 		`store=${store.config.name}::json-selector-family`,
 		(event) => {
 			if (event.token.family) {
-				seekInStore(jsonFamily, parseJson(event.token.family.subKey) as K, store)
+				seekInStore(store, jsonFamily, parseJson(event.token.family.subKey) as K)
 			}
 		},
 	)

--- a/packages/atom.io/json/src/select-json.ts
+++ b/packages/atom.io/json/src/select-json.ts
@@ -9,14 +9,11 @@ export const selectJson = <T, J extends Json.Serializable>(
 	transform: JsonInterface<T, J>,
 	store: Store = IMPLICIT.STORE,
 ): AtomIO.WritableSelectorToken<J> => {
-	return createStandaloneSelector(
-		{
-			key: `${atom.key}:JSON`,
-			get: ({ get }) => transform.toJson(get(atom)),
-			set: ({ set }, newValue) => {
-				set(atom, transform.fromJson(newValue))
-			},
+	return createStandaloneSelector(store, {
+		key: `${atom.key}:JSON`,
+		get: ({ get }) => transform.toJson(get(atom)),
+		set: ({ set }, newValue) => {
+			set(atom, transform.fromJson(newValue))
 		},
-		store,
-	)
+	})
 }

--- a/packages/atom.io/react/src/parse-state-overloads.ts
+++ b/packages/atom.io/react/src/parse-state-overloads.ts
@@ -28,13 +28,13 @@ export function parseStateOverloads<T, K extends Canonical>(
 		const key = rest[1]
 
 		if (store.config.lifespan === `immortal`) {
-			const maybeToken = seekInStore(family, key, store)
+			const maybeToken = seekInStore(store, family, key)
 			if (!maybeToken) {
 				throw new NotFoundError(family, key, store)
 			}
 			token = maybeToken
 		} else {
-			token = findInStore(family, key, store)
+			token = findInStore(store, family, key)
 		}
 	} else {
 		token = rest[0]

--- a/packages/atom.io/react/src/use-i.ts
+++ b/packages/atom.io/react/src/use-i.ts
@@ -25,7 +25,7 @@ export function useI<T, K extends Canonical>(
 	> = React.useRef(null)
 	if (setter.current === null) {
 		setter.current = (next) => {
-			setIntoStore(token, next, store)
+			setIntoStore(store, token, next)
 		}
 	}
 	return setter.current

--- a/packages/atom.io/react/src/use-json.ts
+++ b/packages/atom.io/react/src/use-json.ts
@@ -31,8 +31,8 @@ export function useJSON<
 	const store = React.useContext(StoreContext)
 	const stateToken: ReadableToken<any> =
 		token.type === `mutable_atom_family`
-			? findInStore(token, key as Key, store)
+			? findInStore(store, token, key as Key)
 			: token
-	const jsonToken = getJsonToken(stateToken, store)
+	const jsonToken = getJsonToken(store, stateToken)
 	return useO(jsonToken)
 }

--- a/packages/atom.io/react/src/use-o.ts
+++ b/packages/atom.io/react/src/use-o.ts
@@ -21,7 +21,7 @@ export function useO<T, K extends Canonical>(
 	const id = React.useId()
 	return React.useSyncExternalStore<T>(
 		(dispatch) => subscribeToState(token, dispatch, `use-o:${id}`, store),
-		() => getFromStore(token, store),
-		() => getFromStore(token, store),
+		() => getFromStore(store, token),
+		() => getFromStore(store, token),
 	)
 }

--- a/packages/atom.io/realtime-client/src/pull-atom-family-member.ts
+++ b/packages/atom.io/realtime-client/src/pull-atom-family-member.ts
@@ -16,7 +16,7 @@ export function pullAtomFamilyMember<J extends Json.Serializable>(
 	const { key: familyKey, subKey: serializedSubKey } = token.family
 	const subKey = parseJson(serializedSubKey)
 	socket?.on(`serve:${token.key}`, (data: J) => {
-		setIntoStore(token, data, store)
+		setIntoStore(store, token, data)
 	})
 	socket?.emit(`sub:${familyKey}`, subKey)
 	return () => {

--- a/packages/atom.io/realtime-client/src/pull-atom.ts
+++ b/packages/atom.io/realtime-client/src/pull-atom.ts
@@ -9,7 +9,7 @@ export function pullAtom<J extends Json.Serializable>(
 	store: Store,
 ): () => void {
 	const setServedValue = (data: J) => {
-		setIntoStore(token, data, store)
+		setIntoStore(store, token, data)
 	}
 	socket.on(`serve:${token.key}`, setServedValue)
 	socket.emit(`sub:${token.key}`)

--- a/packages/atom.io/realtime-client/src/pull-mutable-atom-family-member.ts
+++ b/packages/atom.io/realtime-client/src/pull-mutable-atom-family-member.ts
@@ -20,7 +20,7 @@ export function pullMutableAtomFamilyMember<
 	const { key: familyKey, subKey: serializedSubKey } = token.family
 	const subKey = parseJson(serializedSubKey)
 	socket.on(`init:${token.key}`, (data: J) => {
-		const jsonToken = getJsonToken(token, store)
+		const jsonToken = getJsonToken(store, token)
 		setIntoStore(store, jsonToken, data)
 	})
 	socket.on(

--- a/packages/atom.io/realtime-client/src/pull-mutable-atom-family-member.ts
+++ b/packages/atom.io/realtime-client/src/pull-mutable-atom-family-member.ts
@@ -21,13 +21,13 @@ export function pullMutableAtomFamilyMember<
 	const subKey = parseJson(serializedSubKey)
 	socket.on(`init:${token.key}`, (data: J) => {
 		const jsonToken = getJsonToken(token, store)
-		setIntoStore(jsonToken, data, store)
+		setIntoStore(store, jsonToken, data)
 	})
 	socket.on(
 		`next:${token.key}`,
 		(data: T extends Transceiver<infer Signal> ? Signal : never) => {
 			const trackerToken = getUpdateToken(token)
-			setIntoStore(trackerToken, data, store)
+			setIntoStore(store, trackerToken, data)
 		},
 	)
 	socket.emit(`sub:${familyKey}`, subKey)

--- a/packages/atom.io/realtime-client/src/pull-mutable-atom.ts
+++ b/packages/atom.io/realtime-client/src/pull-mutable-atom.ts
@@ -12,7 +12,7 @@ export function pullMutableAtom<
 	socket: Socket,
 	store: Store,
 ): () => void {
-	const jsonToken = getJsonToken(token, store)
+	const jsonToken = getJsonToken(store, token)
 	const updateToken = getUpdateToken(token)
 	socket.on(`init:${token.key}`, (data: J) => {
 		setIntoStore(store, jsonToken, data)

--- a/packages/atom.io/realtime-client/src/pull-mutable-atom.ts
+++ b/packages/atom.io/realtime-client/src/pull-mutable-atom.ts
@@ -15,12 +15,12 @@ export function pullMutableAtom<
 	const jsonToken = getJsonToken(token, store)
 	const updateToken = getUpdateToken(token)
 	socket.on(`init:${token.key}`, (data: J) => {
-		setIntoStore(jsonToken, data, store)
+		setIntoStore(store, jsonToken, data)
 	})
 	socket.on(
 		`next:${token.key}`,
 		(data: T extends Transceiver<infer Update> ? Update : never) => {
-			setIntoStore(updateToken, data, store)
+			setIntoStore(store, updateToken, data)
 		},
 	)
 	socket.emit(`sub:${token.key}`)

--- a/packages/atom.io/realtime-client/src/sync-continuity.ts
+++ b/packages/atom.io/realtime-client/src/sync-continuity.ts
@@ -41,9 +41,9 @@ export function syncContinuity<F extends Func>(
 			} else {
 				v = x
 				if (`type` in k && k.type === `mutable_atom`) {
-					k = getJsonToken(k, store)
+					k = getJsonToken(store, k)
 				}
-				setIntoStore(k, v, store)
+				setIntoStore(store, k, v)
 			}
 			i++
 		}

--- a/packages/atom.io/realtime-client/src/sync-continuity.ts
+++ b/packages/atom.io/realtime-client/src/sync-continuity.ts
@@ -65,14 +65,10 @@ export function syncContinuity<F extends Func>(
 				continuityKey,
 				`reconciling updates`,
 			)
-			setIntoStore(
-				optimisticUpdateQueue,
-				(queue) => {
-					queue.shift()
-					return queue
-				},
-				store,
-			)
+			setIntoStore(store, optimisticUpdateQueue, (queue) => {
+				queue.shift()
+				return queue
+			})
 			if (optimisticUpdate.id === confirmedUpdate.id) {
 				const clientResult = JSON.stringify(optimisticUpdate.updates)
 				const serverResult = JSON.stringify(confirmedUpdate.updates)
@@ -199,15 +195,11 @@ export function syncContinuity<F extends Func>(
 						`pushing confirmed update to queue`,
 						confirmed,
 					)
-					setIntoStore(
-						confirmedUpdateQueue,
-						(queue) => {
-							queue.push(confirmed)
-							queue.sort((a, b) => a.epoch - b.epoch)
-							return queue
-						},
-						store,
-					)
+					setIntoStore(store, confirmedUpdateQueue, (queue) => {
+						queue.push(confirmed)
+						queue.sort((a, b) => a.epoch - b.epoch)
+						return queue
+					})
 				}
 			}
 		} else {
@@ -260,15 +252,11 @@ export function syncContinuity<F extends Func>(
 						continuityKey,
 						`pushing confirmed update #${confirmed.epoch} to queue`,
 					)
-					setIntoStore(
-						confirmedUpdateQueue,
-						(queue) => {
-							queue.push(confirmed)
-							queue.sort((a, b) => a.epoch - b.epoch)
-							return queue
-						},
-						store,
-					)
+					setIntoStore(store, confirmedUpdateQueue, (queue) => {
+						queue.push(confirmed)
+						queue.sort((a, b) => a.epoch - b.epoch)
+						return queue
+					})
 				}
 			}
 		}
@@ -297,15 +285,11 @@ export function syncContinuity<F extends Func>(
 						continuityKey,
 						`enqueuing new optimistic update`,
 					)
-					setIntoStore(
-						optimisticUpdateQueue,
-						(queue) => {
-							queue.push(clientUpdate)
-							queue.sort((a, b) => a.epoch - b.epoch)
-							return queue
-						},
-						store,
-					)
+					setIntoStore(store, optimisticUpdateQueue, (queue) => {
+						queue.push(clientUpdate)
+						queue.sort((a, b) => a.epoch - b.epoch)
+						return queue
+					})
 				} else {
 					store.logger.info(
 						`🤞`,
@@ -313,14 +297,10 @@ export function syncContinuity<F extends Func>(
 						continuityKey,
 						`replacing existing optimistic update at index ${optimisticUpdateIndex}`,
 					)
-					setIntoStore(
-						optimisticUpdateQueue,
-						(queue) => {
-							queue[optimisticUpdateIndex] = clientUpdate
-							return queue
-						},
-						store,
-					)
+					setIntoStore(store, optimisticUpdateQueue, (queue) => {
+						queue[optimisticUpdateIndex] = clientUpdate
+						return queue
+					})
 				}
 				socket.emit(`tx-run:${continuityKey}`, {
 					id: clientUpdate.id,

--- a/packages/atom.io/realtime-client/src/sync-continuity.ts
+++ b/packages/atom.io/realtime-client/src/sync-continuity.ts
@@ -27,8 +27,8 @@ export function syncContinuity<F extends Func>(
 	store: Store,
 ): () => void {
 	const continuityKey = continuity.key
-	const optimisticUpdates = getFromStore(optimisticUpdateQueue, store)
-	const confirmedUpdates = getFromStore(confirmedUpdateQueue, store)
+	const optimisticUpdates = getFromStore(store, optimisticUpdateQueue)
+	const confirmedUpdates = getFromStore(store, confirmedUpdateQueue)
 
 	const initializeContinuity = (epoch: number, payload: Json.Array) => {
 		socket.off(`continuity-init:${continuityKey}`, initializeContinuity)

--- a/packages/atom.io/realtime-react/src/use-pull-atom-family-member.ts
+++ b/packages/atom.io/realtime-react/src/use-pull-atom-family-member.ts
@@ -13,7 +13,7 @@ export function usePullAtomFamilyMember<
 	Key extends K,
 >(family: AtomIO.RegularAtomFamilyToken<J, K>, subKey: Key): J {
 	const store = React.useContext(StoreContext)
-	const token = findInStore(family, subKey, store)
+	const token = findInStore(store, family, subKey)
 	useRealtimeService(`pull:${token.key}`, (socket) =>
 		RTC.pullAtomFamilyMember(token, socket, store),
 	)

--- a/packages/atom.io/realtime-react/src/use-pull-mutable-family-member.ts
+++ b/packages/atom.io/realtime-react/src/use-pull-mutable-family-member.ts
@@ -15,7 +15,7 @@ export function usePullMutableAtomFamilyMember<
 	Key extends K,
 >(familyToken: AtomIO.MutableAtomFamilyToken<T, J, K>, key: Key): T {
 	const store = React.useContext(StoreContext)
-	const token = findInStore(familyToken, key, store)
+	const token = findInStore(store, familyToken, key)
 	useRealtimeService(`pull:${token.key}`, (socket) =>
 		RTC.pullMutableAtomFamilyMember(token, socket, store),
 	)

--- a/packages/atom.io/realtime-react/src/use-pull-selector-family-member.ts
+++ b/packages/atom.io/realtime-react/src/use-pull-selector-family-member.ts
@@ -13,7 +13,7 @@ export function usePullSelectorFamilyMember<
 	Key extends K,
 >(familyToken: AtomIO.SelectorFamilyToken<T, K>, key: Key): T {
 	const store = React.useContext(StoreContext)
-	const token = findInStore(familyToken, key, store)
+	const token = findInStore(store, familyToken, key)
 	useRealtimeService(`pull:${token.key}`, (socket) =>
 		RTC.pullSelectorFamilyMember(token, socket, store),
 	)

--- a/packages/atom.io/realtime-server/src/realtime-continuity-synchronizer.ts
+++ b/packages/atom.io/realtime-server/src/realtime-continuity-synchronizer.ts
@@ -36,7 +36,7 @@ export function realtimeContinuitySynchronizer({
 			socket.id,
 			store,
 		).userKeyOfSocket
-		const userKey = getFromStore(userKeyState, store)
+		const userKey = getFromStore(store, userKeyState)
 		if (!userKey) {
 			store.logger.error(
 				`❌`,
@@ -71,7 +71,7 @@ export function realtimeContinuitySynchronizer({
 					return
 				}
 				const newSocketState = findInStore(socketAtoms, newSocketKey, store)
-				const newSocket = getFromStore(newSocketState, store)
+				const newSocket = getFromStore(store, newSocketState)
 				socket = newSocket
 			},
 			`sync-continuity:${continuityKey}:${userKey}`,
@@ -84,8 +84,8 @@ export function realtimeContinuitySynchronizer({
 			store,
 		)
 		const userUnacknowledgedUpdates = getFromStore(
-			userUnacknowledgedQueue,
 			store,
+			userUnacknowledgedQueue,
 		)
 		const unsubscribeFunctions: (() => void)[] = []
 
@@ -109,7 +109,7 @@ export function realtimeContinuitySynchronizer({
 									token.type === `mutable_atom`
 										? getJsonToken(token, store)
 										: token
-								const resource = getFromStore(resourceToken, store)
+								const resource = getFromStore(store, resourceToken)
 								return [resourceToken, resource]
 							})
 						store.logger.info(
@@ -142,12 +142,12 @@ export function realtimeContinuitySynchronizer({
 			for (const atom of continuity.globals) {
 				const resourceToken =
 					atom.type === `mutable_atom` ? getJsonToken(atom, store) : atom
-				initialPayload.push(resourceToken, getFromStore(atom, store))
+				initialPayload.push(resourceToken, getFromStore(store, atom))
 			}
 			for (const perspective of continuity.perspectives) {
 				const { viewAtoms, resourceAtoms } = perspective
 				const userViewState = findInStore(viewAtoms, userKey, store)
-				const userView = getFromStore(userViewState, store)
+				const userView = getFromStore(store, userViewState)
 				store.logger.info(`👁`, `atom`, resourceAtoms.key, `${userKey} can see`, {
 					viewAtoms,
 					resourceAtoms,
@@ -158,7 +158,7 @@ export function realtimeContinuitySynchronizer({
 						visibleToken.type === `mutable_atom`
 							? getJsonToken(visibleToken, store)
 							: visibleToken
-					const resource = getFromStore(resourceToken, store)
+					const resource = getFromStore(store, resourceToken)
 
 					initialPayload.push(resourceToken, resource)
 				}
@@ -186,8 +186,8 @@ export function realtimeContinuitySynchronizer({
 											store,
 										)
 										const visibleTokens = getFromStore(
-											userPerspectiveTokenState,
 											store,
+											userPerspectiveTokenState,
 										)
 										return visibleTokens.map((token) => {
 											const key =

--- a/packages/atom.io/realtime-server/src/realtime-continuity-synchronizer.ts
+++ b/packages/atom.io/realtime-server/src/realtime-continuity-synchronizer.ts
@@ -70,7 +70,7 @@ export function realtimeContinuitySynchronizer({
 					)
 					return
 				}
-				const newSocketState = findInStore(socketAtoms, newSocketKey, store)
+				const newSocketState = findInStore(store, socketAtoms, newSocketKey)
 				const newSocket = getFromStore(store, newSocketState)
 				socket = newSocket
 			},
@@ -79,9 +79,9 @@ export function realtimeContinuitySynchronizer({
 		)
 
 		const userUnacknowledgedQueue = findInStore(
+			store,
 			userUnacknowledgedQueues,
 			userKey,
-			store,
 		)
 		const userUnacknowledgedUpdates = getFromStore(
 			store,
@@ -93,7 +93,7 @@ export function realtimeContinuitySynchronizer({
 			const unsubFns: (() => void)[] = []
 			for (const perspective of continuity.perspectives) {
 				const { viewAtoms } = perspective
-				const userViewState = findInStore(viewAtoms, userKey, store)
+				const userViewState = findInStore(store, viewAtoms, userKey)
 				const unsubscribe = subscribeToState(
 					userViewState,
 					({ oldValue, newValue }) => {
@@ -107,7 +107,7 @@ export function realtimeContinuitySynchronizer({
 							.flatMap((token) => {
 								const resourceToken =
 									token.type === `mutable_atom`
-										? getJsonToken(token, store)
+										? getJsonToken(store, token)
 										: token
 								const resource = getFromStore(store, resourceToken)
 								return [resourceToken, resource]
@@ -141,12 +141,12 @@ export function realtimeContinuitySynchronizer({
 			const initialPayload: Json.Serializable[] = []
 			for (const atom of continuity.globals) {
 				const resourceToken =
-					atom.type === `mutable_atom` ? getJsonToken(atom, store) : atom
+					atom.type === `mutable_atom` ? getJsonToken(store, atom) : atom
 				initialPayload.push(resourceToken, getFromStore(store, atom))
 			}
 			for (const perspective of continuity.perspectives) {
 				const { viewAtoms, resourceAtoms } = perspective
-				const userViewState = findInStore(viewAtoms, userKey, store)
+				const userViewState = findInStore(store, viewAtoms, userKey)
 				const userView = getFromStore(store, userViewState)
 				store.logger.info(`👁`, `atom`, resourceAtoms.key, `${userKey} can see`, {
 					viewAtoms,
@@ -156,7 +156,7 @@ export function realtimeContinuitySynchronizer({
 				for (const visibleToken of userView) {
 					const resourceToken =
 						visibleToken.type === `mutable_atom`
-							? getJsonToken(visibleToken, store)
+							? getJsonToken(store, visibleToken)
 							: visibleToken
 					const resource = getFromStore(store, resourceToken)
 
@@ -181,9 +181,9 @@ export function realtimeContinuitySynchronizer({
 									continuity.perspectives.flatMap((perspective) => {
 										const { viewAtoms } = perspective
 										const userPerspectiveTokenState = findInStore(
+											store,
 											viewAtoms,
 											userKey,
-											store,
 										)
 										const visibleTokens = getFromStore(
 											store,

--- a/packages/atom.io/realtime-server/src/realtime-family-provider.ts
+++ b/packages/atom.io/realtime-server/src/realtime-family-provider.ts
@@ -37,7 +37,7 @@ export function realtimeAtomFamilyProvider({
 			const exposedSubKeys = getFromStore(store, index)
 			for (const exposedSubKey of exposedSubKeys) {
 				if (stringifyJson(exposedSubKey) === stringifyJson(subKey)) {
-					const token = findInStore(family, subKey, store)
+					const token = findInStore(store, family, subKey)
 					socket.emit(`serve:${token.key}`, getFromStore(store, token))
 					const unsubscribe = subscribeToState(
 						token,

--- a/packages/atom.io/realtime-server/src/realtime-family-provider.ts
+++ b/packages/atom.io/realtime-server/src/realtime-family-provider.ts
@@ -34,11 +34,11 @@ export function realtimeAtomFamilyProvider({
 		}
 
 		const fillSubRequest = (subKey: K) => {
-			const exposedSubKeys = getFromStore(index, store)
+			const exposedSubKeys = getFromStore(store, index)
 			for (const exposedSubKey of exposedSubKeys) {
 				if (stringifyJson(exposedSubKey) === stringifyJson(subKey)) {
 					const token = findInStore(family, subKey, store)
-					socket.emit(`serve:${token.key}`, getFromStore(token, store))
+					socket.emit(`serve:${token.key}`, getFromStore(store, token))
 					const unsubscribe = subscribeToState(
 						token,
 						({ newValue }) => {

--- a/packages/atom.io/realtime-server/src/realtime-mutable-family-provider.ts
+++ b/packages/atom.io/realtime-server/src/realtime-mutable-family-provider.ts
@@ -43,9 +43,9 @@ export function realtimeMutableFamilyProvider({
 			const exposedSubKeys = getFromStore(store, index)
 			for (const exposedSubKey of exposedSubKeys) {
 				if (stringifyJson(exposedSubKey) === stringifyJson(subKey)) {
-					const token = findInStore(family, subKey, store)
+					const token = findInStore(store, family, subKey)
 					getFromStore(store, token)
-					const jsonToken = getJsonToken(token, store)
+					const jsonToken = getJsonToken(store, token)
 					const updateToken = getUpdateToken(token)
 					socket.emit(`init:${token.key}`, getFromStore(store, jsonToken))
 					const unsubscribe = subscribeToState(

--- a/packages/atom.io/realtime-server/src/realtime-mutable-family-provider.ts
+++ b/packages/atom.io/realtime-server/src/realtime-mutable-family-provider.ts
@@ -40,14 +40,14 @@ export function realtimeMutableFamilyProvider({
 		}
 
 		const fillSubRequest = (subKey: K) => {
-			const exposedSubKeys = getFromStore(index, store)
+			const exposedSubKeys = getFromStore(store, index)
 			for (const exposedSubKey of exposedSubKeys) {
 				if (stringifyJson(exposedSubKey) === stringifyJson(subKey)) {
 					const token = findInStore(family, subKey, store)
-					getFromStore(token, store)
+					getFromStore(store, token)
 					const jsonToken = getJsonToken(token, store)
 					const updateToken = getUpdateToken(token)
-					socket.emit(`init:${token.key}`, getFromStore(jsonToken, store))
+					socket.emit(`init:${token.key}`, getFromStore(store, jsonToken))
 					const unsubscribe = subscribeToState(
 						updateToken,
 						({ newValue }) => {

--- a/packages/atom.io/realtime-server/src/realtime-mutable-provider.ts
+++ b/packages/atom.io/realtime-server/src/realtime-mutable-provider.ts
@@ -22,7 +22,7 @@ export function realtimeMutableProvider({
 	>(token: AtomIO.MutableAtomToken<Core, SerializableCore>): () => void {
 		let unsubscribeFromStateUpdates: (() => void) | null = null
 
-		const jsonToken = getJsonToken(token, store)
+		const jsonToken = getJsonToken(store, token)
 		const trackerToken = getUpdateToken(token)
 
 		const fillUnsubRequest = () => {

--- a/packages/atom.io/realtime-server/src/realtime-mutable-provider.ts
+++ b/packages/atom.io/realtime-server/src/realtime-mutable-provider.ts
@@ -32,7 +32,7 @@ export function realtimeMutableProvider({
 		}
 
 		const fillSubRequest = () => {
-			socket.emit(`init:${token.key}`, getFromStore(jsonToken, store))
+			socket.emit(`init:${token.key}`, getFromStore(store, jsonToken))
 			unsubscribeFromStateUpdates = subscribeToState(
 				trackerToken,
 				({ newValue }) => {

--- a/packages/atom.io/realtime-server/src/realtime-state-provider.ts
+++ b/packages/atom.io/realtime-server/src/realtime-state-provider.ts
@@ -15,7 +15,7 @@ export function realtimeStateProvider({
 		let unsubscribeFromStateUpdates: (() => void) | undefined
 
 		const fillSubRequest = () => {
-			socket.emit(`serve:${token.key}`, getFromStore(token, store))
+			socket.emit(`serve:${token.key}`, getFromStore(store, token))
 
 			unsubscribeFromStateUpdates = subscribeToState(
 				token,

--- a/packages/atom.io/realtime-server/src/realtime-state-receiver.ts
+++ b/packages/atom.io/realtime-server/src/realtime-state-receiver.ts
@@ -13,7 +13,7 @@ export function realtimeStateReceiver({
 		token: WritableToken<J>,
 	): () => void {
 		const publish = (newValue: J) => {
-			setIntoStore(token, newValue, store)
+			setIntoStore(store, token, newValue)
 		}
 
 		const fillPubUnclaim = () => {

--- a/packages/atom.io/realtime-testing/src/setup-realtime-test.tsx
+++ b/packages/atom.io/realtime-testing/src/setup-realtime-test.tsx
@@ -90,7 +90,7 @@ export const setupRealtimeTestServer = (
 		const { token, username } = socket.handshake.auth
 		if (token === `test` && socket.id) {
 			const socketState = findInStore(RTS.socketAtoms, socket.id, silo.store)
-			setIntoStore(socketState, socket, silo.store)
+			setIntoStore(silo.store, socketState, socket)
 			editRelationsInStore(
 				RTS.usersOfSockets,
 				(relations) => {
@@ -98,8 +98,8 @@ export const setupRealtimeTestServer = (
 				},
 				silo.store,
 			)
-			setIntoStore(RTS.userIndex, (index) => index.add(username), silo.store)
-			setIntoStore(RTS.socketIndex, (index) => index.add(socket.id), silo.store)
+			setIntoStore(silo.store, RTS.userIndex, (index) => index.add(username))
+			setIntoStore(silo.store, RTS.socketIndex, (index) => index.add(socket.id))
 			console.log(`${username} connected on ${socket.id}`)
 			next()
 		} else {

--- a/packages/atom.io/realtime-testing/src/setup-realtime-test.tsx
+++ b/packages/atom.io/realtime-testing/src/setup-realtime-test.tsx
@@ -89,7 +89,7 @@ export const setupRealtimeTestServer = (
 	const server = new SocketIO.Server(httpServer).use((socket, next) => {
 		const { token, username } = socket.handshake.auth
 		if (token === `test` && socket.id) {
-			const socketState = findInStore(RTS.socketAtoms, socket.id, silo.store)
+			const socketState = findInStore(silo.store, RTS.socketAtoms, socket.id)
 			setIntoStore(silo.store, socketState, socket)
 			editRelationsInStore(
 				RTS.usersOfSockets,
@@ -115,7 +115,7 @@ export const setupRealtimeTestServer = (
 		server.close()
 		const roomKeys = getFromStore(silo.store, RT.roomIndex)
 		for (const roomKey of roomKeys) {
-			const roomState = findInStore(RTS.roomSelectors, roomKey, silo.store)
+			const roomState = findInStore(silo.store, RTS.roomSelectors, roomKey)
 			const room = getFromStore(silo.store, roomState)
 			if (room && !(room instanceof Promise)) {
 				room.process.kill()

--- a/packages/atom.io/realtime-testing/src/setup-realtime-test.tsx
+++ b/packages/atom.io/realtime-testing/src/setup-realtime-test.tsx
@@ -113,10 +113,10 @@ export const setupRealtimeTestServer = (
 
 	const dispose = () => {
 		server.close()
-		const roomKeys = getFromStore(RT.roomIndex, silo.store)
+		const roomKeys = getFromStore(silo.store, RT.roomIndex)
 		for (const roomKey of roomKeys) {
 			const roomState = findInStore(RTS.roomSelectors, roomKey, silo.store)
-			const room = getFromStore(roomState, silo.store)
+			const room = getFromStore(silo.store, roomState)
 			if (room && !(room instanceof Promise)) {
 				room.process.kill()
 			}

--- a/packages/atom.io/src/atom.ts
+++ b/packages/atom.io/src/atom.ts
@@ -53,7 +53,7 @@ export function atom<T>(options: RegularAtomOptions<T>): RegularAtomToken<T>
 export function atom(
 	options: MutableAtomOptions<any, any> | RegularAtomOptions<any>,
 ): AtomToken<any> {
-	return createStandaloneAtom(options, IMPLICIT.STORE)
+	return createStandaloneAtom(IMPLICIT.STORE, options)
 }
 
 export type RegularAtomFamilyOptions<T, K extends Canonical> = {
@@ -112,5 +112,5 @@ export function atomFamily<T, K extends Canonical>(
 		| MutableAtomFamilyOptions<any, any, any>
 		| RegularAtomFamilyOptions<T, K>,
 ): MutableAtomFamilyToken<any, any, any> | RegularAtomFamilyToken<T, K> {
-	return createAtomFamily(options, IMPLICIT.STORE)
+	return createAtomFamily(IMPLICIT.STORE, options)
 }

--- a/packages/atom.io/src/dispose-state.ts
+++ b/packages/atom.io/src/dispose-state.ts
@@ -32,8 +32,8 @@ export function disposeState(
 	key?: Json.Serializable,
 ): void {
 	if (key) {
-		Internal.disposeFromStore(token as any, key, Internal.IMPLICIT.STORE)
+		Internal.disposeFromStore(Internal.IMPLICIT.STORE, token as any, key)
 	} else {
-		Internal.disposeFromStore(token as any, Internal.IMPLICIT.STORE)
+		Internal.disposeFromStore(Internal.IMPLICIT.STORE, token as any)
 	}
 }

--- a/packages/atom.io/src/get-state.ts
+++ b/packages/atom.io/src/get-state.ts
@@ -34,7 +34,7 @@ export function getState(
 		| [token: MoleculeToken<any> | ReadableToken<any>]
 ): any {
 	if (params.length === 2) {
-		Internal.getFromStore(Internal.IMPLICIT.STORE, ...params)
+		return Internal.getFromStore(Internal.IMPLICIT.STORE, ...params)
 	}
 	return Internal.getFromStore(Internal.IMPLICIT.STORE, ...params)
 }

--- a/packages/atom.io/src/get-state.ts
+++ b/packages/atom.io/src/get-state.ts
@@ -40,5 +40,5 @@ export function getState(
 			Internal.IMPLICIT.STORE,
 		)
 	}
-	return Internal.getFromStore(token as any, Internal.IMPLICIT.STORE)
+	return Internal.getFromStore(Internal.IMPLICIT.STORE, token as any)
 }

--- a/packages/atom.io/src/get-state.ts
+++ b/packages/atom.io/src/get-state.ts
@@ -26,19 +26,15 @@ export function getState<M extends MoleculeConstructor>(
 ): InstanceType<M>
 
 export function getState(
-	token:
-		| MoleculeFamilyToken<any>
-		| MoleculeToken<any>
-		| ReadableFamilyToken<any, any>
-		| ReadableToken<any>,
-	key?: Canonical,
+	...params:
+		| [
+				token: MoleculeFamilyToken<any> | ReadableFamilyToken<any, any>,
+				key: Canonical,
+		  ]
+		| [token: MoleculeToken<any> | ReadableToken<any>]
 ): any {
-	if (key) {
-		return Internal.getFromStore(
-			token as any,
-			key as any,
-			Internal.IMPLICIT.STORE,
-		)
+	if (params.length === 2) {
+		Internal.getFromStore(Internal.IMPLICIT.STORE, ...params)
 	}
-	return Internal.getFromStore(Internal.IMPLICIT.STORE, token as any)
+	return Internal.getFromStore(Internal.IMPLICIT.STORE, ...params)
 }

--- a/packages/atom.io/src/molecule.ts
+++ b/packages/atom.io/src/molecule.ts
@@ -101,7 +101,7 @@ export type MoleculeToken<M extends MoleculeConstructor> = {
 export function moleculeFamily<M extends MoleculeConstructor>(
 	options: MoleculeFamilyOptions<M>,
 ): MoleculeFamilyToken<M> {
-	return createMoleculeFamily(options, IMPLICIT.STORE)
+	return createMoleculeFamily(IMPLICIT.STORE, options)
 }
 
 export function makeMolecule<M extends MoleculeConstructor>(

--- a/packages/atom.io/src/selector.ts
+++ b/packages/atom.io/src/selector.ts
@@ -27,7 +27,7 @@ export function selector<T>(
 export function selector<T>(
 	options: ReadonlySelectorOptions<T> | WritableSelectorOptions<T>,
 ): ReadonlySelectorToken<T> | WritableSelectorToken<T> {
-	return createStandaloneSelector(options, IMPLICIT.STORE)
+	return createStandaloneSelector(IMPLICIT.STORE, options)
 }
 
 export type WritableSelectorFamilyOptions<T, K extends Canonical> = {
@@ -69,5 +69,5 @@ export function selectorFamily<T, K extends Canonical>(
 		| ReadonlySelectorFamilyOptions<T, K>
 		| WritableSelectorFamilyOptions<T, K>,
 ): ReadonlySelectorFamilyToken<T, K> | WritableSelectorFamilyToken<T, K> {
-	return createSelectorFamily(options, IMPLICIT.STORE)
+	return createSelectorFamily(IMPLICIT.STORE, options)
 }

--- a/packages/atom.io/src/set-state.ts
+++ b/packages/atom.io/src/set-state.ts
@@ -1,6 +1,5 @@
 import * as Internal from "atom.io/internal"
 import type { Canonical } from "atom.io/json"
-import type { Json } from "rel8"
 
 import type { WritableFamilyToken, WritableToken } from "."
 
@@ -32,13 +31,17 @@ export function setState<T, K extends Canonical, New extends T, Key extends K>(
 ): void
 
 export function setState<T, New extends T>(
-	token: WritableFamilyToken<T, Canonical> | WritableToken<T>,
-	p1: Json.Serializable | New | ((oldValue: T) => New),
-	p2?: New | ((oldValue: T) => New),
+	...params:
+		| [
+				token: WritableFamilyToken<T, Canonical>,
+				key: Canonical,
+				value: New | ((oldValue: T) => New),
+		  ]
+		| [token: WritableToken<T>, value: New | ((oldValue: T) => New)]
 ): void {
-	if (p2) {
-		Internal.setIntoStore(token as any, p1 as any, p2, Internal.IMPLICIT.STORE)
+	if (params.length === 2) {
+		Internal.setIntoStore(Internal.IMPLICIT.STORE, ...params)
 	} else {
-		Internal.setIntoStore(token as any, p1 as any, Internal.IMPLICIT.STORE)
+		Internal.setIntoStore(Internal.IMPLICIT.STORE, ...params)
 	}
 }

--- a/packages/atom.io/src/silo.ts
+++ b/packages/atom.io/src/silo.ts
@@ -96,7 +96,7 @@ export class Silo {
 		this.timeline = (options) => createTimeline(options, s)
 		this.findState = (token, key) => findInStore(token, key, s) as any
 		this.getState = ((...params: Parameters<typeof getState>) =>
-			getFromStore(...params, s)) as typeof getState
+			getFromStore(s, ...params)) as typeof getState
 		this.setState = ((...params: Parameters<typeof setState>) => {
 			setIntoStore(...params, s)
 		}) as typeof setState

--- a/packages/atom.io/src/silo.ts
+++ b/packages/atom.io/src/silo.ts
@@ -61,35 +61,11 @@ export class Silo {
 	public makeMolecule: typeof makeMolecule
 	public constructor(config: Store[`config`], fromStore: Store | null = null) {
 		const s = new Store(config, fromStore)
-		function _atom<T>(options: RegularAtomOptions<T>): RegularAtomToken<T>
-		function _atom<T extends Transceiver<any>, J extends Json.Serializable>(
-			options: MutableAtomOptions<T, J>,
-		): MutableAtomToken<T, J>
-		function _atom<T>(
-			options: MutableAtomOptions<any, any> | RegularAtomOptions<T>,
-		): AtomToken<T> {
-			return createStandaloneAtom(options, s)
-		}
-		function _atomFamily<
-			T extends Transceiver<any>,
-			J extends Json.Serializable,
-			K extends Canonical,
-		>(
-			options: MutableAtomFamilyOptions<T, J, K>,
-		): MutableAtomFamilyToken<T, J, K>
-		function _atomFamily<T, K extends Canonical>(
-			options: RegularAtomFamilyOptions<T, K>,
-		): RegularAtomFamilyToken<T, K>
-		function _atomFamily<T, K extends Canonical>(
-			options:
-				| MutableAtomFamilyOptions<any, any, any>
-				| RegularAtomFamilyOptions<T, K>,
-		): MutableAtomFamilyToken<any, any, any> | RegularAtomFamilyToken<T, K> {
-			return createAtomFamily(options, s)
-		}
 		this.store = s
-		this.atom = _atom
-		this.atomFamily = _atomFamily
+		this.atom = ((...params: Parameters<typeof atom>) =>
+			createStandaloneAtom(s, ...params)) as typeof atom
+		this.atomFamily = ((...params: Parameters<typeof atomFamily>) =>
+			createAtomFamily(s, ...params)) as typeof atomFamily
 		this.selector = (options) => createStandaloneSelector(options, s) as any
 		this.selectorFamily = (options) => createSelectorFamily(options, s) as any
 		this.transaction = (options) => createTransaction(options, s)

--- a/packages/atom.io/src/silo.ts
+++ b/packages/atom.io/src/silo.ts
@@ -75,10 +75,10 @@ export class Silo {
 		this.subscribe = ((...params: Parameters<typeof subscribe>) =>
 			subscribeInStore(s, ...params)) as typeof subscribe
 		this.undo = (token) => {
-			timeTravel(`undo`, token, s)
+			timeTravel(s, `undo`, token)
 		}
 		this.redo = (token) => {
-			timeTravel(`redo`, token, s)
+			timeTravel(s, `redo`, token)
 		}
 		this.moleculeFamily = ((options: Parameters<typeof moleculeFamily>[0]) => {
 			return createMoleculeFamily(s, options)

--- a/packages/atom.io/src/silo.ts
+++ b/packages/atom.io/src/silo.ts
@@ -94,14 +94,15 @@ export class Silo {
 		this.selectorFamily = (options) => createSelectorFamily(options, s) as any
 		this.transaction = (options) => createTransaction(options, s)
 		this.timeline = (options) => createTimeline(options, s)
-		this.findState = (token, key) => findInStore(s, token, key) as any
+		this.findState = ((...params: Parameters<typeof findState>) =>
+			findInStore(s, ...params)) as typeof findState
 		this.getState = ((...params: Parameters<typeof getState>) =>
 			getFromStore(s, ...params)) as typeof getState
 		this.setState = ((...params: Parameters<typeof setState>) => {
 			setIntoStore(s, ...params)
 		}) as typeof setState
 		this.disposeState = ((...params: Parameters<typeof disposeState>) => {
-			disposeFromStore(...params, s)
+			disposeFromStore(s, ...params)
 		}) as typeof disposeState
 		this.subscribe = (token, handler, key) => subscribe(token, handler, key, s)
 		this.undo = (token) => {

--- a/packages/atom.io/src/silo.ts
+++ b/packages/atom.io/src/silo.ts
@@ -98,7 +98,7 @@ export class Silo {
 		this.getState = ((...params: Parameters<typeof getState>) =>
 			getFromStore(s, ...params)) as typeof getState
 		this.setState = ((...params: Parameters<typeof setState>) => {
-			setIntoStore(...params, s)
+			setIntoStore(s, ...params)
 		}) as typeof setState
 		this.disposeState = ((...params: Parameters<typeof disposeState>) => {
 			disposeFromStore(...params, s)

--- a/packages/atom.io/src/silo.ts
+++ b/packages/atom.io/src/silo.ts
@@ -1,5 +1,4 @@
 import type { findState } from "atom.io/ephemeral"
-import type { Transceiver } from "atom.io/internal"
 import {
 	createAtomFamily,
 	createMoleculeFamily,
@@ -16,28 +15,19 @@ import {
 	Store,
 	timeTravel,
 } from "atom.io/internal"
-import type { Canonical, Json } from "atom.io/json"
 
 import type {
-	AtomToken,
 	disposeState,
 	getState,
 	makeMolecule,
 	moleculeFamily,
-	MutableAtomFamilyOptions,
-	MutableAtomFamilyToken,
-	MutableAtomOptions,
-	MutableAtomToken,
 	redo,
-	RegularAtomFamilyOptions,
-	RegularAtomFamilyToken,
-	RegularAtomOptions,
-	RegularAtomToken,
 	setState,
+	subscribe,
 	timeline,
 	undo,
 } from "."
-import { subscribe } from "."
+import { subscribeInStore } from "."
 import type { atom, atomFamily } from "./atom"
 import type { selector, selectorFamily } from "./selector"
 import type { transaction } from "./transaction"
@@ -82,7 +72,8 @@ export class Silo {
 		this.disposeState = ((...params: Parameters<typeof disposeState>) => {
 			disposeFromStore(s, ...params)
 		}) as typeof disposeState
-		this.subscribe = (token, handler, key) => subscribe(token, handler, key, s)
+		this.subscribe = ((...params: Parameters<typeof subscribe>) =>
+			subscribeInStore(s, ...params)) as typeof subscribe
 		this.undo = (token) => {
 			timeTravel(`undo`, token, s)
 		}
@@ -91,9 +82,9 @@ export class Silo {
 		}
 		this.moleculeFamily = ((options: Parameters<typeof moleculeFamily>[0]) => {
 			return createMoleculeFamily(s, options)
-		}) as any
+		}) as typeof moleculeFamily
 		this.makeMolecule = ((...params: Parameters<typeof makeMolecule>) => {
 			return makeMoleculeInStore(s, ...params)
-		}) as any
+		}) as typeof makeMolecule
 	}
 }

--- a/packages/atom.io/src/silo.ts
+++ b/packages/atom.io/src/silo.ts
@@ -13,6 +13,7 @@ import {
 	makeMoleculeInStore,
 	setIntoStore,
 	Store,
+	subscribeInStore,
 	timeTravel,
 } from "atom.io/internal"
 
@@ -27,7 +28,6 @@ import type {
 	timeline,
 	undo,
 } from "."
-import { subscribeInStore } from "."
 import type { atom, atomFamily } from "./atom"
 import type { selector, selectorFamily } from "./selector"
 import type { transaction } from "./transaction"

--- a/packages/atom.io/src/silo.ts
+++ b/packages/atom.io/src/silo.ts
@@ -62,12 +62,14 @@ export class Silo {
 	public constructor(config: Store[`config`], fromStore: Store | null = null) {
 		const s = new Store(config, fromStore)
 		this.store = s
-		this.atom = ((...params: Parameters<typeof atom>) =>
-			createStandaloneAtom(s, ...params)) as typeof atom
-		this.atomFamily = ((...params: Parameters<typeof atomFamily>) =>
-			createAtomFamily(s, ...params)) as typeof atomFamily
-		this.selector = (options) => createStandaloneSelector(options, s) as any
-		this.selectorFamily = (options) => createSelectorFamily(options, s) as any
+		this.atom = ((options: Parameters<typeof atom>[0]) =>
+			createStandaloneAtom(s, options)) as typeof atom
+		this.atomFamily = ((options: Parameters<typeof atomFamily>[0]) =>
+			createAtomFamily(s, options)) as typeof atomFamily
+		this.selector = ((options: Parameters<typeof selector>[0]) =>
+			createStandaloneSelector(s, options)) as typeof selector
+		this.selectorFamily = ((options: Parameters<typeof selectorFamily>[0]) =>
+			createSelectorFamily(s, options)) as typeof selectorFamily
 		this.transaction = (options) => createTransaction(options, s)
 		this.timeline = (options) => createTimeline(options, s)
 		this.findState = ((...params: Parameters<typeof findState>) =>
@@ -87,8 +89,8 @@ export class Silo {
 		this.redo = (token) => {
 			timeTravel(`redo`, token, s)
 		}
-		this.moleculeFamily = ((...params: Parameters<typeof moleculeFamily>) => {
-			return createMoleculeFamily(...params, s)
+		this.moleculeFamily = ((options: Parameters<typeof moleculeFamily>[0]) => {
+			return createMoleculeFamily(s, options)
 		}) as any
 		this.makeMolecule = ((...params: Parameters<typeof makeMolecule>) => {
 			return makeMoleculeInStore(s, ...params)

--- a/packages/atom.io/src/silo.ts
+++ b/packages/atom.io/src/silo.ts
@@ -94,7 +94,7 @@ export class Silo {
 		this.selectorFamily = (options) => createSelectorFamily(options, s) as any
 		this.transaction = (options) => createTransaction(options, s)
 		this.timeline = (options) => createTimeline(options, s)
-		this.findState = (token, key) => findInStore(token, key, s) as any
+		this.findState = (token, key) => findInStore(s, token, key) as any
 		this.getState = ((...params: Parameters<typeof getState>) =>
 			getFromStore(s, ...params)) as typeof getState
 		this.setState = ((...params: Parameters<typeof setState>) => {

--- a/packages/atom.io/src/subscribe.ts
+++ b/packages/atom.io/src/subscribe.ts
@@ -31,29 +31,38 @@ export type TransactionUpdateHandler<F extends Func> = (
 	data: TransactionUpdate<F>,
 ) => void
 
-export function subscribe<T>(
+export function subscribeInStore<T>(
+	store: Store,
 	token: ReadableToken<T>,
 	handleUpdate: UpdateHandler<T>,
 	key?: string,
-	store?: Store,
 ): () => void
-export function subscribe<F extends Func>(
+export function subscribeInStore<F extends Func>(
+	store: Store,
 	token: TransactionToken<F>,
 	handleUpdate: TransactionUpdateHandler<F>,
 	key?: string,
-	store?: Store,
 ): () => void
-export function subscribe<M extends TimelineManageable>(
+export function subscribeInStore<M extends TimelineManageable>(
+	store: Store,
 	token: TimelineToken<M>,
 	handleUpdate: (update: TimelineUpdate<M> | `redo` | `undo`) => void,
 	key?: string,
-	store?: Store,
 ): () => void
-export function subscribe(
+export function subscribeInStore<M extends TimelineManageable>(
+	store: Store,
+	token: ReadableToken<any> | TimelineToken<M> | TransactionToken<any>,
+	handleUpdate:
+		| TransactionUpdateHandler<any>
+		| UpdateHandler<any>
+		| ((update: TimelineUpdate<M> | `redo` | `undo`) => void),
+	key?: string,
+): () => void
+export function subscribeInStore(
+	store: Store,
 	token: ReadableToken<any> | TimelineToken<any> | TransactionToken<any>,
 	handleUpdate: (update: any) => void,
 	key: string = arbitrary(),
-	store = IMPLICIT.STORE,
 ): () => void {
 	switch (token.type) {
 		case `atom`:
@@ -66,4 +75,27 @@ export function subscribe(
 		case `timeline`:
 			return subscribeToTimeline(token, handleUpdate, key, store)
 	}
+}
+
+export function subscribe<T>(
+	token: ReadableToken<T>,
+	handleUpdate: UpdateHandler<T>,
+	key?: string,
+): () => void
+export function subscribe<F extends Func>(
+	token: TransactionToken<F>,
+	handleUpdate: TransactionUpdateHandler<F>,
+	key?: string,
+): () => void
+export function subscribe<M extends TimelineManageable>(
+	token: TimelineToken<M>,
+	handleUpdate: (update: TimelineUpdate<M> | `redo` | `undo`) => void,
+	key?: string,
+): () => void
+export function subscribe(
+	token: ReadableToken<any> | TimelineToken<any> | TransactionToken<any>,
+	handleUpdate: (update: any) => void,
+	key: string = arbitrary(),
+): () => void {
+	return subscribeInStore(IMPLICIT.STORE, token, handleUpdate, key)
 }

--- a/packages/atom.io/src/subscribe.ts
+++ b/packages/atom.io/src/subscribe.ts
@@ -1,11 +1,5 @@
-import type { Flat, Func, Store } from "atom.io/internal"
-import {
-	arbitrary,
-	IMPLICIT,
-	subscribeToState,
-	subscribeToTimeline,
-	subscribeToTransaction,
-} from "atom.io/internal"
+import type { Flat, Func } from "atom.io/internal"
+import { arbitrary, IMPLICIT, subscribeInStore } from "atom.io/internal"
 
 import type {
 	FamilyMetadata,
@@ -30,52 +24,6 @@ export type UpdateHandler<T> = (update: StateUpdate<T>) => void
 export type TransactionUpdateHandler<F extends Func> = (
 	data: TransactionUpdate<F>,
 ) => void
-
-export function subscribeInStore<T>(
-	store: Store,
-	token: ReadableToken<T>,
-	handleUpdate: UpdateHandler<T>,
-	key?: string,
-): () => void
-export function subscribeInStore<F extends Func>(
-	store: Store,
-	token: TransactionToken<F>,
-	handleUpdate: TransactionUpdateHandler<F>,
-	key?: string,
-): () => void
-export function subscribeInStore<M extends TimelineManageable>(
-	store: Store,
-	token: TimelineToken<M>,
-	handleUpdate: (update: TimelineUpdate<M> | `redo` | `undo`) => void,
-	key?: string,
-): () => void
-export function subscribeInStore<M extends TimelineManageable>(
-	store: Store,
-	token: ReadableToken<any> | TimelineToken<M> | TransactionToken<any>,
-	handleUpdate:
-		| TransactionUpdateHandler<any>
-		| UpdateHandler<any>
-		| ((update: TimelineUpdate<M> | `redo` | `undo`) => void),
-	key?: string,
-): () => void
-export function subscribeInStore(
-	store: Store,
-	token: ReadableToken<any> | TimelineToken<any> | TransactionToken<any>,
-	handleUpdate: (update: any) => void,
-	key: string = arbitrary(),
-): () => void {
-	switch (token.type) {
-		case `atom`:
-		case `mutable_atom`:
-		case `readonly_selector`:
-		case `selector`:
-			return subscribeToState(token, handleUpdate, key, store)
-		case `transaction`:
-			return subscribeToTransaction(token, handleUpdate, key, store)
-		case `timeline`:
-			return subscribeToTimeline(token, handleUpdate, key, store)
-	}
-}
 
 export function subscribe<T>(
 	token: ReadableToken<T>,

--- a/packages/atom.io/src/timeline.ts
+++ b/packages/atom.io/src/timeline.ts
@@ -54,9 +54,9 @@ export const timeline = <ManagedAtom extends TimelineManageable>(
 }
 
 export const redo = (tl: TimelineToken<any>): void => {
-	timeTravel(`redo`, tl, IMPLICIT.STORE)
+	timeTravel(IMPLICIT.STORE, `redo`, tl)
 }
 
 export const undo = (tl: TimelineToken<any>): void => {
-	timeTravel(`undo`, tl, IMPLICIT.STORE)
+	timeTravel(IMPLICIT.STORE, `undo`, tl)
 }


### PR DESCRIPTION
### **User description**
- **♻️ getFromStore**
- **♻️ setIntoStore**
- **♻️ seekInStore findInStore getJsonToken**
- **♻️ disposeFromStore**
- **♻️ atom, standalone**
- **♻️ selector, molecule**
- **♻️ subscribe**
- **♻️ undo, redo**
- **🚚 more subscribe in store to internal**


___

### **PR Type**
enhancement, tests


___

### **Description**
- Reordered arguments in various function calls across multiple files to ensure consistency and improve readability.
- Updated test files to reflect changes in function call arguments.
- Enhanced the internal logic of store-related operations by standardizing the order of arguments.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>game-servers.test.tsx</strong><dd><code>Reorder arguments in store-related function calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/experimental/realtime-ipc/game-servers.test.tsx

<li>Reordered arguments in <code>findInStore</code> and <code>getFromStore</code> function calls.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2415/files#diff-502d7c24cfde9b5035cb85903f13afea67ab2155f22e8927a6e7e733beecb6e2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>system-server.node.ts</strong><dd><code>Reorder arguments in store-related function calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/experimental/realtime-ipc/system-server.node.ts

<li>Reordered arguments in <code>findInStore</code>, <code>getFromStore</code>, and <code>setIntoStore</code> <br>function calls.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2415/files#diff-6fd4d1380d1f52c912ed9383c64651290caf7e9bb62ab1ba60c3784fd521cfed">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>realtime-mutable-family.test.tsx</strong><dd><code>Reorder arguments in store-related function calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/experimental/realtime/realtime-mutable-family.test.tsx

- Reordered arguments in `setIntoStore` function calls.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2415/files#diff-d1399eb58ab20d40d659906c73aef43f9d373c13604526f489a67b376326a054">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>realtime-pull-regular-atom-family.test.tsx</strong><dd><code>Reorder arguments in store-related function calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/experimental/realtime/realtime-pull-regular-atom-family.test.tsx

- Reordered arguments in `setIntoStore` function calls.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2415/files#diff-a1295556da9ffd1f68069d2c2f7fdaad2a7e407305ff3c0bf14d752083a31da5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mutable-atom.test.ts</strong><dd><code>Reorder arguments in store-related function calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/public/mutability/mutable-atom.test.ts

<li>Reordered arguments in <code>getJsonToken</code> function calls.<br> <li> Reordered arguments in <code>createMutableAtomFamily</code> function calls.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2415/files#diff-dddd54eac289447b2f1d102c5e51204d4c0de17f0d74f4131ee2b36d2e47104e">+12/-15</a>&nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>dict.ts</strong><dd><code>Reorder arguments in store-related function calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/data/src/dict.ts

- Reordered arguments in `createStandaloneSelector` function calls.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2415/files#diff-fd81617099fc6b9662685e6403c1b59ccfbd867a74192e14283edc84d1ccc122">+9/-12</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>join.ts</strong><dd><code>Reorder arguments in store-related function calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/data/src/join.ts

<li>Reordered arguments in various function calls related to store <br>operations.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2415/files#diff-8ede6a54b258362ab00273b6cca0dabe03db72089527006b1cca991abe187da8">+25/-26</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>struct-family.ts</strong><dd><code>Reorder arguments in store-related function calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/data/src/struct-family.ts

<li>Reordered arguments in <code>createRegularAtomFamily</code> and <br><code>createSelectorFamily</code> function calls.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2415/files#diff-21d5683d69769f2cb90f37363ca9c36749da61353433d387370e113cb9bda185">+17/-23</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>struct.ts</strong><dd><code>Reorder arguments in store-related function calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/data/src/struct.ts

<li>Reordered arguments in <code>createRegularAtom</code> and <code>createStandaloneSelector</code> <br>function calls.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2415/files#diff-7f988cc460ba7496ecdae184ff00b079ffb7b8b029cbfdceab7eebc3df551e2a">+9/-12</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>find-state.ts</strong><dd><code>Reorder arguments in store-related function calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/ephemeral/src/find-state.ts

- Reordered arguments in `findInStore` function calls.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2415/files#diff-ef73a9ce2ee005c00ea520d72f3424327eaba278cb328adb5d00327438cb62a4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>seek-state.ts</strong><dd><code>Reorder arguments in store-related function calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/immortal/src/seek-state.ts

- Reordered arguments in `seekInStore` function calls.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2415/files#diff-15faae61264a081e2da4c089cf51c4249994f4ee7c3b13666df42cdc71bc89df">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create-regular-atom.ts</strong><dd><code>Reorder arguments in store-related function calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/atom/create-regular-atom.ts

<li>Reordered arguments in <code>createRegularAtom</code> and <code>setIntoStore</code> function <br>calls.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2415/files#diff-eb1dd1f6cca1a7a398d1eeddfb897a6405a8a663ef988858866149cbecb652f8">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create-standalone-atom.ts</strong><dd><code>Reorder arguments in store-related function calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/atom/create-standalone-atom.ts

- Reordered arguments in `createStandaloneAtom` function calls.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2415/files#diff-064481c04ce3e145621bf873e7bc91535495fd135b5b5b6c5d89e941608606d1">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create-atom-family.ts</strong><dd><code>Reorder arguments in store-related function calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/families/create-atom-family.ts

- Reordered arguments in `createAtomFamily` function calls.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2415/files#diff-1fcd918751641435207b3f2c21cb8b7ab6e2e1c6c9e7364c5fe45f1c0344bdbc">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create-readonly-selector-family.ts</strong><dd><code>Reorder arguments in store-related function calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/families/create-readonly-selector-family.ts

<li>Reordered arguments in <code>createReadonlySelectorFamily</code> function calls.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2415/files#diff-4004c8ac06cc3ab834c8412bed9efb4f49c1c3ac6b3049d851081b19368595c9">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

