### PR TITLE
👷 fix the version script given to changeset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: bun release
-          version: changeset version && bun fmt:fix
+          version: bun changeset version && bun fmt:fix
         env:
           GITHUB_TOKEN: ${{ secrets.RENOVATE_HELPER_GITHUB_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### **PR Type**
bug_fix, configuration changes


___

### **Description**
- Fixed an issue in the GitHub Actions release workflow by correcting the version script command.
- Updated the command from `changeset version` to `bun changeset version` to ensure proper execution.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Fix version script command in release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<li>Fixed the version script command in the release workflow.<br> <li> Replaced <code>changeset version</code> with <code>bun changeset version</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2960/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information