### PR TITLE
✅ restore no default coverage fail

### DIFF
--- a/.changeset/heavy-parents-warn.md
+++ b/.changeset/heavy-parents-warn.md
@@ -1,0 +1,5 @@
+---
+"recoverage": patch
+---
+
+✨ Add the simple invocation, `recoverage`. This invocation runs both `recoverage capture`, placing your current coverage state into your coverage database, and `recoverage diff`, comparing the current coverage state of your package to its coverage state on your repo's default branch.

--- a/.changeset/old-plums-glow.md
+++ b/.changeset/old-plums-glow.md
@@ -1,0 +1,5 @@
+---
+"recoverage": patch
+---
+
+✨ Pass `default-branch` as an option to `recoverage` and `recoverage diff`.

--- a/packages/atom.io/package.json
+++ b/packages/atom.io/package.json
@@ -44,8 +44,6 @@
 		"lint": "bun run lint:biome && bun run lint:eslint && bun run lint:types",
 		"test": "vitest",
 		"test:coverage": "vitest run --coverage && ../recoverage/src/recoverage.x.ts",
-		"cov": "../recoverage/src/recoverage.x.ts",
-		"cov:diff": "recoverage diff",
 		"test:build": "bun run test:manifest && cross-env IMPORT=dist vitest run",
 		"test:once": "echo tested built code",
 		"test:once:public": "cross-env IMPORT=dist vitest run public",

--- a/packages/recoverage/src/recoverage.x.ts
+++ b/packages/recoverage/src/recoverage.x.ts
@@ -60,8 +60,7 @@ switch (inputs.case) {
 					inputs.opts[`default-branch`] ?? `main`,
 				)
 				if (diffCode === 1) {
-					// process.exit(1)
-					console.log(`❗ temporarily disabled exit 1`)
+					process.exit(1)
 				}
 			} catch (thrown) {
 				console.error(thrown)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Restores the functionality to exit with code 1 on failure.

- Removes temporary console log for disabled exit.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>recoverage.x.ts</strong><dd><code>Restore `process.exit(1)` for coverage failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/recoverage/src/recoverage.x.ts

<li>Re-enabled <code>process.exit(1)</code> for coverage failure.<br> <li> Removed temporary console log indicating disabled exit.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3485/files#diff-eaf7b77b987a7788e23497d4da09fab0d2ec890fb2e181fe5d8b4676e36ebcc6">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>