### PR TITLE
👷 run klaxon for appropriate packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,22 +55,13 @@ jobs:
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: bun release
-      
-      - name: Check if a specific package was published
-        id: check_published
-        if: steps.changesets.outputs.hasChangesets == 'false'
-        run: |
-          echo "Published packages: ${{ steps.changesets.outputs.publishedPackages }}"
-          echo "${{ steps.changesets.outputs.publishedPackages }}" | jq '.[] | select(.name == "tempest.games")' > result.json
-          if [ -s result.json ]; then
-            echo "Package was published"
-            echo "::set-output name=package_published::true"
-          else
-            echo "Package was not published"
-            echo "::set-output name=package_published::false"
-          fi
 
       - name: Run Additional Functionality if Package Was Published
-        if: steps.check_published.outputs.package_published == 'true'
+        if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
+          bun ./packages/flightdeck/src/klaxon.bin.ts \
+          --packageConfig="{\"tempest.games\":{\"endpoint\":\"https://flightdeck.tempest.games/\"}}" \
+          --secretsConfig=${{ secrets.FLIGHTDECK_SECRETS }} \
+          --publishedPackages="${{ steps.changesets.outputs.publishedPackages }}" \
+          -- scramble
           


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed the step that checked if the `tempest.games` package was published, simplifying the workflow.
- Changed the condition for running additional functionality to check if there are no changesets.
- Added a command to execute `klaxon.bin.ts` with specific package and secrets configurations, enhancing the release process.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Update release workflow to run klaxon with new conditions</code></dd></summary>
<hr>

.github/workflows/release.yml

<li>Removed the step to check if a specific package was published.<br> <li> Modified the condition for running additional functionality.<br> <li> Added a command to run <code>klaxon.bin.ts</code> with specific configurations.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2580/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+6/-15</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

