### PR TITLE
🔨 add script to use the workspace node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
 		"test:semver": "cross-env CI=true turbo run test:semver",
 		"release": "bun run build && changeset publish",
 		"notes": "changeset",
-		"nuke": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' + && rm pnpm-lock.yaml"
+		"nuke": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' + && rm pnpm-lock.yaml",
+		"nv": "fnm use $(pnpm list -w --json | jq -r '.[0].path')"
 	},
 	"trustedDependencies": ["@biomejs/biome"],
 	"devDependencies": {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced a new script command `nv` in `package.json` to facilitate using the workspace node version.
- The `nv` command leverages `fnm` and `pnpm` to automatically set the node version based on the workspace configuration.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add script to use workspace node version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<li>Added a new script command <code>nv</code> to use the workspace node version.<br> <li> Utilizes <code>fnm</code> and <code>pnpm</code> to set the node version.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3070/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information