### PR TITLE
fix ferret tracking

### DIFF
--- a/.changeset/angry-phones-tell.md
+++ b/.changeset/angry-phones-tell.md
@@ -1,0 +1,5 @@
+---
+"varmint": patch
+---
+
+🐛 Fix issue with `varmintWorkspaceManager`, where, on cleanup, the `.ferret` folder, if initialized in the default location (nested under `.varmint`) would be deleted.

--- a/.changeset/nice-moles-admire.md
+++ b/.changeset/nice-moles-admire.md
@@ -1,0 +1,5 @@
+---
+"varmint": patch
+---
+
+✨ Ship the `bin` files, `varmint-track` and `varmint-clean`. A nice way to use the varmint workspace manager from the command line.

--- a/.changeset/small-roses-jam.md
+++ b/.changeset/small-roses-jam.md
@@ -1,0 +1,5 @@
+---
+"varmint": patch
+---
+
+🐛 Fix issue with `varmintWorkspaceManager`, where, on initialization of tracking, the existing cache would not be properly cleared.

--- a/.changeset/three-crabs-teach.md
+++ b/.changeset/three-crabs-teach.md
@@ -1,0 +1,5 @@
+---
+"varmint": patch
+---
+
+🐛 Fix issue with `varmintWorkspaceManager`, where, on cleanup, all `.stream.txt` files would always be deleted.

--- a/.changeset/unlucky-knives-invite.md
+++ b/.changeset/unlucky-knives-invite.md
@@ -1,0 +1,5 @@
+---
+"varmint": patch
+---
+
+🔊 Improve logging in `varmintWorkspaceManager`.

--- a/packages/varmint/__scripts__/varmint-clean.node.ts
+++ b/packages/varmint/__scripts__/varmint-clean.node.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { varmintWorkspaceManager } from "varmint"
+
+varmintWorkspaceManager.endGlobalTrackingAndFlushUnusedFiles()

--- a/packages/varmint/__scripts__/varmint-track.node.ts
+++ b/packages/varmint/__scripts__/varmint-track.node.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { varmintWorkspaceManager } from "varmint"
+
+varmintWorkspaceManager.startGlobalTracking()

--- a/packages/varmint/__tests__/ai.test.ts
+++ b/packages/varmint/__tests__/ai.test.ts
@@ -40,7 +40,6 @@ describe(`ai`, () => {
 		})
 		console.log(evaluation)
 		expect(evaluation.passed).toBe(true)
-		istanbulEnthusiast.flushTestFiles()
 	}, 20_000)
 	test(`ai testing conversation`, async () => {
 		const testId = `job-search`
@@ -109,6 +108,5 @@ describe(`ai`, () => {
 		})
 		console.log(evaluation)
 		expect(evaluation.passed).toBe(true)
-		careerAdvisor.flushTestFiles()
 	}, 120_000)
 })

--- a/packages/varmint/__tests__/filebox.test.ts
+++ b/packages/varmint/__tests__/filebox.test.ts
@@ -99,7 +99,7 @@ describe(`Filebox`, () => {
 			expect(utils.put).toHaveBeenCalledTimes(0)
 		}
 	})
