### PR TITLE
treetrunks utilities

### DIFF
--- a/.changeset/chilly-ghosts-hammer.md
+++ b/.changeset/chilly-ghosts-hammer.md
@@ -1,0 +1,5 @@
+---
+"treetrunks": patch
+---
+
+✨ isTreePath provides runtime validation for unknown paths.

--- a/packages/treetrunks/__tests__/treetrunks.test.ts
+++ b/packages/treetrunks/__tests__/treetrunks.test.ts
@@ -1,0 +1,19 @@
+import type { Join, ToPath, TreeMap, TreePath } from "treetrunks"
+import { optional, required } from "treetrunks"
+
+type MySplit = ToPath<`hello/$world/good/morning`, `/`>
+
+const myTree = required({
+	hello: optional({
+		world: null,
+		$name: optional({ good: required({ morning: null }) }),
+	}),
+})
+
+type MyTreePath = TreePath<typeof myTree>
+type MyTreeMap = TreeMap<typeof myTree, null>
+
+type MyTreePathsJoined = Join<MyTreePath, `/`>
+// type MyTreePathsJoined$ = Join<MyTreePath$, `/`>
+
+test(`treetrunks`, () => {})

--- a/packages/treetrunks/src/treetrunks.ts
+++ b/packages/treetrunks/src/treetrunks.ts
@@ -60,17 +60,31 @@ export type ToPath<
 		? [string & {}]
 		: [S]
 
-export type MySplit = ToPath<`hello/$world/good/morning`, `/`>
-
-const myTree = required({
-	hello: optional({
-		world: null,
-		$name: optional({ good: required({ morning: null }) }),
-	}),
-})
-
-type MyTreePath = TreePath<typeof myTree>
-type MyTreeMap = TreeMap<typeof myTree, null>
-
-type MyTreePathsJoined = Join<MyTreePath, `/`>
-// type MyTreePathsJoined$ = Join<MyTreePath$, `/`>
+export function isTreePath<T extends Tree>(
+	tree: T,
+	maybePath: unknown[],
+): maybePath is TreePath<T> {
+	let currentTreeNode: Tree | null = tree
+	for (const segment of maybePath) {
+		if (currentTreeNode === null) {
+			return false
+		}
+		if (typeof segment !== `string`) {
+			return false
+		}
+		if (segment in currentTreeNode[1]) {
+			currentTreeNode = currentTreeNode[1][segment]
+		} else {
+			return false
+		}
+	}
+	if (currentTreeNode === null) {
+		return true
+	}
+	switch (currentTreeNode[0]) {
+		case `required`:
+			return false
+		case `optional`:
+			return true
+	}
+}


### PR DESCRIPTION
### **User description**
- **✨ isTreePath**
- **🦋**


___

### **PR Type**
enhancement, tests


___

### **Description**
- Introduced `isTreePath` function in `treetrunks` for runtime validation of unknown paths.
- Replaced custom route validation logic in `router-service.ts` with `isTreePath`.
- Added a new test file for `treetrunks` with basic test structure.
- Documented the `isTreePath` feature in a changeset.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>router-service.ts</strong><dd><code>Integrate `isTreePath` for route validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/tempest.games/src/frontend/services/router-service.ts

<li>Added <code>isTreePath</code> import from <code>treetrunks</code>.<br> <li> Replaced custom <code>isRoute</code> function with <code>isTreePath</code>.<br> <li> Simplified route validation logic.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2763/files#diff-f95fbe57ce0d6101b7840cb5591cb4d64ab01fe4b00f2d1f4c1363123fd4e629">+6/-31</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>treetrunks.ts</strong><dd><code>Implement `isTreePath` function for path validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/treetrunks/src/treetrunks.ts

<li>Implemented <code>isTreePath</code> function for path validation.<br> <li> Removed inline test code and types.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2763/files#diff-a8c369176935cc842ad200017a1218315f36ffaf3f7ad0bf6ffd3286656c025a">+28/-14</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>treetrunks.test.ts</strong><dd><code>Add basic test structure for `treetrunks`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/treetrunks/__tests__/treetrunks.test.ts

<li>Added a new test file for <code>treetrunks</code>.<br> <li> Defined types and constants for testing.<br> <li> Included a basic test structure.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2763/files#diff-9e9fa58e0185b5945180a224748d0c1a10081328e90e68b40066b1fae4dae7d6">+19/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chilly-ghosts-hammer.md</strong><dd><code>Document `isTreePath` feature in changeset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/chilly-ghosts-hammer.md

- Added changeset for `isTreePath` feature.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2763/files#diff-fd8c4f824bafde27b1e51ccb5483a0915a3144a6775179b776bf70955233f787">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information