### PR TITLE
🔧 unexcept semver

### DIFF
--- a/.changeset/dry-news-dress.md
+++ b/.changeset/dry-news-dress.md
@@ -2,4 +2,4 @@
 "atom.io": patch
 ---
 
-🐛 (experimental) realtime continuity handles mutable atoms better.
+🐛 (experimental) `atom.io/realtime` upcoming `continuity` model handles mutable atoms better.

--- a/.changeset/famous-ways-heal.md
+++ b/.changeset/famous-ways-heal.md
@@ -1,5 +1,5 @@
 ---
-"atom.io": patch
+"atom.io": minor
 ---
 
 ✨ `atom.io/immortal` now permits `findState`. Though, it may return a `counterfeit` token.

--- a/packages/atom.io/break-check.config.json
+++ b/packages/atom.io/break-check.config.json
@@ -2,5 +2,5 @@
 	"tagPattern": "atom.io",
 	"testPattern": "__tests__/public/**/*.test.{ts,tsx}",
 	"testCommand": "bun run build && bun run test:once:public",
-	"certifyCommand": "grep -q -F '\"atom.io\": patch' ../../.changeset/*.md"
+	"certifyCommand": "grep -q -F '\"atom.io\": minor' ../../.changeset/*.md"
 }

--- a/packages/break-check/src/break-check.x.ts
+++ b/packages/break-check/src/break-check.x.ts
@@ -3,6 +3,7 @@
 import * as path from "node:path"
 
 import { breakCheck } from "break-check"
+import { stdout } from "bun"
 import { cli, encapsulate, optional, parseBooleanOption } from "comline"
 import logger from "npmlog"
 import { z } from "zod"
@@ -69,20 +70,29 @@ if (positionalArgs.length === 0) {
 		console: true,
 		stdout: true,
 	})
-	process.stdout.write(JSON.stringify(returnValue))
+	if (`testResult` in returnValue && returnValue.breakingChangesFound) {
+		process.stdout.write(returnValue.testResult)
+	}
 	if (`breakingChangesFound` in returnValue) {
 		if (returnValue.breakingChangesFound) {
 			if (returnValue.breakingChangesCertified) {
+				process.stdout.write(`👷 Breaking changes were found and certified.`)
 				process.exit(0)
 			} else {
+				process.stdout.write(
+					`❌ Breaking changes were found, but not certified.`,
+				)
 				process.exit(1)
 			}
 		} else {
+			process.stdout.write(`✅ No breaking changes were found.`)
 			process.exit(0)
 		}
 	} else {
+		process.stdout.write(`💥 Break check failed to determine breaking changes.`)
 		process.exit(2)
 	}
 } else if (positionalArgs[0] === `schema`) {
 	writeJsonSchema(`break-check.schema.json`)
+	process.stdout.write(`📝 Wrote schema to break-check.schema.json`)
 }


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated the `certifyCommand` in `break-check.config.json` to verify a 'minor' version change instead of a 'patch'.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>break-check.config.json</strong><dd><code>Update certify command to check for minor version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/break-check.config.json

<li>Updated the <code>certifyCommand</code> to check for a 'minor' version instead of <br>'patch'.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2435/files#diff-4bcdfcbf7123f7b1cacf0dc2488a1a2487af0b534bc8f0e79432461483498321">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

