### PR TITLE
debug varmint cache miss

### DIFF
--- a/.changeset/smooth-turkeys-hang.md
+++ b/.changeset/smooth-turkeys-hang.md
@@ -1,0 +1,5 @@
+---
+"varmint": patch
+---
+
+🔊 Add detail error logs for when a cache miss occurs when squirrel or ferret are in read mode. Now, when a read fails, you can compare `YOUR INPUT DATA` against all `CACHED INPUT FILES` in the same folder.

--- a/packages/varmint/__tests__/ferret.test.ts
+++ b/packages/varmint/__tests__/ferret.test.ts
@@ -71,3 +71,51 @@ test(`ferret with openAI`, async () => {
 	}
 	expect(chunks.length).toBe(33)
 })
+
+test(`ferret with openAI (cache-miss)`, async () => {
+	let openAI: OpenAI | undefined
+	function getStreamFromOpenAi(
+		body: Omit<OpenAIResources.ChatCompletionCreateParamsStreaming, `stream`>,
+		options?: OpenAICore.RequestOptions,
+	): Promise<AsyncIterable<ChatCompletionChunk>> {
+		if (!openAI) {
+			openAI = new OpenAI({
+				apiKey: import.meta.env.VITE_OPENAI_API_KEY,
+				dangerouslyAllowBrowser: process.env.NODE_ENV === `test`,
+			})
+		}
+
+		const createParams: OpenAIResources.ChatCompletionCreateParamsStreaming = {
+			...body,
+			stream: true,
+		}
+		console.log(`createParams`, createParams)
+		const stream = openAI.chat.completions.create(createParams, options)
+		return stream
+	}
+
+	const myFerret = new Ferret(`read`)
+
+	let caught: Error | undefined
+	try {
+		await myFerret
+			.add(`myAiService`, getStreamFromOpenAi)
+			.for(`miss`)
+			.get({
+				model: `gpt-4-turbo`,
+				messages: [
+					{ role: `user`, content: `Hello!!!!!!!!!!!!!!!!!!!!!!!!!!!!!` },
+				],
+			})
+	} catch (thrown) {
+		if (thrown instanceof Error) {
+			caught = thrown
+		}
+	} finally {
+		expect(caught).toBeInstanceOf(Error)
+		expect(caught?.message).toContain(`Hello, how are you?`)
+		expect(caught?.message).toContain(`Hello!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`)
+		expect(caught?.message).toContain(`YOUR INPUT DATA:`)
+		expect(caught?.message).toContain(`CACHED INPUT FILES:`)
+	}
+})

--- a/packages/varmint/__tests__/filebox.test.ts
+++ b/packages/varmint/__tests__/filebox.test.ts
@@ -74,4 +74,28 @@ describe(`Filebox`, () => {
 		expect(result).toBe(`The best way to predict the future is to invent it.`)
 		expect(utils.put).toHaveBeenCalledTimes(0)
 	})
+	test(`mode:read (cache-miss)`, async () => {
+		const info: string[] = []
+		const squirrel = new Squirrel(`read`, tempDir.name)
+		fs.mkdirSync(path.join(tempDir.name, `hello`))
+		fs.writeFileSync(
+			path.join(tempDir.name, `hello/casa.input.json`),
+			`[\n\t"http://localhost:12500"\n]`,
+		)
+		const fetcher = squirrel.add(`hello`, async (url: string) => {
+			return fetch(url).then((response) => response.text())
+		})
+		let caught: Error | undefined
+		try {
+			await fetcher.for(`home`).get(`http://localhost:12500`)
+		} catch (thrown) {
+			if (thrown instanceof Error) {
+				console.error(`💥`, thrown)
+				caught = thrown
+			}
+		} finally {
+			expect(caught).toBeInstanceOf(Error)
+			expect(utils.put).toHaveBeenCalledTimes(0)
+		}
+	})
 })

--- a/packages/varmint/src/squirrel.ts
+++ b/packages/varmint/src/squirrel.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
+import { inspect } from "node:util"
 
 import type { CacheMode } from "./cache-mode"
 import { sanitizeFilename } from "./sanitize-filename"
@@ -34,8 +35,34 @@ export class Squirrel {
 					`Squirrel: input file for key "${key}" with "${subKey}" was not found. Directory "${groupDirectory}" does not exist.`,
 				)
 			}
