### PR TITLE
flightdeck multi exec

### DIFF
--- a/.changeset/happy-comics-behave.md
+++ b/.changeset/happy-comics-behave.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+✨ `atom.io/internal` Future gains the `done` property, a way to synchronously observe whether it should still be `use()`-d.

--- a/.changeset/late-bugs-yell.md
+++ b/.changeset/late-bugs-yell.md
@@ -1,0 +1,5 @@
+---
+"flightdeck": patch
+---
+
+✨ Allow for multiple executable services in a single flightdeck.

--- a/packages/atom.io/internal/src/future.ts
+++ b/packages/atom.io/internal/src/future.ts
@@ -12,6 +12,8 @@ export class Future<T> extends Promise<T> {
 	private resolve: (value: T) => void
 	private reject: (reason?: any) => void
 
+	public done = false
+
 	public constructor(
 		executor:
 			| Promise<T>
@@ -31,11 +33,13 @@ export class Future<T> extends Promise<T> {
 	private pass(promise: Promise<T>, value: T) {
 		if (promise === this.fate) {
 			this.resolve(value)
+			this.done = true
 		}
 	}
 	private fail(promise: Promise<T>, reason: any) {
 		if (promise === this.fate) {
 			this.reject(reason)
+			this.done = true
 		}
 	}
 

--- a/packages/flightdeck/__tests__/fixtures/app@v0.ts
+++ b/packages/flightdeck/__tests__/fixtures/app@v0.ts
@@ -3,7 +3,7 @@
 import { ParentSocket } from "atom.io/realtime-server"
 import { serve } from "bun"
 
-const PORT = 4444
+const PORT = process.argv[2] ?? 4444
 const parentSocket = new ParentSocket()
 serve({
 	port: PORT,
@@ -17,3 +17,4 @@ parentSocket.emit(`alive`)
 parentSocket.on(`updatesReady`, () => {
 	parentSocket.emit(`readyToUpdate`)
 })
+parentSocket.logger.info(`🚀 Server started on port ${PORT}`)

--- a/packages/flightdeck/__tests__/fixtures/app@v1.ts
+++ b/packages/flightdeck/__tests__/fixtures/app@v1.ts
@@ -3,7 +3,7 @@
 import { ParentSocket } from "atom.io/realtime-server"
 import { serve } from "bun"
 
-const PORT = 4444
+const PORT = process.argv[2] ?? 4444
 const parentSocket = new ParentSocket()
 serve({
 	port: PORT,

--- a/packages/flightdeck/__tests__/fixtures/app@v1.ts
+++ b/packages/flightdeck/__tests__/fixtures/app@v1.ts
@@ -17,3 +17,4 @@ parentSocket.emit(`alive`)
 parentSocket.on(`updatesReady`, () => {
 	parentSocket.emit(`readyToUpdate`)
 })
+parentSocket.logger.info(`🚀 Server started on port ${PORT}`)

--- a/packages/flightdeck/__tests__/flightdeck.test.ts
+++ b/packages/flightdeck/__tests__/flightdeck.test.ts
@@ -53,6 +53,8 @@ describe(`FlightDeck`, () => {
 		await flightDeck.alive
 		const data = await fetch(`http://localhost:7777/`)
 		console.log(await data.text())
+		const data0 = await fetch(`http://localhost:8888/`)
+		console.log(await data0.text())
 
 		version++
 		const response = await Klaxon.alert({

--- a/packages/flightdeck/__tests__/flightdeck.test.ts
+++ b/packages/flightdeck/__tests__/flightdeck.test.ts
@@ -28,7 +28,8 @@ describe(`FlightDeck`, () => {
 			secret: `secret`,
 			packageName: `my-app`,
 			executables: {
-				frontend: [`./app`],
+				frontend: [`./frontend`, `7777`],
+				backend: [`./backend`, `8888`],
 			},
 			flightdeckRootDir: tmpDir.name,
 			get downloadPackageToUpdatesCmd() {
@@ -38,12 +39,19 @@ describe(`FlightDeck`, () => {
 					`${testDirname}/fixtures/app@v${version}.ts`,
 					`--bundle`,
 					`--outfile`,
-					`${resolve(tmpDir.name, `my-app`, `update`, `app`)}`,
+					`${resolve(tmpDir.name, `my-app`, `update`, `frontend`)}`,
+					`&&`,
+					`bun`,
+					`build`,
+					`${testDirname}/fixtures/app@v${version}.ts`,
+					`--bundle`,
+					`--outfile`,
+					`${resolve(tmpDir.name, `my-app`, `update`, `backend`)}`,
 				]
 			},
 		})
 		await flightDeck.alive
-		const data = await fetch(`http://localhost:4444/`)
+		const data = await fetch(`http://localhost:7777/`)
 		console.log(await data.text())
 
 		version++
@@ -55,6 +63,8 @@ describe(`FlightDeck`, () => {
 		expect(response.status).toBe(200)
 
 		await flightDeck.dead
+		console.log(`👷 FlightDeck is dead`)
 		await flightDeck.alive
+		console.log(`👷 FlightDeck is alive`)
 	}, 5000)
 })

--- a/packages/flightdeck/__tests__/flightdeck.test.ts
+++ b/packages/flightdeck/__tests__/flightdeck.test.ts
@@ -1,4 +1,3 @@
-import { readdir } from "node:fs/promises"
 import { resolve } from "node:path"
 
 import tmp from "tmp"
@@ -39,17 +38,11 @@ describe(`FlightDeck`, () => {
 					`${testDirname}/fixtures/app@v${version}.ts`,
 					`--bundle`,
 					`--outfile`,
-					`${resolve(tmpDir.name, `update`, `app`)}`,
+					`${resolve(tmpDir.name, `my-app`, `update`, `app`)}`,
 				]
 			},
 		})
 		await flightDeck.alive
-		// list files in the flightdeckRootDir
-		console.log({
-			root: await readdir(tmpDir.name),
-			// current: await readdir(resolve(tmpDir.name, `current`, `app`)),
-			currentApp: await readdir(flightDeck.currentServiceDir),
-		})
 		const data = await fetch(`http://localhost:4444/`)
 		console.log(await data.text())
 

--- a/packages/flightdeck/__tests__/flightdeck.test.ts
+++ b/packages/flightdeck/__tests__/flightdeck.test.ts
@@ -18,6 +18,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+	console.log(`---------------------TEST: cleaning up`)
 	flightDeck.stopAllServices()
 })
 
@@ -50,7 +51,7 @@ describe(`FlightDeck`, () => {
 				]
 			},
 		})
-		await flightDeck.alive
+		await flightDeck.live
 		const data = await fetch(`http://localhost:7777/`)
 		console.log(await data.text())
 		const data0 = await fetch(`http://localhost:8888/`)
@@ -64,9 +65,29 @@ describe(`FlightDeck`, () => {
 		console.log(response)
 		expect(response.status).toBe(200)
 
+		console.log(`before dead`, {
+			servicesAlive: flightDeck.servicesLive.map((f) => f.done),
+			servicesDead: flightDeck.servicesDead.map((f) => f.done),
+			alive: flightDeck.live.done,
+			dead: flightDeck.dead.done,
+		})
 		await flightDeck.dead
-		console.log(`👷 FlightDeck is dead`)
-		await flightDeck.alive
-		console.log(`👷 FlightDeck is alive`)
+		console.log(`👷 flightdeck: all services are dead`)
+		console.log(`after dead`, {
+			servicesAlive: flightDeck.servicesLive.map((f) => f.done),
+			servicesDead: flightDeck.servicesDead.map((f) => f.done),
+			alive: flightDeck.live.done,
+			dead: flightDeck.dead.done,
+		})
+		await flightDeck.live
+		console.log(`👷 flightdeck: all services are alive`)
+		console.log(`after alive`, {
+			servicesAlive: flightDeck.servicesLive.map((f) => f.done),
+			servicesDead: flightDeck.servicesDead.map((f) => f.done),
+			alive: flightDeck.live.done,
+			dead: flightDeck.dead.done,
+		})
+		// throw new Error(`here`)
+		// await new Promise((res) => setTimeout(res, 1000))
 	}, 5000)
 })

--- a/packages/flightdeck/__tests__/flightdeck.test.ts
+++ b/packages/flightdeck/__tests__/flightdeck.test.ts
@@ -1,3 +1,4 @@
+import { readdir } from "node:fs/promises"
 import { resolve } from "node:path"
 
 import tmp from "tmp"
@@ -18,7 +19,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-	flightDeck.stopService()
+	flightDeck.stopAllServices()
 })
 
 describe(`FlightDeck`, () => {
@@ -26,11 +27,12 @@ describe(`FlightDeck`, () => {
 		let version = 0
 		flightDeck = new FlightDeck({
 			secret: `secret`,
-			repo: `sample/repo`,
-			app: `my-app`,
-			runCmd: [`./app`],
-			serviceDir: tmpDir.name,
-			get updateCmd() {
+			packageName: `my-app`,
+			executables: {
+				frontend: [`./app`],
+			},
+			flightdeckRootDir: tmpDir.name,
+			get downloadPackageToUpdatesCmd() {
 				return [
 					`bun`,
 					`build`,
@@ -42,6 +44,12 @@ describe(`FlightDeck`, () => {
 			},
 		})
 		await flightDeck.alive
+		// list files in the flightdeckRootDir
+		console.log({
+			root: await readdir(tmpDir.name),
+			// current: await readdir(resolve(tmpDir.name, `current`, `app`)),
+			currentApp: await readdir(flightDeck.currentServiceDir),
+		})
 		const data = await fetch(`http://localhost:4444/`)
 		console.log(await data.text())
 

--- a/packages/flightdeck/src/flightdeck.bin.ts
+++ b/packages/flightdeck/src/flightdeck.bin.ts
@@ -13,13 +13,15 @@ const FLIGHTDECK_MANUAL = {
 	optionsSchema: z.object({
 		secret: z.string(),
 		packageName: z.string(),
-		executables: z.record(z.array(z.string())),
+		services: z.record(
+			z.object({ run: z.array(z.string()), waitFor: z.boolean() }),
+		),
 		flightDeckRootDir: z.string(),
 		downloadPackageToUpdatesCmd: z.array(z.string()),
 	}),
 	options: {
 		secret: {
-			flag: `s`,
+			flag: `x`,
 			required: true,
 			description: `Secret used to authenticate with the service.`,
 			example: `--secret=\"secret\"`,
@@ -30,11 +32,11 @@ const FLIGHTDECK_MANUAL = {
 			description: `Name of the package.`,
 			example: `--packageName=\"my-app\"`,
 		},
-		executables: {
-			flag: `e`,
+		services: {
+			flag: `s`,
 			required: true,
 			description: `Map of service names to executables.`,
-			example: `--executables="{\\"frontend\\":[\\"./app\\"]}"`,
+			example: `--services="{\\"frontend\\":{\\"run\\":[\\"./app\\"],\\"waitFor\\":false},\\"backend\\":{\\"run\\":[\\"./backend\\"],\\"waitFor\\":true}}"`,
 			parse: JSON.parse,
 		},
 		flightdeckRootDir: {

--- a/packages/flightdeck/src/flightdeck.bin.ts
+++ b/packages/flightdeck/src/flightdeck.bin.ts
@@ -12,11 +12,10 @@ import { FlightDeck } from "~/packages/flightdeck/src/flightdeck.lib"
 const FLIGHTDECK_MANUAL = {
 	optionsSchema: z.object({
 		secret: z.string(),
-		repo: z.string(),
-		app: z.string(),
-		runCmd: z.array(z.string()),
-		serviceDir: z.string(),
-		updateCmd: z.array(z.string()),
+		packageName: z.string(),
+		executables: z.record(z.array(z.string())),
+		flightDeckRootDir: z.string(),
+		downloadPackageToUpdatesCmd: z.array(z.string()),
 	}),
 	options: {
 		secret: {
@@ -25,36 +24,30 @@ const FLIGHTDECK_MANUAL = {
 			description: `Secret used to authenticate with the service.`,
 			example: `--secret=\"secret\"`,
 		},
-		repo: {
-			flag: `r`,
+		packageName: {
+			flag: `p`,
 			required: true,
-			description: `Name of the repository.`,
-			example: `--repo=\"sample/repo\"`,
+			description: `Name of the package.`,
+			example: `--packageName=\"my-app\"`,
 		},
-		app: {
-			flag: `a`,
+		executables: {
+			flag: `e`,
 			required: true,
-			description: `Name of the application.`,
-			example: `--app=\"my-app\"`,
+			description: `Map of service names to executables.`,
+			example: `--executables="{\\"frontend\\":[\\"./app\\"]}"`,
+			parse: JSON.parse,
 		},
-		runCmd: {
-			flag: `r`,
-			required: true,
-			description: `Command to run the application.`,
-			example: `--runCmd=\"./app\"`,
-			parse: parseArrayOption,
-		},
-		serviceDir: {
+		flightdeckRootDir: {
 			flag: `d`,
 			required: true,
 			description: `Directory where the service is stored.`,
-			example: `--serviceDir=\"./services/sample/repo/my-app/current\"`,
+			example: `--flightdeckRootDir=\"./services/sample/repo/my-app/current\"`,
 		},
-		updateCmd: {
+		downloadPackageToUpdatesCmd: {
 			flag: `u`,
 			required: true,
 			description: `Command to update the service.`,
-			example: `--updateCmd=\"./app\"`,
+			example: `--downloadPackageToUpdatesCmd=\"./app\"`,
 			parse: parseArrayOption,
 		},
 	},
@@ -107,7 +100,7 @@ switch (inputs.case) {
 	default: {
 		const flightDeck = new FlightDeck(inputs.opts)
 		process.on(`close`, async () => {
-			flightDeck.stopService()
+			flightDeck.stopAllServices()
 			await flightDeck.dead
 		})
 	}

--- a/packages/flightdeck/src/flightdeck.lib.ts
+++ b/packages/flightdeck/src/flightdeck.lib.ts
@@ -1,5 +1,5 @@
 import { execSync, spawn } from "node:child_process"
-import { existsSync, mkdirSync, renameSync, rmSync, unlinkSync } from "node:fs"
+import { existsSync, mkdirSync, renameSync, rmSync } from "node:fs"
 import type { Server } from "node:http"
 import { createServer } from "node:http"
 import { homedir } from "node:os"
@@ -60,9 +60,21 @@ export class FlightDeck<S extends string = string> {
 		this.alive.use(Promise.all(this.servicesAlive))
 		this.dead.use(Promise.all(this.servicesDead))
 
-		this.currentServiceDir = resolve(flightdeckRootDir, `current`)
-		this.backupServiceDir = resolve(flightdeckRootDir, `backup`)
-		this.updateServiceDir = resolve(flightdeckRootDir, `update`)
+		this.currentServiceDir = resolve(
+			flightdeckRootDir,
+			options.packageName,
+			`current`,
+		)
+		this.backupServiceDir = resolve(
+			flightdeckRootDir,
+			options.packageName,
+			`backup`,
+		)
+		this.updateServiceDir = resolve(
+			flightdeckRootDir,
+			options.packageName,
+			`update`,
+		)
 
 		createServer((req, res) => {
 			let data: Uint8Array[] = []

--- a/packages/flightdeck/src/flightdeck.lib.ts
+++ b/packages/flightdeck/src/flightdeck.lib.ts
@@ -171,11 +171,11 @@ export class FlightDeck<S extends string = string> {
 		})
 		this.services[serviceName] = new ChildSocket(
 			serviceProcess,
-			this.options.packageName,
+			`${this.options.packageName}::${serviceName}`,
 			console,
 		)
 		this.services[serviceName].onAny((...messages) => {
-			console.log(`🛰 `, ...messages)
+			console.log(`${this.options.packageName}::${serviceName} 💬`, ...messages)
 		})
 		this.services[serviceName].on(`readyToUpdate`, () => {
 			this.stopService(serviceName)
@@ -190,12 +190,14 @@ export class FlightDeck<S extends string = string> {
 		})
 		this.services[serviceName].process.on(`close`, (exitCode) => {
 			console.log(
-				`Service ${this.options.packageName} exited with code ${exitCode}`,
+				`${this.options.packageName}::${serviceName} exited with code ${exitCode}`,
 			)
 			this.services[serviceName] = null
 			const updatesAreReady = existsSync(this.updateServiceDir)
 			if (updatesAreReady) {
-				console.log(`Updates are ready; applying and restarting...`)
+				console.log(
+					`${this.options.packageName}::${serviceName} will be updated before startup...`,
+				)
 				this.restartTimes = []
 				this.applyUpdate()
 				this.startService(serviceName)
@@ -210,12 +212,12 @@ export class FlightDeck<S extends string = string> {
 
 					if (this.restartTimes.length < 5) {
 						console.log(
-							`Service ${this.options.packageName} crashed. Restarting...`,
+							`Service ${this.options.packageName}::${serviceName} crashed. Restarting...`,
 						)
 						this.startService(serviceName)
 					} else {
 						console.log(
-							`Service ${this.options.packageName} crashed too many times. Not restarting.`,
+							`Service ${this.options.packageName}::${serviceName} crashed too many times. Not restarting.`,
 						)
 					}
 				}
@@ -279,7 +281,9 @@ export class FlightDeck<S extends string = string> {
 
 	public stopService(serviceName: S): void {
 		if (this.services[serviceName]) {
-			console.log(`Stopping service ${this.options.packageName}...`)
+			console.log(
+				`Stopping service ${this.options.packageName}::${serviceName}...`,
+			)
 			this.services[serviceName].process.kill()
 			this.services[serviceName] = null
 			this.servicesDead[this.serviceIdx[serviceName]].use(Promise.resolve())
@@ -290,7 +294,7 @@ export class FlightDeck<S extends string = string> {
 			this.alive.use(Promise.all(this.servicesAlive))
 		} else {
 			console.error(
-				`Failed to stop service ${this.options.packageName}: Service is not running.`,
+				`Failed to stop service ${this.options.packageName}::${serviceName}: Service is not running.`,
 			)
 		}
 	}

--- a/packages/flightdeck/src/flightdeck.lib.ts
+++ b/packages/flightdeck/src/flightdeck.lib.ts
@@ -183,7 +183,9 @@ export class FlightDeck<S extends string = string> {
 		this.services[serviceName].on(`alive`, () => {
 			this.servicesAlive[this.serviceIdx[serviceName]].use(Promise.resolve())
 			this.servicesDead[this.serviceIdx[serviceName]] = new Future(() => {})
-			this.dead = new Future(() => {})
+			if (this.dead.done) {
+				this.dead = new Future(() => {})
+			}
 			this.dead.use(Promise.all(this.servicesDead))
 		})
 		this.services[serviceName].process.on(`close`, (exitCode) => {
@@ -282,7 +284,9 @@ export class FlightDeck<S extends string = string> {
 			this.services[serviceName] = null
 			this.servicesDead[this.serviceIdx[serviceName]].use(Promise.resolve())
 			this.servicesAlive[this.serviceIdx[serviceName]] = new Future(() => {})
-			this.alive = new Future(() => {})
+			if (this.alive.done) {
+				this.alive = new Future(() => {})
+			}
 			this.alive.use(Promise.all(this.servicesAlive))
 		} else {
 			console.error(


### PR DESCRIPTION
### **User description**
- **✨ allow multiple executables**
- **✨ use subfolders**
- **✅ test and fix asynchrony bug**
- **🔊 improve logs**
- **🦋**


___

### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced the `Future` class by adding a `done` property to track completion status.
- Refactored FlightDeck to support multiple executable services, including changes to start and stop services.
- Updated tests to accommodate and verify the new multi-service functionality.
- Improved command-line interface for FlightDeck to handle multiple executables.
- Added documentation for the new features in the changeset files.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>future.ts</strong><dd><code>Add `done` property to `Future` class for completion tracking</code></dd></summary>
<hr>

packages/atom.io/internal/src/future.ts

<li>Added a <code>done</code> property to the <code>Future</code> class.<br> <li> Updated methods to set <code>done</code> to true when resolved or rejected.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2587/files#diff-cc344e2b185ed47ac99da5844176b739d7c36d707b46af3851258de9f28f7d08">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>app@v0.ts</strong><dd><code>Make server port configurable and add logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/flightdeck/__tests__/fixtures/app@v0.ts

<li>Made server port configurable via command-line arguments.<br> <li> Added logging for server start.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2587/files#diff-3864d94995a831f6c2ff372d7ce72fd19d6626c2e4bbd4d76726d3fe7a58b7d8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>flightdeck.bin.ts</strong><dd><code>Refactor command-line options for multiple executables</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/flightdeck/src/flightdeck.bin.ts

<li>Refactored command-line options for multiple executables.<br> <li> Updated schema and examples to reflect new structure.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2587/files#diff-4537fb95482abbeadf7f5b1a9944f742c02f8607f753333a07ea28713a221a49">+18/-25</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>flightdeck.lib.ts</strong><dd><code>Refactor FlightDeck to support multiple executable services</code></dd></summary>
<hr>

packages/flightdeck/src/flightdeck.lib.ts

<li>Refactored FlightDeck to support multiple services.<br> <li> Added methods to start and stop all services.<br> <li> Updated logging and error handling for multiple services.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2587/files#diff-d31f2dcef2d0e8621f4f90bb047fdc4cf8cc6f9ca25df3c6718432ddf11c5e5e">+138/-75</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flightdeck.test.ts</strong><dd><code>Update tests for multiple service support in FlightDeck</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/flightdeck/__tests__/flightdeck.test.ts

<li>Updated tests to handle multiple services.<br> <li> Modified test setup and teardown for multiple services.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2587/files#diff-3fc604761f1dca6e57f7d838895cf1f9e361038638203f67c8f4572147018550">+21/-8</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>happy-comics-behave.md</strong><dd><code>Document addition of `done` property to Future</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/happy-comics-behave.md

- Documented the addition of the `done` property to `Future`.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2587/files#diff-744d1866fe16ddfe1269482e45e19ad18c87285833ae863826c38abb5cc0de8e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>late-bugs-yell.md</strong><dd><code>Document support for multiple executable services in FlightDeck</code></dd></summary>
<hr>

.changeset/late-bugs-yell.md

- Documented support for multiple executable services in FlightDeck.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2587/files#diff-90b8559eb8a927196705b05c243bf77d752336a402821e09e5e79f310187ed16">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

