### PR TITLE
no emoji over ipc

### DIFF
--- a/.changeset/lemon-bugs-grin.md
+++ b/.changeset/lemon-bugs-grin.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 `atom.io/realtime-server` IPC via `ChildSocket`/`ParentSocket` now reports "ALIVE" instead of "✨" when ready due to difficulties sending emoji over IPC in Bun 1.1.35.

--- a/packages/atom.io/realtime-server/src/ipc-sockets/child-socket.ts
+++ b/packages/atom.io/realtime-server/src/ipc-sockets/child-socket.ts
@@ -65,7 +65,7 @@ export class ChildSocket<
 			<Event extends keyof I>(buffer: EventBuffer<string, I[Event]>) => {
 				const chunk = buffer.toString()
 
-				if (chunk === `✨`) {
+				if (chunk === `ALIVE`) {
 					// console.log(chunk)
 					return
 				}

--- a/packages/atom.io/realtime-server/src/ipc-sockets/parent-socket.ts
+++ b/packages/atom.io/realtime-server/src/ipc-sockets/parent-socket.ts
@@ -180,7 +180,7 @@ export class ParentSocket<
 			}
 		})
 
-		process.stdout.write(`✨`)
+		process.stdout.write(`ALIVE`)
 	}
 
 	public relay(

--- a/packages/atom.io/realtime-server/src/realtime-server-stores/server-room-external-store.ts
+++ b/packages/atom.io/realtime-server/src/realtime-server-stores/server-room-external-store.ts
@@ -30,7 +30,7 @@ export const roomSelectors = selectorFamily<
 				(resolve) => {
 					const room = spawn(script, options, { env: process.env })
 					const resolver = (data: Buffer) => {
-						if (data.toString() === `✨`) {
+						if (data.toString() === `ALIVE`) {
 							room.stdout.off(`data`, resolver)
 							resolve(room)
 						}


### PR DESCRIPTION
### **User description**
- **🐛 let's keep ipc to ASCII characters**
- **🦋**


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Replaced the emoji `✨` with the ASCII string `ALIVE` in IPC communication across multiple files to ensure compatibility with ASCII-only systems.
- Updated documentation to reflect the change and explain the reasoning due to difficulties with emoji handling in Bun 1.1.35.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>child-socket.ts</strong><dd><code>Replace emoji with ASCII string in ChildSocket IPC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/realtime-server/src/ipc-sockets/child-socket.ts

<li>Replaced the emoji <code>✨</code> with the string <code>ALIVE</code> for IPC communication.<br> <li> Ensures compatibility with ASCII-only communication.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3013/files#diff-f7fa5b8ee374fe5dcb38f760573d37ccfc6ebb3191d6589a0ff0858bdc8bbc08">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parent-socket.ts</strong><dd><code>Update ParentSocket IPC signal to ASCII</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/realtime-server/src/ipc-sockets/parent-socket.ts

<li>Changed the IPC communication signal from <code>✨</code> to <code>ALIVE</code>.<br> <li> Facilitates ASCII-only communication.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3013/files#diff-2a1c1999f52cb9804ad83e8dca0f1b0b01ae8baa201a79e19920cfe10062402f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server-room-external-store.ts</strong><dd><code>Modify server-room IPC readiness check to ASCII</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/realtime-server/src/realtime-server-stores/server-room-external-store.ts

<li>Modified the IPC readiness check from <code>✨</code> to <code>ALIVE</code>.<br> <li> Supports ASCII character communication.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3013/files#diff-524033e2c997af97bba84fe04a8fffc5bd71e8fa5b56b50c9d93f277575eac36">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lemon-bugs-grin.md</strong><dd><code>Document IPC communication change from emoji to ASCII</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/lemon-bugs-grin.md

<li>Documented the change from <code>✨</code> to <code>ALIVE</code> for IPC communication.<br> <li> Explained the reason for the change due to emoji handling issues.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3013/files#diff-c840086bf4d1b4db4c58c6e1f646ca4c9035d19e9ff121738345a51ead8882e8">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information