### PR TITLE
varmint fix superlong name

### DIFF
--- a/.changeset/whole-paws-talk.md
+++ b/.changeset/whole-paws-talk.md
@@ -1,0 +1,5 @@
+---
+"varmint": patch
+---
+
+🐛 Fix bug where in cases of super long inputs, varmint would fail to shorten them into something reasonable for the file system.

--- a/packages/varmint/src/ferret.ts
+++ b/packages/varmint/src/ferret.ts
@@ -112,7 +112,7 @@ export class Ferret {
 				mgr.storage.setItem(`DID_CACHE_MISS`, `true`)
 			}
 			throw new Error(
-				`Squirrel: the content of the cached input file ${pathToInputFile} does not match the input provided.\n\nProvided:\n${inputStringified}\n\nCached:\n${inputFileContents}`,
+				`Ferret: the content of the cached input file ${pathToInputFile} does not match the input provided.\n\nProvided:\n${inputStringified}\n\nCached:\n${inputFileContents}`,
 			)
 		}
 		const pathToOutputFile = path.join(this.baseDir, key, `${subKey}.stream.txt`)

--- a/packages/varmint/src/ferret.ts
+++ b/packages/varmint/src/ferret.ts
@@ -205,9 +205,9 @@ export class Ferret {
 							let cachedSubKey = this.filenameCache.get(unSafeSubKey)
 							if (!cachedSubKey) {
 								cachedSubKey = sanitizeFilename(unSafeSubKey)
-								this.filenameCache.set(unSafeSubKey, subKey)
-								subKey = cachedSubKey
+								this.filenameCache.set(unSafeSubKey, cachedSubKey)
 							}
+							subKey = cachedSubKey
 							this.filesTouched.get(key)?.add(subKey)
 							const fileName = `${listName}${SBS}${subKey}` as const
 							const fileNameTagged = `file${SBS}${fileName}` as const

--- a/packages/varmint/src/squirrel.ts
+++ b/packages/varmint/src/squirrel.ts
@@ -161,9 +161,9 @@ export class Squirrel {
 							let cachedSubKey = this.filenameCache.get(unSafeSubKey)
 							if (!cachedSubKey) {
 								cachedSubKey = sanitizeFilename(unSafeSubKey)
-								this.filenameCache.set(unSafeSubKey, subKey)
-								subKey = cachedSubKey
+								this.filenameCache.set(unSafeSubKey, cachedSubKey)
 							}
+							subKey = cachedSubKey
 							this.filesTouched.get(key)?.add(subKey)
 							const fileName = `${listName}${SBS}${subKey}` as const
 							const fileNameTagged = `file${SBS}${fileName}` as const


### PR DESCRIPTION
### **User description**
- **🐛 fix bug where superlong inputs would occasionally bust the filesystem write**
- **🦋**


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug causing failure with superlong inputs.

- Corrected caching logic for sanitized filenames.

- Added a changeset entry documenting the bug fix.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>squirrel.ts</strong><dd><code>Corrected caching and handling of superlong inputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/varmint/src/squirrel.ts

<li>Fixed caching logic for sanitized filenames.<br> <li> Ensured proper handling of superlong input keys.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3599/files#diff-9c13ff70463abbb2f10798088d0c1f77b5ac1bc2ec894bf81c0a223d62e9970b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>whole-paws-talk.md</strong><dd><code>Added changeset entry for bug fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/whole-paws-talk.md

<li>Added a changeset entry for the bug fix.<br> <li> Documented the issue with superlong inputs.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3599/files#diff-637ee14fd50432c084e34c0614d928fa96761cebd5bcf6339d963b2f188fc2cf">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>