-	test.only(`flushing untouched files`, async () => {
+	test(`flushing untouched files`, async () => {
 		const setup = spawn(
 			`node`,
 			[`--experimental-strip-types`, `global-setup.node.ts`, tempDir.name],

--- a/packages/varmint/__tests__/filebox.test.ts
+++ b/packages/varmint/__tests__/filebox.test.ts
@@ -99,7 +99,7 @@ describe(`Filebox`, () => {
 			expect(utils.put).toHaveBeenCalledTimes(0)
 		}
 	})
-	test(`flushing untouched files`, async () => {
+	test.only(`flushing untouched files`, async () => {
 		const setup = spawn(
 			`node`,
 			[`--experimental-strip-types`, `global-setup.node.ts`, tempDir.name],
@@ -115,11 +115,20 @@ describe(`Filebox`, () => {
 			path.join(tempDir.name, `rand`, `some-random-file.whatever`),
 			`{}`,
 		)
-		expect(fs.readdirSync(tempDir.name)).toEqual([`other`, `rand`])
+		fs.writeFileSync(
+			path.join(tempDir.name, `myStreamer`, `another-random-file.whatever`),
+			`{}`,
+		)
+		expect(fs.readdirSync(tempDir.name)).toEqual([`myStreamer`, `other`, `rand`])
 		expect(fs.readdirSync(path.join(tempDir.name, `rand`))).toEqual([
 			`my-rand.input.json`,
 			`my-rand.output.json`,
 			`some-random-file.whatever`,
+		])
+		expect(fs.readdirSync(path.join(tempDir.name, `myStreamer`))).toEqual([
+			`another-random-file.whatever`,
+			`myAsyncIterable.input.json`,
+			`myAsyncIterable.stream.txt`,
 		])
 		const teardown = spawn(
 			`node`,
@@ -130,10 +139,14 @@ describe(`Filebox`, () => {
 			},
 		)
 		await new Promise((resolve) => teardown.on(`exit`, resolve))
-		expect(fs.readdirSync(tempDir.name)).toEqual([`rand`])
+		expect(fs.readdirSync(tempDir.name)).toEqual([`myStreamer`, `rand`])
 		expect(fs.readdirSync(path.join(tempDir.name, `rand`))).toEqual([
 			`my-rand.input.json`,
 			`my-rand.output.json`,
+		])
+		expect(fs.readdirSync(path.join(tempDir.name, `myStreamer`))).toEqual([
+			`myAsyncIterable.input.json`,
+			`myAsyncIterable.stream.txt`,
 		])
 	})
 })

--- a/packages/varmint/__tests__/isolation/global-setup.node.ts
+++ b/packages/varmint/__tests__/isolation/global-setup.node.ts
@@ -1,7 +1,10 @@
+import { Ferret } from "../../src/ferret.ts"
 import { Squirrel } from "../../src/squirrel.ts"
 import { varmintWorkspaceManager } from "../../src/varmint-workspace-manager.ts"
 
 const tempdirName = process.argv[2]
+
+varmintWorkspaceManager.startGlobalTracking()
 
 function asyncRand() {
 	return new Promise((resolve) =>
@@ -10,10 +13,21 @@ function asyncRand() {
 		}, 1),
 	)
 }
-
-varmintWorkspaceManager.startGlobalTracking()
-
 const squirrel = new Squirrel(`read-write`, tempdirName)
-const rand = squirrel.add(`rand`, asyncRand)
-const myRand = rand.for(`my-rand`)
-await myRand.get()
+await squirrel.add(`rand`, asyncRand).for(`my-rand`).get()
+
+const myStreamFunction = () => {
+	const myAsyncIterable = {
+		async *[Symbol.asyncIterator]() {
+			await new Promise((resolve) => setTimeout(resolve, 1))
+			yield `chunk1`
+			await new Promise((resolve) => setTimeout(resolve, 1))
+			yield `chunk2`
+			await new Promise((resolve) => setTimeout(resolve, 1))
+			yield `chunk3`
+		},
+	}
+	return Promise.resolve(myAsyncIterable)
+}
+const myFerret = new Ferret(`read-write`, tempdirName)
+await myFerret.add(`myStreamer`, myStreamFunction).for(`myAsyncIterable`).get()

--- a/packages/varmint/build.bun.ts
+++ b/packages/varmint/build.bun.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env bun
+
+import { build } from "bun"
+
+await Promise.all([
+	build({
+		entrypoints: [`src/index.ts`],
+		outdir: `./dist`,
+		target: `node`,
+	}),
+	build({
+		entrypoints: [
+			`__scripts__/varmint-track.node.ts`,
+			`__scripts__/varmint-clean.node.ts`,
+		],
+		outdir: `./bin`,
+		target: `node`,
+		packages: `external`,
+	}),
+])

--- a/packages/varmint/package.json
+++ b/packages/varmint/package.json
@@ -18,7 +18,11 @@
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"module": "dist/index.js",
-	"files": ["dist", "src"],
+	"bin": {
+		"varmint-clean": "bin/varmint-clean.node.js",
+		"varmint-track": "bin/varmint-track.node.js"
+	},
+	"files": ["bin", "dist", "src", "CHANGELOG.md"],
 	"scripts": {
 		"build:js": "./build.bun.ts",
 		"build:dts": "tsup",

--- a/packages/varmint/package.json
+++ b/packages/varmint/package.json
@@ -40,6 +40,7 @@
 	"devDependencies": {
 		"@types/node": "22.13.1",
 		"@types/tmp": "0.2.6",
+		"bun-types": "1.2.2",
 		"concurrently": "9.1.2",
 		"eslint": "9.19.0",
 		"openai": "4.83.0",

--- a/packages/varmint/package.json
+++ b/packages/varmint/package.json
@@ -33,7 +33,7 @@
 		"lint:types:watch": "tsc --watch --noEmit",
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "vitest",
-		"test:once": "vitest run",
+		"test:once": "bun ./__scripts__/varmint-track.node.ts && vitest run && bun ./__scripts__/varmint-clean.node.ts",
 		"test:coverage": "echo no test coverage yet",
 		"postversion": "biome format --write package.json"
 	},

--- a/packages/varmint/package.json
+++ b/packages/varmint/package.json
@@ -20,7 +20,7 @@
 	"module": "dist/index.js",
 	"files": ["dist", "src"],
 	"scripts": {
-		"build:js": "bun build --outdir dist --target node -- src/index.ts",
+		"build:js": "./build.bun.ts",
 		"build:dts": "tsup",
 		"build": "concurrently \"bun:build:*\"",
 		"lint:biome": "biome check -- .",

--- a/packages/varmint/src/ferret.ts
+++ b/packages/varmint/src/ferret.ts
@@ -2,9 +2,9 @@ import * as fs from "node:fs"
 import * as path from "node:path"
 import { inspect } from "node:util"
 
-import type { CacheMode } from "./cache-mode"
-import { sanitizeFilename } from "./sanitize-filename"
-import { varmintWorkspaceManager as mgr } from "./varmint-workspace-manager"
+import type { CacheMode } from "./cache-mode.ts"
+import { sanitizeFilename } from "./sanitize-filename.ts"
+import { varmintWorkspaceManager as mgr } from "./varmint-workspace-manager.ts"
 
 export type Loadable<T> = Promise<T> | T
 

--- a/packages/varmint/src/varmint-workspace-manager.ts
+++ b/packages/varmint/src/varmint-workspace-manager.ts
@@ -111,7 +111,7 @@ export const varmintWorkspaceManager = {
 			}
 			const realRootContents = fs.readdirSync(realRoot)
 			for (const rootContent of realRootContents) {
-				if (!rootMap.has(rootContent)) {
+				if (rootContent !== `.ferret` && !rootMap.has(rootContent)) {
 					const pathForRemoval = path.join(realRoot, rootContent)
 					console.log(`🧹 globalFlush: removing directory ${pathForRemoval}`)
 					fs.rmSync(pathForRemoval, { recursive: true })

--- a/packages/varmint/src/varmint-workspace-manager.ts
+++ b/packages/varmint/src/varmint-workspace-manager.ts
@@ -124,7 +124,7 @@ export const varmintWorkspaceManager = {
 					const contentTrimmed = realListContent
 						.replace(`.input.json`, ``)
 						.replace(`.output.json`, ``)
-						.replace(`stream.txt`, ``)
+						.replace(`.stream.txt`, ``)
 					if (!list.has(contentTrimmed)) {
 						const pathForRemoval = path.join(realList, realListContent)
 						console.log(`🧹 globalFlush: removing file ${pathForRemoval}`)

--- a/packages/varmint/src/varmint-workspace-manager.ts
+++ b/packages/varmint/src/varmint-workspace-manager.ts
@@ -30,7 +30,7 @@ export const varmintWorkspaceManager = {
 			console.error(
 				`💥 The global cache for the project "${PROJECT_IDENTIFIER}" was found already initialized. Clearing it and starting fresh.`,
 			)
-			return
+			varmintWorkspaceManager.storage.clear()
 		}
 		varmintWorkspaceManager.storage.initialize()
 	},

--- a/packages/varmint/src/varmint-workspace-manager.ts
+++ b/packages/varmint/src/varmint-workspace-manager.ts
@@ -8,10 +8,8 @@ import { FilesystemStorage } from "safedeposit"
 import { sanitizeFilename } from "./sanitize-filename.ts"
 
 const GLOBAL_CACHE_FOLDER = cachedir(`varmint`)
-const CACHE_FOLDER = resolve(
-	GLOBAL_CACHE_FOLDER,
-	sanitizeFilename(process.cwd()),
-)
+const PROJECT_IDENTIFIER = sanitizeFilename(process.cwd())
+const CACHE_FOLDER = resolve(GLOBAL_CACHE_FOLDER, PROJECT_IDENTIFIER)
 
 export type FilesTouched = Record<`file__${string}`, `true`>
 export type ListsTouched = Record<`list__${string}`, `true`>
@@ -25,15 +23,21 @@ export const varmintWorkspaceManager = {
 		eagerInit: false,
 	}),
 	startGlobalTracking(): void {
+		console.log(
+			`🐿️  Starting global tracking of varmint files using project identifier "${PROJECT_IDENTIFIER}"`,
+		)
 		if (varmintWorkspaceManager.storage.initialized) {
 			console.error(
-				`💥 called startGlobalTracking, but the global cache was already initialized`,
+				`💥 The global cache for the project "${PROJECT_IDENTIFIER}" was found already initialized. Clearing it and starting fresh.`,
 			)
 			return
 		}
 		varmintWorkspaceManager.storage.initialize()
 	},
 	endGlobalTrackingAndFlushUnusedFiles(): void {
+		console.log(
+			`🐿️  Ending global tracking of varmint files using project identifier "${PROJECT_IDENTIFIER}"`,
+		)
 		if (!varmintWorkspaceManager.storage.initialized) {
 			console.error(
 				`💥 called flushGlobal, but the global cache wasn't initialized with startGlobalTracking`,
@@ -98,6 +102,7 @@ export const varmintWorkspaceManager = {
 				)
 			}
 		}
+		console.log(`🐿️ `, tree)
 		for (const [rootName, rootMap] of tree.entries()) {
 			const realRoot = realRoots.get(rootName)
 			if (!realRoot) {

--- a/packages/varmint/src/varmint-workspace-manager.ts
+++ b/packages/varmint/src/varmint-workspace-manager.ts
@@ -36,7 +36,7 @@ export const varmintWorkspaceManager = {
 	},
 	endGlobalTrackingAndFlushUnusedFiles(): void {
 		console.log(
-			`🐿️  Ending global tracking of varmint files using project identifier "${PROJECT_IDENTIFIER}"`,
+			`🐿️  Ending global tracking of varmint files using project identifier "${PROJECT_IDENTIFIER}" and starting cleanup of untouched	 files.`,
 		)
 		if (!varmintWorkspaceManager.storage.initialized) {
 			console.error(
@@ -109,6 +109,13 @@ export const varmintWorkspaceManager = {
 				console.error(`💥 Could not find root ${rootName}`)
 				continue
 			}
+			const realRootStillExists = fs.existsSync(realRoot)
+			if (!realRootStillExists) {
+				console.warn(
+					`💥 Root folder ${realRoot}, identified as being used during tracking, no longer exists during cleanup.`,
+				)
+				continue
+			}
 			const realRootContents = fs.readdirSync(realRoot)
 			for (const rootContent of realRootContents) {
 				if (rootContent !== `.ferret` && !rootMap.has(rootContent)) {
@@ -119,6 +126,13 @@ export const varmintWorkspaceManager = {
 			}
 			for (const [listName, list] of rootMap.entries()) {
 				const realList = path.join(realRoot, listName)
+				const realListStillExists = fs.existsSync(realList)
+				if (!realListStillExists) {
+					console.warn(
+						`💥 List folder ${realList}, identified as being used during tracking, no longer exists.`,
+					)
+					continue
+				}
 				const realListContents = fs.readdirSync(realList)
 				for (const realListContent of realListContents) {
 					const contentTrimmed = realListContent

--- a/packages/varmint/tsconfig.json
+++ b/packages/varmint/tsconfig.json
@@ -1,7 +1,14 @@
 {
 	"extends": "../../tsconfig.json",
-	"include": ["src", "__tests__", "**/*.config.ts", "./vite-env.d.ts"],
+	"include": [
+		"**/*.config.ts",
+		"./vite-env.d.ts",
+		"__scripts__",
+		"__tests__",
+		"build.bun.ts",
+		"src"
+	],
 	"compilerOptions": {
-		"types": ["vite/client", "vitest/globals"]
+		"types": ["vite/client", "vitest/globals", "bun-types"]
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1379,6 +1379,9 @@ importers:
       '@types/tmp':
         specifier: 0.2.6
         version: 0.2.6
+      bun-types:
+        specifier: 1.2.2
+        version: 1.2.2
       concurrently:
         specifier: 9.1.2
         version: 9.1.2

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
 			"treetrunks": ["./packages/treetrunks/src/treetrunks.ts"],
 			"tsdoc.json": ["packages/tsdoc.json/src"],
 			"tsdoc.json/*": ["packages/tsdoc.json/*/src"],
+			"varmint": ["./packages/varmint/src/index.ts"],
 			"wayfarer.quest/*": ["./apps/wayfarer.quest/src/*"],
 			"~/*": ["./*"]
 		},


### PR DESCRIPTION
### **User description**
- **✅ remove old flush calls**
- **🔧 add varmint to global tsconfig to simulate install**
- **➕ bun-types (varmint)**
- **🚚 add file extensions to ferret for nodenext in testing**
- **🛠️ add tracking scripts**
- **♻️ add build.bun.ts; include new bin build**
- **📦 include new bin files**
- **🔊 add improved logs to workspace manager**
- **🐛 fix issue where stream files from ferret would always be deleted**
- **🐛 fix issue where the .ferret folder would automatically be deleted if nested by default**
- **🐛 automatically pave over an already initialized cache if initializing**
- **🔨 use workspace scripts to wrap single test run**
- **✅ test ferret with workspace cleanup**
- **🦋**


___

### **PR Type**
Bug fix, Enhancement, Tests, Documentation


___

### **Description**
- Added CLI scripts `varmint-track` and `varmint-clean` for workspace management.

- Enhanced `varmintWorkspaceManager` with improved logging and cache handling.

- Fixed issues with `.ferret` folder deletion and `.stream.txt` files during cleanup.

- Updated tests and configurations to align with new functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>varmint-clean.node.ts</strong><dd><code>Added CLI script for cleaning unused files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-b3eb09c318a1c2e9aef396808e15192a2d6905391e87ce4f499ed3680eae55f6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>varmint-track.node.ts</strong><dd><code>Added CLI script for starting global tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-9359c61fac82ff0d4fca5066e817eda242c40dad12e462f107dd531a19c05143">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>varmint-workspace-manager.ts</strong><dd><code>Improved logging and cache handling in workspace manager</code>&nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-57cf296b0d56271d709c1e0f5a9c9e771ac3ba4902530bdd74be2952552ecca6">+13/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>ai.test.ts</strong><dd><code>Removed redundant flush calls in AI tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-8fc5e2860beb9c1eed8130d590fdb9fc453d5a3971f9b4b6e894f466b31a6436">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>filebox.test.ts</strong><dd><code>Updated test for flushing untouched files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-703db7603a03cecf08a1f8280891f48032de664cbdfbe760f9218f450c57bbc2">+16/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>global-setup.node.ts</strong><dd><code>Added async iterable stream setup in global test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-e2e2f9d72d2718ab6b2ba0a3d60eed056318416e9fbd03d0bb75eca5b6b1f5f8">+20/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>build.bun.ts</strong><dd><code>Added build script for CLI and main files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-6e69eec70d41a48c701ae0bad43417f68ab4bebed5cb0e089cfedb3838874872">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>package.json</strong><dd><code>Updated package.json with CLI scripts and dependencies</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-c008bfd5f12db59e707f4789de0eede340d64c7154f8c6ade6a4e2dd44581c7a">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tsconfig.json</strong><dd><code>Updated tsconfig to include new scripts and types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-e412605cdae4af2759e3d9b02cb63cc52578877c3db02639e45299018c964616">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tsconfig.json</strong><dd><code>Added `varmint` alias to tsconfig paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ferret.ts</strong><dd><code>Updated imports to include file extensions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-a1e4fccc50cd055493a3e8cec8d0923c6f7f0d320b284880944d2824376dda49">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>angry-phones-tell.md</strong><dd><code>Documented fix for `.ferret` folder deletion issue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-f3999a184a21ee55d86b9b25481e180ad03fc803f3f19d0eab6eb9426b52c095">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nice-moles-admire.md</strong><dd><code>Documented addition of CLI scripts for workspace management</code></dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-35441908689f0a749ed193b91b19ebe46ccd1c6d530f96564ec98aa22beabce5">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>small-roses-jam.md</strong><dd><code>Documented fix for cache clearing on initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-270fbd558f40bdfcd0c6cf54bd3bf9bf0fe461845b64359c4792c99265cfbea4">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>three-crabs-teach.md</strong><dd><code>Documented fix for `.stream.txt` file deletion issue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-a5a97d85a1183d3a1cd5d3386bb4b6b8502ec609615c2d8289c44621b32d933c">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>unlucky-knives-invite.md</strong><dd><code>Documented logging improvements in workspace manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-13bbb9df480ba9558188a74bac1b224d98e79aeadb8d51183ce0336294c2906b">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>pnpm-lock.yaml</strong><dd><code>Added `bun-types` dependency to lockfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3412/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>