### PR TITLE
fix port typo

### DIFF
--- a/.changeset/famous-vans-tell.md
+++ b/.changeset/famous-vans-tell.md
@@ -1,0 +1,5 @@
+---
+"tempest.games": patch
+---
+
+🐛 Fix bug where frontend would start on the wrong port.

--- a/apps/tempest.games/src/backend.bun.ts
+++ b/apps/tempest.games/src/backend.bun.ts
@@ -12,13 +12,25 @@ const gameWorker = worker(parent, `backend.worker.game.bun`)
 
 serve({
 	port: BACKEND_PORT ?? 4444,
-	async fetch(req) {
-		parent.logger.info(`🚀`, req.method, req.url)
+	async fetch(req, server) {
+		const ip = server.requestIP(req)?.address ?? `??`
+		parent.logger.info(`🚀`, ip, Date.now(), `<-`, req.method, req.url)
 		const text = await req.text()
 		if (text) {
 			parent.logger.info(`📬`, { text })
 		}
-		return new Response(`Welcome!`)
+		switch (req.method) {
+			case `GET`:
+				if (req.url.endsWith(`/.env`)) {
+					// researching what attackers will try for moira
+					return new Response(`PASSWORD="I am a silly, silly robot."`, {
+						status: 200,
+					})
+				}
+				return new Response(null, { status: 404 })
+			default:
+				return new Response(null, { status: 405 })
+		}
 	},
 })
 

--- a/apps/tempest.games/src/backend.bun.ts
+++ b/apps/tempest.games/src/backend.bun.ts
@@ -1,12 +1,31 @@
 #!/usr/bin/env bun
 
 import { ParentSocket } from "atom.io/realtime-server"
+import { serve } from "bun"
 
 import { worker } from "./backend.worker.ts"
+import { BACKEND_PORT } from "./library/const.ts"
 
 const parent = new ParentSocket()
 
 const gameWorker = worker(parent, `backend.worker.game.bun`)
+
+serve({
+	port: BACKEND_PORT ?? 4444,
+	async fetch(req) {
+		parent.logger.info(`🚀`, req.method, req.url)
+		const text = await req.text()
+		if (text) {
+			parent.logger.info(`📬`, { text })
+		}
+		return new Response(`Welcome!`)
+	},
+})
+
+parent.emit(`alive`)
+parent.on(`updatesReady`, () => {
+	parent.emit(`readyToUpdate`)
+})
 
 process.on(`exit`, () => {
 	gameWorker.process.kill()

--- a/apps/tempest.games/src/frontend.bun.ts
+++ b/apps/tempest.games/src/frontend.bun.ts
@@ -12,7 +12,7 @@ parent.logger.info(` ready`)
 const appDir = resolve(import.meta.dir, `..`, `app`)
 
 serve({
-	port: process.env.PORT ?? 8080,
+	port: FRONTEND_PORT ?? 3333,
 	static: {
 		"/": new Response(await Bun.file(resolve(appDir, `index.html`)).bytes(), {
 			headers: {

--- a/apps/tempest.games/src/library/const.ts
+++ b/apps/tempest.games/src/library/const.ts
@@ -1,1 +1,1 @@
-export const { MODE, FRONTEND_PORT } = process.env
+export const { MODE, FRONTEND_PORT, BACKEND_PORT } = process.env


### PR DESCRIPTION
### **User description**
- **✏️ fix typo**
- **🦋**


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug where the frontend server was starting on the wrong port by changing the port configuration in `frontend.bun.ts`.
- Updated the changeset documentation to reflect the bug fix in the frontend port configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>frontend.bun.ts</strong><dd><code>Fix port configuration for frontend server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/tempest.games/src/frontend.bun.ts

<li>Corrected the port variable from <code>process.env.PORT</code> to <code>FRONTEND_PORT</code>.<br> <li> Changed the default port from 8080 to 3333.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2620/files#diff-a3d90a7b34c541b0ba13d3ced042f4819ab5ad3a247f5082452e936d59cd2bc1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>famous-vans-tell.md</strong><dd><code>Add changeset for frontend port bug fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/famous-vans-tell.md

- Added a changeset entry describing the port bug fix.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2620/files#diff-9d2f6d2f9c5141b708a5d10e9e621b2ed741b238f5c465884a5aa4a42b0954e5">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

