### PR TITLE
🔧 fix access setting on filestore

### DIFF
--- a/packages/socket-io.filestore/package.json
+++ b/packages/socket-io.filestore/package.json
@@ -4,6 +4,9 @@
 	"type": "module",
 	"description": "save json to the filesystem over socket.io",
 	"files": ["dist", "node", "web", "CHANGELOG.md", "README.md"],
+	"publishConfig": {
+		"access": "public"
+	},
 	"scripts": {
 		"build": "tsup --entry src/socket-filestore-node.ts --entry src/socket-filestore-atom-cli.ts --format cjs,esm --dts --external atom.io,react,socket.io,socket.io-client",
 		"lint:biome": "biome check -- .",


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a `publishConfig` section in `package.json` to set the access level for the package.
- Ensured the package is configured to be published with public access.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Added `publishConfig` with public access in package.json</code>&nbsp; </dd></summary>
<hr>

packages/socket-io.filestore/package.json

<li>Added a <code>publishConfig</code> section to specify the access level for the <br>package.<br> <li> Set the <code>access</code> property to <code>public</code> under <code>publishConfig</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3114/files#diff-24c91afa63c58ebd4abb9209df93a9b069b9bcd2abadecd4109030da8579d0d1">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information