### PR TITLE
varmint workspace special break sequence

### DIFF
--- a/.changeset/dirty-squids-destroy.md
+++ b/.changeset/dirty-squids-destroy.md
@@ -1,0 +1,5 @@
+---
+"varmint": patch
+---
+
+🐛 Fix issue where certain filenames would always be purged if they contained the sequence "\_\_".

--- a/packages/varmint/src/ferret.ts
+++ b/packages/varmint/src/ferret.ts
@@ -4,7 +4,10 @@ import { inspect } from "node:util"
 
 import type { CacheMode } from "./cache-mode.ts"
 import { sanitizeFilename } from "./sanitize-filename.ts"
-import { varmintWorkspaceManager as mgr } from "./varmint-workspace-manager.ts"
+import {
+	SPECIAL_BREAK_SEQ as SBS,
+	varmintWorkspaceManager as mgr,
+} from "./varmint-workspace-manager.ts"
 
 export type Loadable<T> = Promise<T> | T
 
@@ -41,9 +44,9 @@ export class Ferret {
 		this.rootName = sanitizeFilename(this.baseDir)
 		if (
 			mgr.storage.initialized &&
-			!mgr.storage.getItem(`root__${this.rootName}`)
+			!mgr.storage.getItem(`root${SBS}${this.rootName}`)
 		) {
-			mgr.storage.setItem(`root__${this.rootName}`, this.baseDir)
+			mgr.storage.setItem(`root${SBS}${this.rootName}`, this.baseDir)
 		}
 	}
 
