### PR TITLE
👷 changesets via bun (again)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: bun release
           version: |
-            changeset version
+            bun changeset version
             bun fmt:fix
         env:
           GITHUB_TOKEN: ${{ secrets.RENOVATE_HELPER_GITHUB_PAT }}


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated the release workflow to use `bun changeset version` instead of `changeset version`.
- Ensures consistency with the use of `bun` for versioning and publishing.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Update version script in release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<li>Updated the version script in the release workflow.<br> <li> Changed from <code>changeset version</code> to <code>bun changeset version</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2962/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information