### PR TITLE
atom.io permit find in immortal

### DIFF
--- a/.changeset/famous-ways-heal.md
+++ b/.changeset/famous-ways-heal.md
@@ -1,0 +1,12 @@
+---
+"atom.io": patch
+---
+
+✨ `atom.io/immortal` now permits `findState`. Though, it may return a `counterfeit` token.
+
+- A `counterfeit` token is a reference to a state that is not actually created in the store, but does belong to a real family that is known to the store.
+- We create a counterfeit token when we attempt to `findState`, but we are not permitted to initialize the state we need to find. This can happen in `immortal` stores, where we cannot create free-floating states, but must have previously reserved space for them using the `moleculeFamily` function.
+- Counterfeit is the best of several undesirable options where we cannot return a real token:
+  - We could throw an error. This is not preferred because it can lead to unstable production environments and frustrating developer environments.
+  - We could return `undefined`. This is not preferred because it overwhelms the developer with constant null checks in situations where the state is practically  guaranteed to exist.
+  - We can return a functional facsimile (a counterfeit) and log a detailed warning. We prefer this option because it will bring undefined behavior to the developer's attention without demanding their immediate attention.

--- a/.changeset/tasty-fireants-study.md
+++ b/.changeset/tasty-fireants-study.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+✨ Stack traces are now provided when attempting to get, set, or dispose a previously disposed state. These traces point to line of code responsible for last-known disposal of the state in question.

--- a/.changeset/twelve-humans-hide.md
+++ b/.changeset/twelve-humans-hide.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🎁 `atom.io/web` Provides platform-specific tools for the browser. ✨ The first such tool is the new `persistSync` function! This function returns an `AtomEffect` that can be used to sync your state to the browser's `window.localStorage` or `window.sessionStorage`.

--- a/apps/web/strand/src/services/auth.ts
+++ b/apps/web/strand/src/services/auth.ts
@@ -4,5 +4,5 @@ import { persistSync } from "atom.io/web"
 export const secretState = AtomIO.atom<string>({
 	key: `secret`,
 	default: ``,
-	effects: [persistSync(window.localStorage)(JSON)(`secret`)],
+	effects: [persistSync(window.localStorage, JSON, `secret`)],
 })

