### PR TITLE
🔧 allow vercel/speed-insights to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
 		"typescript": "5.7.3",
 		"vite-tsconfig-paths": "5.1.4",
 		"vitest": "3.0.5"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": ["@vercel/speed-insights"]
 	}
 }


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added `pnpm.onlyBuiltDependencies` configuration to `package.json`.

- Enabled build support for `@vercel/speed-insights` dependency.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add pnpm configuration for build dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<li>Added a new <code>pnpm</code> configuration section.<br> <li> Configured <code>onlyBuiltDependencies</code> to include <code>@vercel/speed-insights</code>.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3473/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>