### PR TITLE
simplify flightdeck exec options

### DIFF
--- a/.changeset/tricky-clocks-melt.md
+++ b/.changeset/tricky-clocks-melt.md
@@ -1,0 +1,5 @@
+---
+"flightdeck": patch
+---
+
+💥 Only pass a string to spawn a process.

--- a/packages/flightdeck/__tests__/flightdeck.test.ts
+++ b/packages/flightdeck/__tests__/flightdeck.test.ts
@@ -29,8 +29,8 @@ describe(`FlightDeck`, () => {
 			secret: `secret`,
 			packageName: `my-app`,
 			services: {
-				frontend: { run: [`./frontend`, `7777`], waitFor: false },
-				backend: { run: [`./backend`, `8888`], waitFor: true },
+				frontend: { run: `./frontend 7777`, waitFor: false },
+				backend: { run: `./backend 8888`, waitFor: true },
 			},
 			flightdeckRootDir: tmpDir.name,
 			get scripts() {

--- a/packages/flightdeck/src/flightdeck.bin.ts
+++ b/packages/flightdeck/src/flightdeck.bin.ts
@@ -13,9 +13,7 @@ const FLIGHTDECK_MANUAL = {
 	optionsSchema: z.object({
 		secret: z.string(),
 		packageName: z.string(),
-		services: z.record(
-			z.object({ run: z.array(z.string()), waitFor: z.boolean() }),
-		),
+		services: z.record(z.object({ run: z.string(), waitFor: z.boolean() })),
 		flightdeckRootDir: z.string(),
 		scripts: z.object({
 			download: z.string(),
@@ -39,7 +37,7 @@ const FLIGHTDECK_MANUAL = {
 			flag: `s`,
 			required: true,
 			description: `Map of service names to executables.`,
-			example: `--services="{\\"frontend\\":{\\"run\\":[\\"./app\\"],\\"waitFor\\":false},\\"backend\\":{\\"run\\":[\\"./backend\\"],\\"waitFor\\":true}}"`,
+			example: `--services="{\\"frontend\\":{\\"run\\":\\"./frontend\\",\\"waitFor\\":false},\\"backend\\":{\\"run\\":\\"./backend\\",\\"waitFor\\":true}}"`,
 			parse: JSON.parse,
 		},
 		flightdeckRootDir: {

--- a/packages/flightdeck/src/flightdeck.lib.ts
+++ b/packages/flightdeck/src/flightdeck.lib.ts
@@ -18,7 +18,7 @@ import { ChildSocket } from "atom.io/realtime-server"
 export type FlightDeckOptions<S extends string = string> = {
 	secret: string
 	packageName: string
-	services: { [service in S]: { run: string[]; waitFor: boolean } }
+	services: { [service in S]: { run: string; waitFor: boolean } }
 	scripts: {
 		download: string
 		install: string
@@ -237,8 +237,8 @@ export class FlightDeck<S extends string = string> {
 			return
 		}
 
-		const [executable, ...args] = this.options.services[serviceName].run
-		const serviceProcess = spawn(executable, args, {
+		const [exe, ...args] = this.options.services[serviceName].run.split(` `)
+		const serviceProcess = spawn(exe, args, {
 			cwd: this.options.flightdeckRootDir,
 			env: import.meta.env,
 		})


### PR DESCRIPTION
### **User description**
- **♻️ simplify the run commands in flightdeck**
- **🦋**


___

### **PR Type**
enhancement


___

### **Description**
- Simplified the `run` command format for services from an array to a single string across the codebase.
- Updated the `FlightDeckOptions` type and process spawning logic to accommodate the new `run` command format.
- Modified test cases and example usage to reflect the changes in the `run` command format.
- Added a changeset note documenting the update to the `run` command format.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flightdeck.test.ts</strong><dd><code>Simplify service run command format in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/flightdeck/__tests__/flightdeck.test.ts

<li>Simplified the <code>run</code> command format for services in test cases.<br> <li> Changed <code>run</code> from an array to a single string.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2614/files#diff-3fc604761f1dca6e57f7d838895cf1f9e361038638203f67c8f4572147018550">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flightdeck.bin.ts</strong><dd><code>Update services schema and example for run command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/flightdeck/src/flightdeck.bin.ts

<li>Updated the <code>services</code> schema to use a string for <code>run</code> instead of an <br>array.<br> <li> Modified example usage to reflect the new <code>run</code> format.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2614/files#diff-4537fb95482abbeadf7f5b1a9944f742c02f8607f753333a07ea28713a221a49">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>flightdeck.lib.ts</strong><dd><code>Refactor run command handling in FlightDeckOptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/flightdeck/src/flightdeck.lib.ts

<li>Changed <code>run</code> command from an array to a string in <code>FlightDeckOptions</code>.<br> <li> Updated process spawning logic to split the <code>run</code> string into executable <br>and arguments.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2614/files#diff-d31f2dcef2d0e8621f4f90bb047fdc4cf8cc6f9ca25df3c6718432ddf11c5e5e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tricky-clocks-melt.md</strong><dd><code>Document changes to run command format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/tricky-clocks-melt.md

- Added a changeset note for the update to the `run` command format.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2614/files#diff-be3486a32b8a541c15616d09fc68cafa2e63c25df6dfba2da632f974d42273d2">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

