### PR TITLE
🔧 adjust retries to 3, not 10

### DIFF
--- a/packages/flightdeck/src/flightdeck.lib.ts
+++ b/packages/flightdeck/src/flightdeck.lib.ts
@@ -17,7 +17,7 @@ export type FlightDeckOptions = {
 	serviceDir?: string | undefined
 }
 
-let safety = 0
+let safety = -3
 const PORT = process.env.PORT ?? 8080
 const ORIGIN = `http://localhost:${PORT}`
 export class FlightDeck {
@@ -115,7 +115,7 @@ export class FlightDeck {
 
 	protected startService(): void {
 		safety++
-		if (safety > 10) {
+		if (safety >= 0) {
 			throw new Error(`safety exceeded`)
 		}
 		if (!existsSync(this.currentServiceDir)) {

--- a/packages/flightdeck/src/flightdeck.lib.ts
+++ b/packages/flightdeck/src/flightdeck.lib.ts
@@ -115,6 +115,7 @@ export class FlightDeck {
 
 	protected startService(): void {
 		safety++
+		console.log(`safety is ${safety}`)
 		if (safety >= 0) {
 			throw new Error(`safety exceeded`)
 		}
@@ -177,6 +178,7 @@ export class FlightDeck {
 				}
 			}
 		})
+		safety = -3
 	}
 
 	protected applyUpdate(): void {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Adjusted the `safety` variable initialization from 0 to -3 to change the retry mechanism.
- Modified the condition for throwing an error to trigger when `safety` is non-negative, effectively limiting retries.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flightdeck.lib.ts</strong><dd><code>Adjust safety mechanism in FlightDeck service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/flightdeck/src/flightdeck.lib.ts

<li>Adjusted the <code>safety</code> variable initialization from 0 to -3.<br> <li> Modified the condition for throwing an error from <code>safety > 10</code> to <br><code>safety >= 0</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2585/files#diff-d31f2dcef2d0e8621f4f90bb047fdc4cf8cc6f9ca25df3c6718432ddf11c5e5e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

