### PR TITLE
fix varmint exports

### DIFF
--- a/.changeset/mighty-ears-approve.md
+++ b/.changeset/mighty-ears-approve.md
@@ -1,0 +1,5 @@
+---
+"varmint": patch
+---
+
+🐛 Fix bug where the `Ferret` class wasn't properly exported and neither was `CacheMode` (previously `SquirrelMode`).

--- a/packages/varmint/__tests__/ferret.test.ts
+++ b/packages/varmint/__tests__/ferret.test.ts
@@ -3,7 +3,7 @@ import type * as OpenAICore from "openai/core"
 import type OpenAIResources from "openai/resources/index"
 import type { ChatCompletionChunk } from "openai/resources/index"
 
-import { Ferret } from "../src/ferret"
+import { Ferret } from "../src"
 
 test(`ferret`, async () => {
 	const myStreamFunction = () => {

--- a/packages/varmint/src/index.ts
+++ b/packages/varmint/src/index.ts
@@ -1,1 +1,4 @@
+export type * from "./cache-mode"
+export * from "./ferret"
+export * from "./sanitize-filename"
 export * from "./squirrel"


### PR DESCRIPTION
### **User description**
- **🐛 export all resources**
- **🦋**


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug where the `Ferret` class was not properly exported in the `varmint` package.
- Added missing export for `CacheMode` type and `sanitize-filename` utility.
- Updated test file to correctly import `Ferret` from the main module.
- Added a changeset file to document the fixes and changes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ferret.test.ts</strong><dd><code>Fix import path for `Ferret` in test file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/varmint/__tests__/ferret.test.ts

<li>Updated import path for <code>Ferret</code> to ensure proper module resolution.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3099/files#diff-f317b0100f15676b8978cdc2e76d46a3bd4d806884504c1e93d1819f09f6fc62">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Fix and expand exports in `index.ts`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/varmint/src/index.ts

<li>Added export for <code>CacheMode</code> type.<br> <li> Fixed export for <code>Ferret</code> class.<br> <li> Added export for <code>sanitize-filename</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3099/files#diff-716dab157ab2e96e2b008036b44c22689eb0945bd7257b0236ba271cd60772b0">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mighty-ears-approve.md</strong><dd><code>Document export fixes in changeset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/mighty-ears-approve.md

<li>Added a changeset file documenting the fix for <code>Ferret</code> and <code>CacheMode</code> <br>exports.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3099/files#diff-0b7c448e468b625a577102033066780bd650cc9ef0084ec071e2bb510f3561ab">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information