@@ -166,7 +169,7 @@ export class Ferret {
 	}
 
 	public add<F extends StreamFunc>(key: string, getStream: F): Ferreted<F> {
-		const listName = `${this.rootName}__${sanitizeFilename(key)}` as const
+		const listName = `${this.rootName}${SBS}${sanitizeFilename(key)}` as const
 		return {
 			flush: () => {
 				this.flush(key)
@@ -176,9 +179,9 @@ export class Ferret {
 					this.filesTouched.set(key, new Set())
 					if (
 						mgr.storage.initialized &&
-						!mgr.storage.getItem(`list__${listName}`)
+						!mgr.storage.getItem(`list${SBS}${listName}`)
 					) {
-						mgr.storage.setItem(`list__${listName}`, `true`)
+						mgr.storage.setItem(`list${SBS}${listName}`, `true`)
 					}
 				}
 				return {
@@ -192,8 +195,8 @@ export class Ferret {
 								subKey = cachedSubKey
 							}
 							this.filesTouched.get(key)?.add(subKey)
-							const fileName = `${listName}__${subKey}` as const
-							const fileNameTagged = `file__${fileName}` as const
+							const fileName = `${listName}${SBS}${subKey}` as const
+							const fileNameTagged = `file${SBS}${fileName}` as const
 							if (
 								mgr.storage.initialized &&
 								!mgr.storage.getItem(fileNameTagged)

--- a/packages/varmint/src/squirrel.ts
+++ b/packages/varmint/src/squirrel.ts
@@ -4,7 +4,10 @@ import { inspect } from "node:util"
 
 import type { CacheMode } from "./cache-mode.ts"
 import { sanitizeFilename } from "./sanitize-filename.ts"
-import { varmintWorkspaceManager as mgr } from "./varmint-workspace-manager.ts"
+import {
+	SPECIAL_BREAK_SEQ as SBS,
+	varmintWorkspaceManager as mgr,
+} from "./varmint-workspace-manager.ts"
 
 export type AsyncFunc = (...args: any[]) => Promise<any>
 
@@ -29,9 +32,9 @@ export class Squirrel {
 		this.rootName = sanitizeFilename(this.baseDir)
 		if (
 			mgr.storage.initialized &&
-			!mgr.storage.getItem(`root__${this.rootName}`)
+			!mgr.storage.getItem(`root${SBS}${this.rootName}`)
 		) {
-			mgr.storage.setItem(`root__${this.rootName}`, this.baseDir)
+			mgr.storage.setItem(`root${SBS}${this.rootName}`, this.baseDir)
 		}
 	}
 
@@ -120,7 +123,7 @@ export class Squirrel {
 	}
 
 	public add<F extends AsyncFunc>(key: string, get: F): Squirreled<F> {
-		const listName = `${this.rootName}__${sanitizeFilename(key)}` as const
+		const listName = `${this.rootName}${SBS}${sanitizeFilename(key)}` as const
 		return {
 			flush: () => {
 				this.flush(key)
@@ -130,9 +133,9 @@ export class Squirrel {
 					this.filesTouched.set(key, new Set())
 					if (
 						mgr.storage.initialized &&
-						!mgr.storage.getItem(`list__${listName}`)
+						!mgr.storage.getItem(`list${SBS}${listName}`)
 					) {
-						mgr.storage.setItem(`list__${listName}`, `true`)
+						mgr.storage.setItem(`list${SBS}${listName}`, `true`)
 					}
 				}
 				return {
@@ -148,8 +151,8 @@ export class Squirrel {
 								subKey = cachedSubKey
 							}
 							this.filesTouched.get(key)?.add(subKey)
-							const fileName = `${listName}__${subKey}` as const
-							const fileNameTagged = `file__${fileName}` as const
+							const fileName = `${listName}${SBS}${subKey}` as const
+							const fileNameTagged = `file${SBS}${fileName}` as const
 							if (
 								mgr.storage.initialized &&
 								!mgr.storage.getItem(fileNameTagged)


### PR DESCRIPTION
### **User description**
- **♻️ use special break sequence very unlikely to occur in real filenames**
- **🦋**


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Introduced `SPECIAL_BREAK_SEQ` to replace `__` in filenames.

- Updated file and list tagging logic to use `SPECIAL_BREAK_SEQ`.

- Enhanced type definitions for file, list, and root tags.

- Added a changeset entry to document the bug fix.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ferret.ts</strong><dd><code>Use `SPECIAL_BREAK_SEQ` in Ferret class logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/varmint/src/ferret.ts

<li>Replaced <code>__</code> with <code>SPECIAL_BREAK_SEQ</code> in key and filename generation.<br> <li> Updated storage access logic to use <code>SPECIAL_BREAK_SEQ</code>.<br> <li> Improved readability by importing <code>SPECIAL_BREAK_SEQ</code> as <code>SBS</code>.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3415/files#diff-a1e4fccc50cd055493a3e8cec8d0923c6f7f0d320b284880944d2824376dda49">+11/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>squirrel.ts</strong><dd><code>Use `SPECIAL_BREAK_SEQ` in Squirrel class logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/varmint/src/squirrel.ts

<li>Replaced <code>__</code> with <code>SPECIAL_BREAK_SEQ</code> in key and filename generation.<br> <li> Updated storage access logic to use <code>SPECIAL_BREAK_SEQ</code>.<br> <li> Improved readability by importing <code>SPECIAL_BREAK_SEQ</code> as <code>SBS</code>.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3415/files#diff-9c13ff70463abbb2f10798088d0c1f77b5ac1bc2ec894bf81c0a223d62e9970b">+11/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>varmint-workspace-manager.ts</strong><dd><code>Introduce `SPECIAL_BREAK_SEQ` and update workspace manager logic</code></dd></summary>
<hr>

packages/varmint/src/varmint-workspace-manager.ts

<li>Defined <code>SPECIAL_BREAK_SEQ</code> and related constants for tagging.<br> <li> Replaced <code>__</code> with <code>SPECIAL_BREAK_SEQ</code> in root, list, and file handling.<br> <li> Enhanced type definitions for file, list, and root tags.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3415/files#diff-57cf296b0d56271d709c1e0f5a9c9e771ac3ba4902530bdd74be2952552ecca6">+25/-14</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dirty-squids-destroy.md</strong><dd><code>Document bug fix for filename handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/dirty-squids-destroy.md

- Added a changeset entry documenting the bug fix for filenames.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3415/files#diff-23aea26a2e53b068be4d20155e01618a629cda523990513ae44e470dbbc140e6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>