### PR TITLE
tempest logging

### DIFF
--- a/.changeset/sixty-dodos-remember.md
+++ b/.changeset/sixty-dodos-remember.md
@@ -1,0 +1,5 @@
+---
+"tempest.games": patch
+---
+
+🐛 Use ParentSocket for logging.

--- a/apps/tempest.games/package.json
+++ b/apps/tempest.games/package.json
@@ -21,7 +21,7 @@
 		"build:backend:game": "bun build ./src/backend.worker.game.bun.ts --outdir ./bin --bundle --minify --target bun",
 		"preview": "concurrently \"bun:preview:*\"",
 		"preview:frontend": "bun ./bin/frontend.bun.js",
-		"preview:backend": "bun ./bin/backend.node.js",
+		"preview:backend": "bun ./bin/backend.bun.js",
 		"test": "echo no tests yet",
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint --flag unstable_ts_config -- .",

--- a/apps/tempest.games/src/backend.bun.ts
+++ b/apps/tempest.games/src/backend.bun.ts
@@ -1,9 +1,16 @@
 #!/usr/bin/env bun
 
+import { ParentSocket } from "atom.io/realtime-server"
+
 import { worker } from "./backend.worker.ts"
 
-console.log(`hello world`)
+const parent = new ParentSocket()
 
-const gameWorker = worker(`backend.worker.game.bun`)
+const gameWorker = worker(parent, `backend.worker.game.bun`)
 
-process.on(`exit`, () => gameWorker.process.kill())
+process.on(`exit`, () => {
+	gameWorker.process.kill()
+	parent.logger.info(`🛬 backend server exiting`)
+})
+
+parent.logger.info(`🛫 backend server ready`)

--- a/apps/tempest.games/src/backend.worker.game.bun.ts
+++ b/apps/tempest.games/src/backend.worker.game.bun.ts
@@ -3,8 +3,8 @@
 import { ParentSocket } from "atom.io/realtime-server"
 
 const parent = new ParentSocket()
-parent.logger.info(`🚀`, `hello from game worker`)
 
 process.on(`exit`, () => {
-	parent.logger.info(`🚀`, `goodbye from game worker`)
+	parent.logger.info(`🛬 game worker exiting`)
 })
+parent.logger.info(`🛫 game worker ready`)

--- a/apps/tempest.games/src/backend.worker.ts
+++ b/apps/tempest.games/src/backend.worker.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process"
 import { resolve } from "node:path"
 
+import type { ParentSocket } from "atom.io/realtime-server"
 import { ChildSocket } from "atom.io/realtime-server"
 
 export type Role = `backend` | `frontend`
@@ -9,6 +10,7 @@ export type Extension = `js` | `ts`
 export type Runner = `bun` | `node`
 
 export function worker(
+	from: ParentSocket<any, any>,
 	name: `${Role}.worker.${string}.${Runner}`,
 ): ChildSocket<any, any> {
 	const isDev = process.env.MODE === `development`
@@ -20,5 +22,5 @@ export function worker(
 		args.push(`--experimental-strip-types`)
 	}
 	const child = spawn(runner, args)
-	return new ChildSocket(child, name, console)
+	return new ChildSocket(child, name, from.logger)
 }

--- a/apps/tempest.games/src/frontend.bun.ts
+++ b/apps/tempest.games/src/frontend.bun.ts
@@ -1,8 +1,10 @@
 import { join, normalize, resolve } from "node:path"
 
+import { ParentSocket } from "atom.io/realtime-server"
 import { file, serve } from "bun"
 
-// Set the directory of your Vite app build
+const parent = new ParentSocket()
+parent.logger.info(` ready`)
 const appDir = resolve(import.meta.dir, `..`, `app`)
 
 // Create the HTTP server using Bun
