### PR TITLE
👷‍♂️ 9 minutes for build and test job

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -60,7 +60,7 @@ jobs:
   Test:
     name: Build & Test
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 9
     env:
       NEXT_PUBLIC_REMOTE_ORIGIN: ${{ secrets.NEXT_PUBLIC_REMOTE_ORIGIN }}
 


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Increased the timeout for the 'Build & Test' job in the CI workflow from 7 to 9 minutes to allow for longer build and test processes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>integration.yml</strong><dd><code>Extend timeout for build and test job in CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/integration.yml

<li>Increased the timeout for the 'Build & Test' job from 7 to 9 minutes.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3061/files#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information