### PR TITLE
recursively create varmint base directories

### DIFF
--- a/.changeset/calm-zoos-compare.md
+++ b/.changeset/calm-zoos-compare.md
@@ -1,0 +1,5 @@
+---
+"varmint": patch
+---
+
+🐛 Fix issue where the base directory for storing varmint's cached files wouldn't be created if it was nested inside an already non-existing directory.

--- a/packages/varmint/src/ferret.ts
+++ b/packages/varmint/src/ferret.ts
@@ -85,7 +85,7 @@ export class Ferret {
 		const pathToStreamFile = path.join(subDir, `${subKey}.stream.txt`)
 		const inputStringified = JSON.stringify(args, null, `\t`)
 		if (!fs.existsSync(this.baseDir)) {
-			fs.mkdirSync(this.baseDir)
+			fs.mkdirSync(this.baseDir, { recursive: true })
 		}
 		if (!fs.existsSync(subDir)) {
 			fs.mkdirSync(subDir)

--- a/packages/varmint/src/squirrel.ts
+++ b/packages/varmint/src/squirrel.ts
@@ -57,7 +57,7 @@ export class Squirrel {
 		const pathToOutputFile = path.join(subDir, `${subKey}.output.json`)
 		const inputStringified = JSON.stringify(args, null, `\t`)
 		if (!fs.existsSync(this.baseDir)) {
-			fs.mkdirSync(this.baseDir)
+			fs.mkdirSync(this.baseDir, { recursive: true })
 		}
 		if (!fs.existsSync(subDir)) {
 			fs.mkdirSync(subDir)


### PR DESCRIPTION
### **User description**
- **🐛 recursively create the baseDir**
- **🦋**


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue where nested directories for caching files were not being created automatically in `ferret.ts` and `squirrel.ts`.
- Updated `fs.mkdirSync` calls to include the `recursive: true` option, ensuring all necessary parent directories are created.
- Added a changeset file to document the fix for this issue.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ferret.ts</strong><dd><code>Enable recursive directory creation in `ferret.ts`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/varmint/src/ferret.ts

<li>Updated <code>fs.mkdirSync</code> to use the <code>recursive: true</code> option for creating <br>directories.<br> <li> Ensures nested directories are created if they do not exist.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3179/files#diff-a1e4fccc50cd055493a3e8cec8d0923c6f7f0d320b284880944d2824376dda49">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>squirrel.ts</strong><dd><code>Enable recursive directory creation in `squirrel.ts`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/varmint/src/squirrel.ts

<li>Updated <code>fs.mkdirSync</code> to use the <code>recursive: true</code> option for creating <br>directories.<br> <li> Ensures nested directories are created if they do not exist.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3179/files#diff-9c13ff70463abbb2f10798088d0c1f77b5ac1bc2ec894bf81c0a223d62e9970b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>calm-zoos-compare.md</strong><dd><code>Document fix for nested directory creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/calm-zoos-compare.md

<li>Added a changeset file documenting the fix for nested directory <br>creation.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3179/files#diff-3a2be0f8da486c1bb208743bd3a59085d558aff58aed24fbf41f7acd880b6c5b">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information