@@ -19,7 +21,7 @@ serve({
 		const url = new URL(req.url)
 
 		const ip = server.requestIP(req)?.address ?? `??`
-		console.log(`[${ip}]`, req.method, url.pathname)
+		parent.logger.info(`[${ip}]`, req.method, url.pathname)
 
 		// Normalize the requested path and prevent path traversal
 		const filePath = join(appDir, url.pathname)
@@ -37,4 +39,9 @@ serve({
 	},
 })
 
-console.log(`Server running at http://localhost:${process.env.PORT ?? 8080}/`)
+process.on(`exit`, () => {
+	parent.logger.info(`🛬 frontend server exiting`)
+})
+parent.logger.info(
+	`🛫 frontend server running at http://localhost:${process.env.FRONTEND_PORT ?? 3333}/`,
+)

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -223,7 +223,10 @@ const configs = [
 		rules: commonRules,
 	},
 	{
-		files: [`packages/atom.io/**/src/**/*.ts{,x}`],
+		files: [
+			`packages/atom.io/**/src/**/*.ts{,x}`,
+			`apps/tempest.games/src/**/*.ts{,x}`,
+		],
 		rules: {
 			"no-console": ERROR,
 		},


### PR DESCRIPTION
### **User description**
- **🔧 disallow console**
- **✏️ fix typo**
- **♻️ always use parent logger**
- **🦋**


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Replaced console logging with `ParentSocket` logging across backend and frontend scripts.
- Updated worker initialization to use `ParentSocket` for logging.
- Added logging for server and worker readiness and exit events.
- Disallowed console logging in the `tempest.games` app through ESLint configuration.
- Corrected the backend preview script path in `package.json`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend.bun.ts</strong><dd><code>Integrate ParentSocket for logging in backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/tempest.games/src/backend.bun.ts

<li>Replaced console logging with <code>ParentSocket</code> logging.<br> <li> Added logging for server readiness and exit events.<br> <li> Integrated <code>ParentSocket</code> into worker initialization.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2613/files#diff-d5ca211eb7d581e37c81fdb777843c7ee3aef3c19b16eef5144b7a6d136fcbe0">+10/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>backend.worker.game.bun.ts</strong><dd><code>Update logging in game worker with ParentSocket</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/tempest.games/src/backend.worker.game.bun.ts

<li>Updated logging messages for worker readiness and exit.<br> <li> Removed redundant console logging.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2613/files#diff-87c439768c6366f669fee96da42e64c1df9b2172763fda1ee1fbb749673f311e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>backend.worker.ts</strong><dd><code>Modify worker function to use ParentSocket for logging</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/tempest.games/src/backend.worker.ts

<li>Modified worker function to accept <code>ParentSocket</code>.<br> <li> Replaced console logging with <code>ParentSocket</code> logging.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2613/files#diff-e9431c4dd1ee4feeaf856cfd16f36c7e9069598f3d815f3599de1cf218dbcc9d">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>frontend.bun.ts</strong><dd><code>Use ParentSocket for logging in frontend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/tempest.games/src/frontend.bun.ts

<li>Implemented <code>ParentSocket</code> for logging.<br> <li> Added logging for server readiness and exit events.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2613/files#diff-a3d90a7b34c541b0ba13d3ced042f4819ab5ad3a247f5082452e936d59cd2bc1">+10/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>eslint.config.ts</strong><dd><code>Disallow console logging in tempest.games app</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

eslint.config.ts

- Added rule to disallow console logging in `tempest.games` app.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2613/files#diff-3202509a51dddde1968b20a04dfcedc90615eb6681cca0cda5f43a418a516857">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sixty-dodos-remember.md</strong><dd><code>Document use of ParentSocket for logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/sixty-dodos-remember.md

- Documented the use of `ParentSocket` for logging.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2613/files#diff-d68e2e5a6d6ed1c10711ac8acdc430caa18d179d6045cbddd7b763f10468febc">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Fix backend preview script path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/tempest.games/package.json

- Corrected backend preview script to use `backend.bun.js`.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2613/files#diff-06649773c9efab9e1b7c10bb48b5206da3188258deee16c2f2862d601472144f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

