### PR TITLE
🔨 fix wrangler deploy

### DIFF
--- a/apps/edge/recoverage.cloud/package.json
+++ b/apps/edge/recoverage.cloud/package.json
@@ -1,11 +1,12 @@
 {
-	"name": "recoverage-server",
+	"name": "recoverage.cloud",
 	"type": "module",
 	"scripts": {
-		"go": "pnpm db:up --remote && pnpm gen && pnpm run deploy",
-		"gen": "bun __scripts__/gen-scripts.bun.ts",
+		"go": "concurrently \"pnpm:setup:*\" && wrangler deploy --minify",
+		"setup:deps": "pnpm -w build --filter=recoverage.cloud",
+		"setup:scripts": "bun __scripts__/gen-scripts.bun.ts",
+		"setup:db": "pnpm db:up --remote",
 		"dev": "wrangler dev --live-reload",
-		"deploy": "wrangler deploy --minify",
 		"test": "vitest",
 		"test:once": "vitest run",
 		"db:gen": "drizzle-kit generate",

--- a/apps/edge/recoverage.cloud/package.json
+++ b/apps/edge/recoverage.cloud/package.json
@@ -6,6 +6,7 @@
 		"setup:deps": "pnpm -w build --filter=recoverage.cloud",
 		"setup:scripts": "bun __scripts__/gen-scripts.bun.ts",
 		"setup:db": "pnpm db:up --remote",
+		"gen": "pnpm setup:scripts",
 		"dev": "wrangler dev --live-reload",
 		"test": "vitest",
 		"test:once": "vitest run",


### PR DESCRIPTION
### **PR Type**
- Enhancement



___

### **Description**
- Change project name to recoverage.cloud.

- Refactor go script to run concurrent setup tasks.

- Add setup:deps, setup:scripts, setup:db commands.

- Update lint:types to use bun and node tsc.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update deployment and lint scripts configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/edge/recoverage.cloud/package.json

<li>Renamed project from recoverage-server to recoverage.cloud.<br> <li> Updated "go" script for concurrent setup commands.<br> <li> Added new setup scripts for dependencies, scripts, and DB.<br> <li> Modified lint:types command to integrate bun and TSC.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3625/files#diff-bd17b91e615b6372593ca6727f85b06425846f5415ef86f9119359cc91c83edf">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>