### PR TITLE
flightdeck kill sigint

### DIFF
--- a/.changeset/strong-buses-drive.md
+++ b/.changeset/strong-buses-drive.md
@@ -1,0 +1,5 @@
+---
+"flightdeck": patch
+---
+
+🐛 FlightDeck now sends a "SIGINT" to the processes it kills.

--- a/packages/flightdeck/src/flightdeck.lib.ts
+++ b/packages/flightdeck/src/flightdeck.lib.ts
@@ -347,7 +347,7 @@ export class FlightDeck<S extends string = string> {
 	public stopService(serviceName: S): void {
 		if (this.services[serviceName]) {
 			this.serviceLoggers[serviceName].info(`Stopping service...`)
-			this.services[serviceName].process.kill()
+			this.services[serviceName].process.kill(`SIGINT`)
 			this.services[serviceName] = null
 			this.servicesDead[this.serviceIdx[serviceName]].use(Promise.resolve())
 			this.servicesLive[this.serviceIdx[serviceName]] = new Future(() => {})


### PR DESCRIPTION
### **User description**
- **🐛 use SIGINT to end processes**
- **🦋**


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Modified the `stopService` method in `FlightDeck` to use `SIGINT` for terminating processes, ensuring a more graceful shutdown.
- Added a changeset entry to document the change in process termination signal.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flightdeck.lib.ts</strong><dd><code>Use SIGINT to terminate processes in FlightDeck</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/flightdeck/src/flightdeck.lib.ts

<li>Changed the signal used to terminate processes from default to <code>SIGINT</code>.<br> <li> Updated the <code>stopService</code> method to improve process termination.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2624/files#diff-d31f2dcef2d0e8621f4f90bb047fdc4cf8cc6f9ca25df3c6718432ddf11c5e5e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>strong-buses-drive.md</strong><dd><code>Document FlightDeck process termination change</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/strong-buses-drive.md

<li>Added a changeset entry documenting the use of <code>SIGINT</code> for process <br>termination.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2624/files#diff-1bbc47eeef6a36d4b46397e3063270e6111ba3f4951a82a01481d12141f3fd97">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

