### PR TITLE
fix hamr submodule manifests

### DIFF
--- a/.changeset/lucky-kids-approve.md
+++ b/.changeset/lucky-kids-approve.md
@@ -1,0 +1,5 @@
+---
+"hamr": patch
+---
+
+🐛 Improved the manifests for hamr's submodules to include types first.

--- a/packages/hamr/__scripts__/define-submodule-manifests.node.ts
+++ b/packages/hamr/__scripts__/define-submodule-manifests.node.ts
@@ -116,10 +116,10 @@ function defineSubmoduleManifest(submoduleName: string): Json.Object {
 		types: `dist/index.d.ts`,
 		exports: {
 			".": {
+				types: `./dist/index.d.ts`,
 				import: `./dist/index.js`,
 				browser: `./dist/index.js`,
 				require: `./dist/index.cjs`,
-				types: `./dist/index.d.ts`,
 			},
 		},
 	}

--- a/packages/hamr/atom.io-combo/package.json
+++ b/packages/hamr/atom.io-combo/package.json
@@ -7,10 +7,10 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
 			"browser": "./dist/index.js",
-			"require": "./dist/index.cjs",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.cjs"
 		}
 	}
 }

--- a/packages/hamr/atom.io-tools/package.json
+++ b/packages/hamr/atom.io-tools/package.json
@@ -7,10 +7,10 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
 			"browser": "./dist/index.js",
-			"require": "./dist/index.cjs",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.cjs"
 		}
 	}
 }

--- a/packages/hamr/react-click-handlers/package.json
+++ b/packages/hamr/react-click-handlers/package.json
@@ -7,10 +7,10 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
 			"browser": "./dist/index.js",
-			"require": "./dist/index.cjs",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.cjs"
 		}
 	}
 }

--- a/packages/hamr/react-css-vars/package.json
+++ b/packages/hamr/react-css-vars/package.json
@@ -7,10 +7,10 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
 			"browser": "./dist/index.js",
-			"require": "./dist/index.cjs",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.cjs"
 		}
 	}
 }

--- a/packages/hamr/react-data-designer/package.json
+++ b/packages/hamr/react-data-designer/package.json
@@ -7,10 +7,10 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
 			"browser": "./dist/index.js",
-			"require": "./dist/index.cjs",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.cjs"
 		}
 	}
 }

--- a/packages/hamr/react-elastic-input/package.json
+++ b/packages/hamr/react-elastic-input/package.json
@@ -7,10 +7,10 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
 			"browser": "./dist/index.js",
-			"require": "./dist/index.cjs",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.cjs"
 		}
 	}
 }

--- a/packages/hamr/react-error-boundary/package.json
+++ b/packages/hamr/react-error-boundary/package.json
@@ -7,10 +7,10 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
 			"browser": "./dist/index.js",
-			"require": "./dist/index.cjs",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.cjs"
 		}
 	}
 }

--- a/packages/hamr/react-id/package.json
+++ b/packages/hamr/react-id/package.json
@@ -7,10 +7,10 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
 			"browser": "./dist/index.js",
-			"require": "./dist/index.cjs",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.cjs"
 		}
 	}
 }

--- a/packages/hamr/react-json-editor/package.json
+++ b/packages/hamr/react-json-editor/package.json
@@ -7,10 +7,10 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
 			"browser": "./dist/index.js",
-			"require": "./dist/index.cjs",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.cjs"
 		}
 	}
 }

--- a/packages/hamr/react-radial/package.json
+++ b/packages/hamr/react-radial/package.json
@@ -7,10 +7,10 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
 			"browser": "./dist/index.js",
-			"require": "./dist/index.cjs",
-			"types": "./dist/index.d.ts"
+			"require": "./dist/index.cjs"
 		}
 	}
 }


### PR DESCRIPTION
### **User description**
- **🐛 types first in manifests**
- **🦋**


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the order of `types` in the `exports` object across multiple submodule manifests to ensure `types` is listed first.
- Updated the `define-submodule-manifests.node.ts` script to reflect the corrected order for `types`.
- Added a changeset entry documenting the fix for submodule manifests.
- Adjusted `package.json` files for various submodules to align with the corrected `exports` structure.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>define-submodule-manifests.node.ts</strong><dd><code>Fix `types` order in submodule manifests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hamr/__scripts__/define-submodule-manifests.node.ts

<li>Fixed the order of <code>types</code> in the <code>exports</code> object for submodule <br>manifests.<br> <li> Ensured <code>types</code> is listed first in the <code>exports</code> object.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3201/files#diff-1aa466c05269c62cad71028ab82ba0abf800c6d394000a62f197179197571f50">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Fix `types` order in atom.io-combo package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hamr/atom.io-combo/package.json

- Adjusted `exports` object to place `types` first.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3201/files#diff-d7c66bb890dac11c83934a3fac17fe5ba663cef3ba7048e334a505eec532f851">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Fix `types` order in atom.io-tools package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hamr/atom.io-tools/package.json

- Adjusted `exports` object to place `types` first.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3201/files#diff-8708f0818291a75afbed91ed83dafb4556d29c3adbc2086aad287bc7f7a537c7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Fix `types` order in react-click-handlers package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hamr/react-click-handlers/package.json

- Adjusted `exports` object to place `types` first.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3201/files#diff-f5de7c12f2466c20e7b138b1289b2ac77ab03bc95124144ef2f261c8dae15d12">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Fix `types` order in react-css-vars package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hamr/react-css-vars/package.json

- Adjusted `exports` object to place `types` first.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3201/files#diff-b210a76b4780d2c7174472e13ae9992b97ba927b8959e15ee2ecaa7e24bfd719">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Fix `types` order in react-data-designer package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hamr/react-data-designer/package.json

- Adjusted `exports` object to place `types` first.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3201/files#diff-270398afbf3f9758950b9f1d05a8f4f580a69d37301b3d9fa0ee0bd4831140f0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Fix `types` order in react-elastic-input package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hamr/react-elastic-input/package.json

- Adjusted `exports` object to place `types` first.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3201/files#diff-cc29f0012ae543570e012b4be4a92706dcde9934a33a8dcc1640c90d92578365">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Fix `types` order in react-error-boundary package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hamr/react-error-boundary/package.json

- Adjusted `exports` object to place `types` first.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3201/files#diff-af3ae0f9d025a59b96d2e1335e507412f2b2efb01b299865dc9cf863829b8769">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Fix `types` order in react-id package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hamr/react-id/package.json

- Adjusted `exports` object to place `types` first.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3201/files#diff-0414f0cba2a0f011b097c2309481146713c542aec2bee0c2799953e9ed66f6c9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Fix `types` order in react-json-editor package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hamr/react-json-editor/package.json

- Adjusted `exports` object to place `types` first.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3201/files#diff-e526b347eff123f8d85213e5ec610a1a405a3d6380fa4d6d715edc86d3bf7a2f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Fix `types` order in react-radial package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/hamr/react-radial/package.json

- Adjusted `exports` object to place `types` first.



</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3201/files#diff-78c5605f13b0d2e26a1e1d720b61d9d42b4326e50919c472a390b2b24a5ac8bf">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>lucky-kids-approve.md</strong><dd><code>Add changeset entry for submodule manifest fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/lucky-kids-approve.md

<li>Added a changeset entry describing the fix for submodule manifests.<br>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3201/files#diff-e9765aa3eaf5f7cd1e9ba39f46a0309f58c1fbf8453a3c20caa9bef1480b8619">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information