+			const directoryFilenames = fs.readdirSync(groupDirectory)
+			const directoryFiles = directoryFilenames
+				.map((filename) => [
+					filename,
+					fs.readFileSync(path.join(groupDirectory, filename), `utf-8`),
+				])
+				.filter(([filename]) => filename.endsWith(`.input.json`))
+			const allInputs: string[] = []
+			for (const [filename, contents] of directoryFiles) {
+				const inputFileName = `\t${filename}`
+				const inputFileData = `\t\t${inspect(JSON.parse(contents), {
+					depth: Number.POSITIVE_INFINITY,
+					colors: true,
+				})
+					.split(`\n`)
+					.join(`\n\t\t`)}`
+				allInputs.push(inputFileName, inputFileData)
+			}
+
+			const inputData = `\t\t${inspect(args, {
+				depth: Number.POSITIVE_INFINITY,
+				colors: true,
+			})
+				.split(`\n`)
+				.join(`\n\t\t`)}`
+
 			throw new Error(
-				`Squirrel: input file for key "${key}" with subKey "${subKey}" (${pathToInputFile}) was not found. Directory "${groupDirectory}" exists, but the file does not.`,
+				`Squirrel: input file for key "${key}" with subKey "${subKey}" (${pathToInputFile}) was not found. Directory "${groupDirectory}" exists, but the file does not. Below is a list of CACHED INPUT FILES from that directory and their contents, followed by YOUR INPUT DATA.\n\nCACHED INPUT FILES:\n${allInputs.join(`\n`)}\n\nYOUR INPUT DATA:\n${inputData}`,
 			)
 		}
 		const inputFileContents = fs.readFileSync(pathToInputFile, `utf-8`)
@@ -136,7 +163,7 @@ export class Squirrel {
 						.replace(`.input.json`, ``)
 						.replace(`.output.json`, ``)
 					if (!filesTouched.has(subKey)) {
-						console.log(`💥 Flushing ${subKey}`)
+						console.info(`💥 Flushing ${subKey}`)
 						fs.unlinkSync(path.join(subDir, subDirFile))
 					}
 				}


### PR DESCRIPTION
### **User description**
- **🔊 add detail error log**
- **🦋**


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added detailed error logs for cache misses in `Ferret` and `Squirrel`.

- Enhanced test coverage for cache-miss scenarios in `ferret.test.ts` and `filebox.test.ts`.

- Improved error messages to include `YOUR INPUT DATA` and `CACHED INPUT FILES`.

- Replaced `console.log` with `console.info` for better log semantics.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ferret.test.ts</strong><dd><code>Add cache-miss test case for `ferret`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/varmint/__tests__/ferret.test.ts

<li>Added a new test case for cache-miss scenarios in <code>ferret</code>.<br> <li> Simulated OpenAI API interaction with detailed error handling.<br> <li> Verified error messages include relevant input and cache details.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3373/files#diff-f317b0100f15676b8978cdc2e76d46a3bd4d806884504c1e93d1819f09f6fc62">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>filebox.test.ts</strong><dd><code>Add cache-miss test case for `filebox`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/varmint/__tests__/filebox.test.ts

<li>Added a new test case for cache-miss scenarios in <code>filebox</code>.<br> <li> Simulated file-based cache interactions with error handling.<br> <li> Verified error messages include relevant input and cache details.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3373/files#diff-703db7603a03cecf08a1f8280891f48032de664cbdfbe760f9218f450c57bbc2">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ferret.ts</strong><dd><code>Improve error logging for `Ferret` cache misses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/varmint/src/ferret.ts

<li>Enhanced error messages for cache misses in <code>Ferret</code>.<br> <li> Included <code>YOUR INPUT DATA</code> and <code>CACHED INPUT FILES</code> in error details.<br> <li> Replaced <code>console.log</code> with <code>console.info</code> for better log semantics.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3373/files#diff-a1e4fccc50cd055493a3e8cec8d0923c6f7f0d320b284880944d2824376dda49">+29/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>squirrel.ts</strong><dd><code>Improve error logging for `Squirrel` cache misses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/varmint/src/squirrel.ts

<li>Enhanced error messages for cache misses in <code>Squirrel</code>.<br> <li> Included <code>YOUR INPUT DATA</code> and <code>CACHED INPUT FILES</code> in error details.<br> <li> Replaced <code>console.log</code> with <code>console.info</code> for better log semantics.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3373/files#diff-9c13ff70463abbb2f10798088d0c1f77b5ac1bc2ec894bf81c0a223d62e9970b">+29/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>smooth-turkeys-hang.md</strong><dd><code>Add changeset for detailed error logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/smooth-turkeys-hang.md

<li>Documented changes for detailed error logs in cache-miss scenarios.<br> <li> Highlighted improvements in <code>Squirrel</code> and <code>Ferret</code> read modes.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3373/files#diff-f884ef03b176b56bb51a9fac003ff8873ca4a02b71cb54bc41879a6427191946">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>