--- a/packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
+++ b/packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
@@ -102,8 +102,8 @@ describe(`immortal mode`, () => {
 			`count`,
 			`tried to get member`,
 			`"nonexistent"`,
-			`but it was not found in store`,
-			`IMPLICIT_STORE`,
+			`but it was not found in store "IMPLICIT_STORE".`,
+			`No previous disposal trace was found.`,
 		)
 		setState(countStates, `nonexistent`, 1)
 		expect(logger.error).toHaveBeenLastCalledWith(
@@ -114,8 +114,8 @@ describe(`immortal mode`, () => {
 			`"nonexistent"`,
 			`to`,
 			1,
-			`but it was not found in store`,
-			`IMPLICIT_STORE`,
+			`but it was not found in store "IMPLICIT_STORE".`,
+			`No previous disposal trace was found.`,
 		)
 		expect(getState(countStates, `nonexistent`)).toBe(0)
 		expect(logger.error).toHaveBeenLastCalledWith(
@@ -124,8 +124,8 @@ describe(`immortal mode`, () => {
 			`count`,
 			`tried to get member`,
 			`"nonexistent"`,
-			`but it was not found in store`,
-			`IMPLICIT_STORE`,
+			`but it was not found in store "IMPLICIT_STORE".`,
+			`No previous disposal trace was found.`,
 		)
 		disposeState(countStates, `nonexistent`)
 		expect(logger.error).toHaveBeenLastCalledWith(
@@ -134,8 +134,8 @@ describe(`immortal mode`, () => {
 			`count`,
 			`tried to dispose of member`,
 			`"nonexistent"`,
-			`but it was not found in store`,
-			`IMPLICIT_STORE`,
+			`but it was not found in store "IMPLICIT_STORE".`,
+			`No previous disposal trace was found.`,
 		)
 
 		const doubleStates = selectorFamily<number, string>({
@@ -160,8 +160,8 @@ describe(`immortal mode`, () => {
 			`double`,
 			`tried to get member`,
 			`"nonexistent"`,
-			`but it was not found in store`,
-			`IMPLICIT_STORE`,
+			`but it was not found in store "IMPLICIT_STORE".`,
+			`No previous disposal trace was found.`,
 		)
 		disposeState(doubleStates, `nonexistent`)
 		expect(logger.error).toHaveBeenLastCalledWith(
@@ -170,8 +170,8 @@ describe(`immortal mode`, () => {
 			`double`,
 			`tried to dispose of member`,
 			`"nonexistent"`,
-			`but it was not found in store`,
-			`IMPLICIT_STORE`,
+			`but it was not found in store "IMPLICIT_STORE".`,
+			`No previous disposal trace was found.`,
 		)
 
 		const factorialStates = selectorFamily<number, string>({
@@ -195,8 +195,8 @@ describe(`immortal mode`, () => {
 			`factorial`,
 			`tried to get member`,
 			`"nonexistent"`,
-			`but it was not found in store`,
-			`IMPLICIT_STORE`,
+			`but it was not found in store "IMPLICIT_STORE".`,
+			`No previous disposal trace was found.`,
 		)
 		disposeState(factorialStates, `nonexistent`)
 		expect(logger.error).toHaveBeenLastCalledWith(
@@ -205,8 +205,8 @@ describe(`immortal mode`, () => {
 			`factorial`,
 			`tried to dispose of member`,
 			`"nonexistent"`,
-			`but it was not found in store`,
-			`IMPLICIT_STORE`,
+			`but it was not found in store "IMPLICIT_STORE".`,
+			`No previous disposal trace was found.`,
 		)
 
 		const counterMolecules = moleculeFamily({
@@ -232,8 +232,8 @@ describe(`immortal mode`, () => {
 			`counter`,
 			`tried to dispose of member`,
 			`"nonexistent"`,
-			`but it was not found in store`,
-			`IMPLICIT_STORE`,
+			`but it was not found in store "IMPLICIT_STORE".`,
+			`No previous disposal trace was found.`,
 		)
 
 		const root = makeRootMolecule(`root`)
@@ -242,6 +242,33 @@ describe(`immortal mode`, () => {
 		setState(countStates, `does exist`, 3)
 		expect(getState(countStates, `does exist`)).toBe(3)
 		expect(getState(factorialStates, `does exist`)).toBe(6)
+
+		disposeState(counterMolecules, `does exist`)
+		expect(() => getState(counterMolecules, `does exist`)).toThrowError(
+			`Molecule Family "counter" member "does exist" not found in store "IMPLICIT_STORE".`,
+		)
+
+		expect(getState(countStates, `does exist`)).toBe(0)
+		expect((logger.error as any).mock.calls.at(-1).at(-1)).toContain(
+			import.meta.filename,
+		)
+		expect((logger.error as any).mock.calls.at(-1).slice(0, -1)).toEqual([
+			`❗`,
+			`atom_family`,
+			`count`,
+			`tried to get member`,
+			`"does exist"`,
+			`but it was not found in store "IMPLICIT_STORE".`,
+		])
+
+		setState(countStates, `does exist`, 3)
+		expect((logger.error as any).mock.calls.at(-1).at(-1)).toContain(
+			import.meta.filename,
+		)
+		disposeState(counterMolecules, `does exist`)
+		expect((logger.error as any).mock.calls.at(-1).at(-1)).toContain(
+			import.meta.filename,
+		)
 	})
 })
 

--- a/packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
+++ b/packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
@@ -31,16 +31,16 @@ beforeEach(() => {
 
 describe(`immortal mode`, () => {
 	test(`implicit initialization with findState is illegal in immortal mode`, () => {
-		const countStates = atomFamily<number, string>({
+		const countStates = atomFamily<number, number>({
 			key: `count`,
 			default: 0,
 		})
-		expect(() =>
-			findState(countStates, `count`),
-		).toThrowErrorMatchingInlineSnapshot(
-			// eslint-disable-next-line quotes
-			"[Error: Do not use `find` or `findState` in an immortal store. Prefer `seek` or `seekState`.]",
-		)
+		expect(findState(countStates, 0)).toStrictEqual({
+			key: `count(0)`,
+			type: `atom`,
+			family: { key: `count`, subKey: `0` },
+			counterfeit: true,
+		})
 	})
 	test(`safe initialization of state with Molecule`, () => {
 		const world = makeRootMolecule(`world`)

--- a/packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
+++ b/packages/atom.io/__tests__/experimental/immortal/immortal.test.ts
@@ -30,7 +30,7 @@ beforeEach(() => {
 })
 
 describe(`immortal mode`, () => {
-	test(`implicit initialization with findState is illegal in immortal mode`, () => {
+	test(`implicit initialization with findState cannot happen in immortal mode`, () => {
 		const countStates = atomFamily<number, number>({
 			key: `count`,
 			default: 0,
@@ -41,6 +41,14 @@ describe(`immortal mode`, () => {
 			family: { key: `count`, subKey: `0` },
 			counterfeit: true,
 		})
+		expect(logger.error).toHaveBeenLastCalledWith(
+			`❗`,
+			`atom`,
+			`count(0)`,
+			`was not found in store "IMPLICIT_STORE"; returned a counterfeit token.`,
+		)
+		expect(Internal.IMPLICIT.STORE.atoms.get(`count(0)`)).toBeUndefined()
+		expect(Internal.IMPLICIT.STORE.valueMap.get(`count(0)`)).toBeUndefined()
 	})
 	test(`safe initialization of state with Molecule`, () => {
 		const world = makeRootMolecule(`world`)
@@ -231,6 +239,9 @@ describe(`immortal mode`, () => {
 		const root = makeRootMolecule(`root`)
 		makeMolecule(root, counterMolecules, `does exist`)
 		expect(() => getState(counterMolecules, `does exist`)).not.toThrowError()
+		setState(countStates, `does exist`, 3)
+		expect(getState(countStates, `does exist`)).toBe(3)
+		expect(getState(factorialStates, `does exist`)).toBe(6)
 	})
 })
 

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
@@ -132,7 +132,7 @@ describe(`synchronizing transactions`, () => {
 		})
 
 		await waitFor(() => jane.renderResult.getByTestId(`2`))
-		await waitFor(() => dave.renderResult.getByTestId(`2`))
+		await waitFor(() => dave.renderResult.getByTestId(`2`), { timeout: 7000 })
 
 		teardown()
 	})

--- a/packages/atom.io/internal/src/families/dispose-from-store.ts
+++ b/packages/atom.io/internal/src/families/dispose-from-store.ts
@@ -52,14 +52,19 @@ export function disposeFromStore(
 					? seekInStore(store, family, key)
 					: findInStore(store, family, key)
 		if (!maybeToken) {
+			const disposed = store.disposalTraces.buffer.find(
+				(item) => item?.key === key,
+			)
 			store.logger.error(
 				`❗`,
 				family.type,
 				family.key,
 				`tried to dispose of member`,
 				stringifyJson(key),
-				`but it was not found in store`,
-				store.config.name,
+				`but it was not found in store "${store.config.name}".`,
+				disposed
+					? `It was disposed at ${disposed.trace}`
+					: `No previous disposal trace was found.`,
 			)
 			return
 		}
@@ -77,5 +82,11 @@ export function disposeFromStore(
 		case `molecule`:
 			disposeMolecule(token, store)
 			break
+	}
+
+	const { stack } = new Error()
+	if (stack) {
+		const trace = stack?.split(`\n`)?.slice(3)?.join(`\n`)
+		store.disposalTraces.add({ key: token.key, trace })
 	}
 }

--- a/packages/atom.io/internal/src/families/find-in-store.ts
+++ b/packages/atom.io/internal/src/families/find-in-store.ts
@@ -96,7 +96,7 @@ export function findInStore(
 			`❗`,
 			fakeToken.type,
 			fakeToken.key,
-			`was not found in store "${store.config.name}"; returned a counterfeit token`,
+			`was not found in store "${store.config.name}"; returned a counterfeit token.`,
 		)
 		return fakeToken
 	}

--- a/packages/atom.io/internal/src/get-state/get-from-store.ts
+++ b/packages/atom.io/internal/src/get-state/get-from-store.ts
@@ -9,6 +9,7 @@ import type {
 import { type Canonical, stringifyJson } from "atom.io/json"
 
 import { findInStore, seekInStore } from "../families"
+import { growMoleculeInStore } from "../molecule"
 import { NotFoundError } from "../not-found-error"
 import type { Store } from "../store"
 import { withdraw } from "../store"
@@ -63,12 +64,24 @@ export function getFromStore(
 	} else {
 		const family = params[0]
 		const key = params[1]
-		const maybeToken =
-			family.type === `molecule_family`
-				? seekInStore(store, family, key)
-				: store.config.lifespan === `immortal`
-					? seekInStore(store, family, key)
-					: findInStore(store, family, key)
+		let maybeToken: MoleculeToken<any> | ReadableToken<any> | undefined
+		if (family.type === `molecule_family`) {
+			maybeToken = seekInStore(store, family, key)
+		} else {
+			if (store.config.lifespan === `immortal`) {
+				maybeToken = seekInStore(store, family, key)
+			} else {
+				maybeToken = findInStore(store, family, key)
+			}
+		}
+		if (!maybeToken) {
+			if (family.type !== `molecule_family`) {
+				const molecule = store.molecules.get(stringifyJson(key))
+				if (molecule) {
+					maybeToken = growMoleculeInStore(molecule, family, store)
+				}
+			}
+		}
 		if (!maybeToken) {
 			store.logger.error(
 				`❗`,

--- a/packages/atom.io/internal/src/get-state/get-from-store.ts
+++ b/packages/atom.io/internal/src/get-state/get-from-store.ts
@@ -83,14 +83,19 @@ export function getFromStore(
 			}
 		}
 		if (!maybeToken) {
+			const disposed = store.disposalTraces.buffer.find(
+				(item) => item?.key === key,
+			)
 			store.logger.error(
 				`❗`,
 				family.type,
 				family.key,
 				`tried to get member`,
 				stringifyJson(key),
-				`but it was not found in store`,
-				store.config.name,
+				`but it was not found in store "${store.config.name}".`,
+				disposed
+					? `This state was previously disposed:\n${disposed.trace}`
+					: `No previous disposal trace was found.`,
 			)
 			switch (family.type) {
 				case `atom_family`:

--- a/packages/atom.io/internal/src/set-state/set-into-store.ts
+++ b/packages/atom.io/internal/src/set-state/set-into-store.ts
@@ -44,6 +44,9 @@ export function setIntoStore<T, New extends T>(
 				? findInStore(store, family, key)
 				: seekInStore(store, family, key)
 		if (!maybeToken) {
+			const disposed = store.disposalTraces.buffer.find(
+				(item) => item?.key === key,
+			)
 			store.logger.error(
 				`❗`,
 				family.type,
@@ -52,8 +55,10 @@ export function setIntoStore<T, New extends T>(
 				stringifyJson(key),
 				`to`,
 				value,
-				`but it was not found in store`,
-				store.config.name,
+				`but it was not found in store "${store.config.name}".`,
+				disposed
+					? `This state was previously disposed:\n${disposed.trace}`
+					: `No previous disposal trace was found.`,
 			)
 			return
 		}

--- a/packages/atom.io/internal/src/store/circular-buffer.ts
+++ b/packages/atom.io/internal/src/store/circular-buffer.ts
@@ -1,7 +1,15 @@
 export class CircularBuffer<T> {
 	protected _buffer: T[]
 	protected _index = 0
-	public constructor(length: number) {
+	public constructor(array: T[])
+	public constructor(length: number)
+	public constructor(lengthOrArray: T[] | number) {
+		let length: number
+		if (typeof lengthOrArray === `number`) {
+			length = lengthOrArray
+		} else {
+			length = lengthOrArray.length
+		}
 		this._buffer = Array.from({ length })
 	}
 
@@ -16,5 +24,11 @@ export class CircularBuffer<T> {
 	public add(item: T): void {
 		this._buffer[this._index] = item
 		this._index = (this._index + 1) % this._buffer.length
+	}
+
+	public copy(): CircularBuffer<T> {
+		const copy = new CircularBuffer<T>([...this._buffer])
+		copy._index = this._index
+		return copy
 	}
 }

--- a/packages/atom.io/internal/src/store/circular-buffer.ts
+++ b/packages/atom.io/internal/src/store/circular-buffer.ts
@@ -1,0 +1,20 @@
+export class CircularBuffer<T> {
+	protected _buffer: T[]
+	protected _index = 0
+	public constructor(length: number) {
+		this._buffer = Array.from({ length })
+	}
+
+	public get buffer(): ReadonlyArray<T | undefined> {
+		return this._buffer
+	}
+
+	public get index(): number {
+		return this._index
+	}
+
+	public add(item: T): void {
+		this._buffer[this._index] = item
+		this._index = (this._index + 1) % this._buffer.length
+	}
+}

--- a/packages/atom.io/internal/src/store/counterfeit.ts
+++ b/packages/atom.io/internal/src/store/counterfeit.ts
@@ -1,0 +1,118 @@
+import type {
+	AtomFamilyToken,
+	AtomToken,
+	MoleculeConstructor,
+	MoleculeFamilyToken,
+	MoleculeKey,
+	MoleculeToken,
+	MutableAtomFamilyToken,
+	MutableAtomToken,
+	ReadableFamilyToken,
+	ReadableToken,
+	ReadonlySelectorFamilyToken,
+	ReadonlySelectorToken,
+	RegularAtomFamilyToken,
+	RegularAtomToken,
+	SelectorFamilyToken,
+	SelectorToken,
+	WritableFamilyToken,
+	WritableSelectorFamilyToken,
+	WritableSelectorToken,
+	WritableToken,
+} from "atom.io"
+import type { Canonical, Json } from "atom.io/json"
+import { stringifyJson } from "atom.io/json"
+
+import type { Transceiver } from "../mutable"
+
+export function counterfeit<
+	T extends Transceiver<any>,
+	J extends Json.Serializable,
+	K extends Canonical,
+	Key extends K,
+>(token: MutableAtomFamilyToken<T, J, K>, key: Key): MutableAtomToken<T, J>
+
+export function counterfeit<T, K extends Canonical, Key extends K>(
+	token: RegularAtomFamilyToken<T, K>,
+	key: Key,
+): RegularAtomToken<T>
+
+export function counterfeit<T, K extends Canonical, Key extends K>(
+	token: AtomFamilyToken<T, K>,
+	key: Key,
+): AtomToken<T>
+
+export function counterfeit<T, K extends Canonical, Key extends K>(
+	token: WritableSelectorFamilyToken<T, K>,
+	key: Key,
+): WritableSelectorToken<T>
+
+export function counterfeit<T, K extends Canonical, Key extends K>(
+	token: ReadonlySelectorFamilyToken<T, K>,
+	key: Key,
+): ReadonlySelectorToken<T>
+
+export function counterfeit<T, K extends Canonical, Key extends K>(
+	token: SelectorFamilyToken<T, K>,
+	key: Key,
+): SelectorToken<T>
+
+export function counterfeit<T, K extends Canonical, Key extends K>(
+	token: WritableFamilyToken<T, K>,
+	key: Key,
+): WritableToken<T>
+
+export function counterfeit<T, K extends Canonical, Key extends K>(
+	token: ReadableFamilyToken<T, K>,
+	key: Key,
+): ReadableToken<T>
+
+export function counterfeit<M extends MoleculeConstructor>(
+	token: MoleculeFamilyToken<M>,
+	key: MoleculeKey<M>,
+): MoleculeKey<M>
+
+export function counterfeit(
+	token: MoleculeFamilyToken<any> | ReadableFamilyToken<any, any>,
+	key: Canonical,
+): MoleculeToken<any> | ReadableToken<any> {
+	const subKey = stringifyJson(key)
+	const fullKey = `${token.key}(${subKey})`
+	let type:
+		| `atom`
+		| `molecule`
+		| `mutable_atom`
+		| `readonly_selector`
+		| `selector`
+	switch (token.type) {
+		case `atom_family`:
+			type = `atom`
+			break
+		case `mutable_atom_family`:
+			type = `mutable_atom`
+			break
+		case `selector_family`:
+			type = `selector`
+			break
+		case `readonly_selector_family`:
+			type = `readonly_selector`
+			break
+		case `molecule_family`:
+			type = `molecule`
+			break
+	}
+	const stateToken = {
+		key: fullKey,
+		type,
+	} satisfies MoleculeToken<any> | ReadableToken<any>
+	if (type !== `molecule`) {
+		Object.assign(stateToken, {
+			family: {
+				key: token.key,
+				subKey,
+			},
+		})
+	}
+	Object.assign(stateToken, { counterfeit: true })
+	return stateToken
+}

--- a/packages/atom.io/internal/src/store/counterfeit.ts
+++ b/packages/atom.io/internal/src/store/counterfeit.ts
@@ -25,6 +25,14 @@ import { stringifyJson } from "atom.io/json"
 
 import type { Transceiver } from "../mutable"
 
+export const FAMILY_MEMBER_TOKEN_TYPES = {
+	atom_family: `atom`,
+	mutable_atom_family: `mutable_atom`,
+	selector_family: `selector`,
+	readonly_selector_family: `readonly_selector`,
+	molecule_family: `molecule`,
+} as const
+
 export function counterfeit<
 	T extends Transceiver<any>,
 	J extends Json.Serializable,
@@ -78,29 +86,7 @@ export function counterfeit(
 ): MoleculeToken<any> | ReadableToken<any> {
 	const subKey = stringifyJson(key)
 	const fullKey = `${token.key}(${subKey})`
-	let type:
-		| `atom`
-		| `molecule`
-		| `mutable_atom`
-		| `readonly_selector`
-		| `selector`
-	switch (token.type) {
-		case `atom_family`:
-			type = `atom`
-			break
-		case `mutable_atom_family`:
-			type = `mutable_atom`
-			break
-		case `selector_family`:
-			type = `selector`
-			break
-		case `readonly_selector_family`:
-			type = `readonly_selector`
-			break
-		case `molecule_family`:
-			type = `molecule`
-			break
-	}
+	const type = FAMILY_MEMBER_TOKEN_TYPES[token.type]
 	const stateToken = {
 		key: fullKey,
 		type,

--- a/packages/atom.io/internal/src/store/deposit.ts
+++ b/packages/atom.io/internal/src/store/deposit.ts
@@ -109,6 +109,20 @@ export function deposit(
 	| MoleculeToken<any>
 	| ReadableFamilyToken<any, any>
 	| ReadableToken<any>
+	| TransactionToken<Func>
+
+export function deposit(
+	state:
+		| Molecule<any>
+		| MoleculeFamily<any>
+		| ReadableFamily<any, any>
+		| ReadableState<any>
+		| Transaction<Func>,
+):
+	| MoleculeFamilyToken<any>
+	| MoleculeToken<any>
+	| ReadableFamilyToken<any, any>
+	| ReadableToken<any>
 	| TransactionToken<Func> {
 	const token = {
 		key: state.key,

--- a/packages/atom.io/internal/src/store/index.ts
+++ b/packages/atom.io/internal/src/store/index.ts
@@ -1,3 +1,4 @@
+export * from "./counterfeit"
 export * from "./deposit"
 export * from "./store"
 export * from "./withdraw"

--- a/packages/atom.io/internal/src/store/store.ts
+++ b/packages/atom.io/internal/src/store/store.ts
@@ -36,6 +36,7 @@ import type {
 	TransactionProgress,
 } from "../transaction"
 import { isRootStore } from "../transaction"
+import { CircularBuffer } from "./circular-buffer"
 
 export class Store implements Lineage {
 	public parent: Store | null = null
@@ -93,6 +94,8 @@ export class Store implements Lineage {
 		between: [`timelineKey`, `topicKey`],
 		cardinality: `1:n`,
 	})
+
+	public disposalTraces = new CircularBuffer<{ key: string; trace: string }>(100)
 
 	public molecules = new Map<string, Molecule<any>>()
 	public moleculeFamilies = new Map<string, MoleculeFamily<any>>()

--- a/packages/atom.io/internal/src/transaction/build-transaction.ts
+++ b/packages/atom.io/internal/src/transaction/build-transaction.ts
@@ -49,6 +49,7 @@ export const buildTransaction = (
 		selectors: new LazyMap(parent.selectors),
 		valueMap: new LazyMap(parent.valueMap),
 		defaults: parent.defaults,
+		disposalTraces: store.disposalTraces.copy(),
 		molecules: new LazyMap(parent.molecules),
 		moleculeFamilies: new LazyMap(parent.moleculeFamilies),
 		moleculeInProgress: parent.moleculeInProgress,

--- a/packages/atom.io/react-devtools/src/store.ts
+++ b/packages/atom.io/react-devtools/src/store.ts
@@ -18,7 +18,7 @@ export const devtoolsAreOpenState = atom<boolean>({
 	effects:
 		typeof window === `undefined`
 			? []
-			: [persistSync(window.localStorage)(JSON)(`👁‍🗨 Devtools Are Open`)],
+			: [persistSync(window.localStorage, JSON, `👁‍🗨 Devtools Are Open`)],
 })
 
 type DevtoolsView = `atoms` | `selectors` | `timelines` | `transactions`
@@ -29,7 +29,7 @@ export const devtoolsViewSelectionState = atom<DevtoolsView>({
 	effects:
 		typeof window === `undefined`
 			? []
-			: [persistSync(window.localStorage)(JSON)(`👁‍🗨 Devtools View`)],
+			: [persistSync(window.localStorage, JSON, `👁‍🗨 Devtools View`)],
 })
 
 export const devtoolsViewOptionsState = atom<DevtoolsView[]>({
@@ -38,7 +38,7 @@ export const devtoolsViewOptionsState = atom<DevtoolsView[]>({
 	effects:
 		typeof window === `undefined`
 			? []
-			: [persistSync(window.localStorage)(JSON)(`👁‍🗨 Devtools View Options`)],
+			: [persistSync(window.localStorage, JSON, `👁‍🗨 Devtools View Options`)],
 })
 
 export const viewIsOpenAtoms = atomFamily<boolean, string>({
@@ -47,5 +47,5 @@ export const viewIsOpenAtoms = atomFamily<boolean, string>({
 	effects: (key) =>
 		typeof window === `undefined`
 			? []
-			: [persistSync(window.localStorage)(JSON)(key + `:view-is-open`)],
+			: [persistSync(window.localStorage, JSON, key + `:view-is-open`)],
 })

--- a/packages/atom.io/realtime-client/src/realtime-client-stores/client-main-store.ts
+++ b/packages/atom.io/realtime-client/src/realtime-client-stores/client-main-store.ts
@@ -16,5 +16,5 @@ export const myUsernameState = AtomIO.atom<string | null>({
 	effects:
 		typeof window === `undefined`
 			? []
-			: [persistSync(window.localStorage)(JSON)(`myUsername`)],
+			: [persistSync(window.localStorage, JSON, `myUsername`)],
 })

--- a/packages/atom.io/web/src/persist-sync.ts
+++ b/packages/atom.io/web/src/persist-sync.ts
@@ -6,9 +6,11 @@ export type StringInterface<T> = {
 }
 
 export const persistSync =
-	<T>(storage: Storage) =>
-	({ stringify, parse }: StringInterface<T>) =>
-	(key: string): AtomEffect<T> =>
+	<T>(
+		storage: Storage,
+		{ stringify, parse }: StringInterface<T>,
+		key: string,
+	): AtomEffect<T> =>
 	({ setSelf, onSet }) => {
 		const savedValue = storage.getItem(key)
 		if (savedValue != null) setSelf(parse(savedValue))


### PR DESCRIPTION
### **User description**
- **✨ counterfeit**
- **♻️ refactor to complete coverage**
- **✅ improve tests**
- **✨ add stack trace when store members are disposed**
- **✨ copy buffer in transaction**
- **⏲️ increase timeout**
- **🦋**
- **♻️ refactor persist-sync away from total currying**


___

### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced the `persistSync` function across multiple files to use a new parameter structure.
- Implemented counterfeit token creation and handling for `immortal` stores, with detailed error logging.
- Added stack trace logging for disposed states to improve debugging.
- Introduced a `CircularBuffer` class for managing disposal traces.
- Updated and improved test cases for `immortal` mode to handle counterfeit tokens and verify logger outputs.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.ts</strong><dd><code>Update `persistSync` function call for new structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/strand/src/services/auth.ts

<li>Updated <code>persistSync</code> function call to use new parameter structure.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2431/files#diff-95c3e0e001c3024d376bb024292fbddd81d3ed70dd1d3b850514c3440a9c0b6e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dispose-from-store.ts</strong><dd><code>Add stack trace logging for disposed states</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/families/dispose-from-store.ts

<li>Added stack trace logging for disposed states.<br> <li> Improved error messages with disposal trace information.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2431/files#diff-f86854992abef68242dbc7fd4725a72e20fd9992f4097f931b36e633b5abf792">+13/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>find-in-store.ts</strong><dd><code>Implement counterfeit tokens for `immortal` stores</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/families/find-in-store.ts

<li>Implemented counterfeit token creation for <code>immortal</code> stores.<br> <li> Enhanced error logging with counterfeit token details.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2431/files#diff-860ce3231bb1f961974ae1bf795e0a998fa25b410b55e008759085aa94466e65">+17/-7</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>get-from-store.ts</strong><dd><code>Enhance error logging and handle counterfeit tokens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/get-state/get-from-store.ts

<li>Enhanced error logging with disposal trace information.<br> <li> Added logic for handling counterfeit tokens.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2431/files#diff-135c02462cc277a6e2619cb01e9780522ace6122893402d79ea70e3a0eb0380d">+26/-8</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>set-into-store.ts</strong><dd><code>Improve error logging with disposal trace information</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/set-state/set-into-store.ts

- Improved error logging with disposal trace information.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2431/files#diff-57e5d076356ff8fdd80da1f26bb40baf03de821e36e28df6db760f2697ba9d3e">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>circular-buffer.ts</strong><dd><code>Introduce `CircularBuffer` class for disposal traces</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/store/circular-buffer.ts

- Introduced `CircularBuffer` class for managing disposal traces.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2431/files#diff-fefe772a1b8fa20eaf8cc60e0963838b420d633c8a88c51d0b4bfdbc55de4ef8">+34/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>counterfeit.ts</strong><dd><code>Add functions for creating counterfeit tokens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/store/counterfeit.ts

<li>Added functions for creating counterfeit tokens.<br> <li> Defined types and logic for counterfeit handling.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2431/files#diff-324a0dab6d0ab93484d6cf1b30dd6308971ca7aa241f99495a64cb1ed0635bc1">+104/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deposit.ts</strong><dd><code>Expand `deposit` function for more state types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/store/deposit.ts

- Expanded `deposit` function to handle additional state types.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2431/files#diff-9998e70928845ae3f801e6b1337c818566c6bb36a0ac006629c3f1fb437c8f1f">+14/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export `counterfeit` module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/store/index.ts

- Exported `counterfeit` module.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2431/files#diff-18ff15788eba2e5155d23bca9f5777b21e48311e3379ca94b08def1e6bf9472f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>store.ts</strong><dd><code>Add `CircularBuffer` for managing disposal traces</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/store/store.ts

- Added `CircularBuffer` for managing disposal traces.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2431/files#diff-395c42a09ae60d4c7488f4b4fb8921f4bfe2eb1f0f805c8d2531bcb46e23a2a3">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>build-transaction.ts</strong><dd><code>Copy disposal traces in transaction building</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/transaction/build-transaction.ts

- Copied disposal traces in transaction building.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2431/files#diff-33c8f8ec504a3beeea3f59ddd82c0b222594050ea6f0003ccde768452f7aaa4f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>store.ts</strong><dd><code>Update `persistSync` calls for new structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/react-devtools/src/store.ts

- Updated `persistSync` function calls to new parameter structure.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2431/files#diff-df00e110ba508243d35a2b13042d9abfe63a0d8e23040ac367051a754e19be0c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>client-main-store.ts</strong><dd><code>Update `persistSync` function call for new structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/realtime-client/src/realtime-client-stores/client-main-store.ts

<li>Updated <code>persistSync</code> function call to use new parameter structure.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2431/files#diff-21dd527fe527f3fecb15f473d90ee2520af729f0ad7db7bf0e4c35d7ce2cda0c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>persist-sync.ts</strong><dd><code>Refactor `persistSync` function for new structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/web/src/persist-sync.ts

- Refactored `persistSync` function to new parameter structure.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2431/files#diff-8398b4d960f650de84e72d89768f5644f5c33e0303de041fc2579db753286c44">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>immortal.test.ts</strong><dd><code>Update tests for `immortal` mode with counterfeit handling</code></dd></summary>
<hr>

packages/atom.io/__tests__/experimental/immortal/immortal.test.ts

<li>Modified tests for <code>immortal</code> mode to handle counterfeit tokens.<br> <li> Added checks for logger error calls with specific messages.<br> <li> Updated test descriptions and expectations.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2431/files#diff-07f4bcf7cde881144c4d396d2b1b2c345ae79bf0dc9e2ebfbb924625f7af8d99">+63/-25</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>realtime-continuity.test.tsx</strong><dd><code>Increase timeout in realtime continuity test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx

- Increased timeout for a specific test case.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2431/files#diff-4f1c176a31b9dff3ac3aea98ff0474ca2328dacd84a7821b215adbf33f198844">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

