### PR TITLE
atom.io join sorts xy to ab

### DIFF
--- a/.changeset/many-garlics-brake.md
+++ b/.changeset/many-garlics-brake.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 Always construct the content keys for relations in Join in A:B order.

--- a/packages/atom.io/data/src/join.ts
+++ b/packages/atom.io/data/src/join.ts
@@ -556,18 +556,19 @@ export class Join<
 				{
 					key: `${options.key}/singleRelatedEntry`,
 					get:
-						(key) =>
+						(x) =>
 						({ get }) => {
-							const relatedKeysState = this.retrieve(relatedKeysAtoms, key)
+							const relatedKeysState = this.retrieve(relatedKeysAtoms, x)
 							const relatedKeys = get(relatedKeysState)
-							for (const relatedKey of relatedKeys) {
-								const contentKey = relations.makeContentKey(
-									key as any,
-									relatedKey as any,
-								) // sort XY to AB ❗
+							for (const y of relatedKeys) {
+								let a = relations.isAType?.(x) ? x : undefined
+								let b = a === undefined ? (x as BType) : undefined
+								a ??= y as AType
+								b ??= y as BType
+								const contentKey = relations.makeContentKey(a, b)
 								const contentState = this.retrieve(contentAtoms, contentKey)
 								const content = get(contentState)
-								return [relatedKey, content]
+								return [y, content]
 							}
 							return null
 						},
@@ -580,19 +581,20 @@ export class Join<
 				{
 					key: `${options.key}/multipleRelatedEntries`,
 					get:
-						(key) =>
+						(x) =>
 						({ get }) => {
 							const jsonFamily = getJsonFamily(relatedKeysAtoms, store)
-							const jsonState = this.retrieve(jsonFamily, key)
+							const jsonState = this.retrieve(jsonFamily, x)
 							const json = get(jsonState)
-							return json.members.map((relatedKey) => {
-								const contentKey = relations.makeContentKey(
-									key as any,
-									relatedKey as any,
-								) // sort XY to AB ❗
+							return json.members.map((y) => {
+								let a = relations.isAType?.(x) ? x : undefined
+								let b = a === undefined ? (x as BType) : undefined
+								a ??= y as AType
+								b ??= y as BType
+								const contentKey = relations.makeContentKey(a, b)
 								const contentState = this.retrieve(contentAtoms, contentKey)
 								const content = get(contentState)
-								return [relatedKey, content]
+								return [y, content]
 							})
 						},
 				},

--- a/packages/atom.io/internal/src/junction.ts
+++ b/packages/atom.io/internal/src/junction.ts
@@ -1,6 +1,5 @@
 import type { Refinement } from "atom.io/introspection"
 import type { Json } from "atom.io/json"
-import { B } from "vitest/dist/chunks/benchmark.JVlTzojj.js"
 
 export type JunctionEntriesBase<
 	AType extends string,
@@ -194,7 +193,7 @@ export class Junction<
 
 	public constructor(
 		data: JunctionSchema<ASide, BSide> &
-			Partial<JunctionEntries<AType, BType, Content>>,
+			Partial<JunctionEntries<NoInfer<AType>, NoInfer<BType>, Content>>,
 		config?: JunctionAdvancedConfiguration<AType, BType, Content>,
 	) {
 		this.a = data.between[0]
@@ -373,9 +372,12 @@ export class Junction<
 						.join(`, `)}). Only one related key was expected.`,
 				)
 			}
+			let singleRelation: AType | BType | undefined
 			for (const relation of relations) {
-				return relation
+				singleRelation = relation
+				break
 			}
+			return singleRelation
 		}
 	}
 
@@ -430,7 +432,7 @@ export class Junction<
 			const aRelations = this.getRelatedKeys(a)
 			if (aRelations) {
 				return [...aRelations].map((aRelation) => {
-					return [aRelation, this.getContent(a, aRelation) ?? (null as Content)]
+					return [aRelation, this.getContent(a, aRelation) as Content]
 				})
 			}
 		}
@@ -438,7 +440,7 @@ export class Junction<
 			const bRelations = this.getRelatedKeys(b)
 			if (bRelations) {
 				return [...bRelations].map((bRelation) => {
-					return [bRelation, this.getContent(bRelation, b) ?? (null as Content)]
+					return [bRelation, this.getContent(bRelation, b) as Content]
 				})
 			}
 		}


### PR DESCRIPTION
### **User description**
- **🐛 sort xy to ab**
- **🦋**


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed a bug to ensure that content keys for relations in the `Join` class are always constructed in A:B order.
- Enhanced the `Junction` class by adding optional type refinements for `AType` and `BType` to improve type safety.
- Updated logic in both `Join` and `Junction` classes to use new type checks and ensure consistent key construction.
- Added documentation for the changes in a changeset file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>join.ts</strong><dd><code>Ensure content keys are constructed in A:B order</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/data/src/join.ts

<li>Changed variable names for clarity and consistency.<br> <li> Ensured content keys are constructed in A:B order.<br> <li> Updated logic for determining types A and B.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2849/files#diff-8ede6a54b258362ab00273b6cca0dabe03db72089527006b1cca991abe187da8">+18/-16</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>junction.ts</strong><dd><code>Add type refinements and ensure A:B order in keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/internal/src/junction.ts

<li>Added optional type refinements for AType and BType.<br> <li> Ensured content keys are constructed in A:B order.<br> <li> Updated relation handling logic to use new type checks.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2849/files#diff-048a08d5bdfbcc17d0ae6107c0e9d87d8998a45e857f7a4a53029b3e375c4606">+16/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>many-garlics-brake.md</strong><dd><code>Document bug fix for content key order</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/many-garlics-brake.md

- Documented the bug fix for constructing content keys in A:B order.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2849/files#diff-a9612a8b9a6869b7725481b7609b619f6785d538c1a5ee4b2140531dfa87ccb4">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information