### PR TITLE
👷 add PAT for changesets to use

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           publish: bun release
           version: ./lib/version.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.RENOVATE_HELPER_GITHUB_PAT }}
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_GITHUB_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Klaxon


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated the GitHub token in the release workflow configuration file to use `CHANGESETS_GITHUB_PAT` instead of `RENOVATE_HELPER_GITHUB_PAT`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Update GitHub token in release workflow configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<li>Updated the GitHub token used in the release workflow.<br> <li> Changed from <code>RENOVATE_HELPER_GITHUB_PAT</code> to <code>CHANGESETS_GITHUB_PAT</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/2964/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information