### PR TITLE
🔧 fix global dependencies; make lint tasks depend on workspace package.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://turbo.build/schema.json",
+	"globalDependencies": ["tsconfig.json", ".bun-version", ".node-version"],
 	"tasks": {
 		"build": {
 			"dependsOn": ["^build"],
@@ -58,6 +59,7 @@
 		"lint:eslint": {
 			"dependsOn": ["lint:eslint:build"],
 			"inputs": [
+				"../../package.json",
 				"../../eslint.config.ts",
 				"**/package.json",
 				"tsconfig.json",
@@ -70,6 +72,7 @@
 		"lint:types": {
 			"dependsOn": ["gen"],
 			"inputs": [
+				"../../package.json",
 				"../../tsconfig.json",
 				"**/package.json",
 				"tsconfig.json",
@@ -83,6 +86,7 @@
 			"persistent": true,
 			"dependsOn": ["gen"],
 			"inputs": [
+				"../../package.json",
 				"**/package.json",
 				"tsconfig.json",
 				"src/**",
@@ -104,9 +108,6 @@
 				"__tests__/**",
 				"__scripts__/**"
 			]
-		},
-		"globalDependencies": {
-			"inputs": ["pnpm-lock.yaml", "tsconfig.json", ".node-version"]
 		}
 	}
 }


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added `globalDependencies` to include `tsconfig.json`, `.bun-version`, and `.node-version`.
- Updated lint tasks to include `../../package.json` as an input, ensuring they depend on the workspace package.json.
- Removed the redundant `globalDependencies` task from the tasks list.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>turbo.json</strong><dd><code>Update global dependencies and lint task configurations</code>&nbsp; &nbsp; </dd></summary>
<hr>

turbo.json

<li>Added <code>globalDependencies</code> field with new dependencies.<br> <li> Updated lint tasks to depend on the workspace <code>package.json</code>.<br> <li> Removed redundant <code>globalDependencies</code> task.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3014/files#diff-f8de965273949793edc0fbfe249bb458c0becde39b2e141db087bcbf5d4ad5e3">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information