### PR TITLE
recoverage exception for current default ref

### DIFF
--- a/.changeset/small-heads-walk.md
+++ b/.changeset/small-heads-walk.md
@@ -1,0 +1,5 @@
+---
+"recoverage": patch
+---
+
+🐛 Previously, recoverage would in some situations clear the default branch's coverage report. Now this coverage report will never be cleared.

--- a/packages/recoverage/src/database.ts
+++ b/packages/recoverage/src/database.ts
@@ -34,11 +34,11 @@ export const saveCoverage = (
 export const getCoverage = (
 	db: Database,
 ): Statement<BranchCoverage, [git_ref: string]> =>
-	db.query(`SELECT * FROM coverage WHERE git_ref = $git_ref`).as(BranchCoverage)
+	db.query(`select * from coverage where git_ref = $git_ref`).as(BranchCoverage)
 
 export const deleteAllButLast10Reports = (
 	db: Database,
-): Statement<BranchCoverage, []> =>
+): Statement<BranchCoverage, [exception: string]> =>
 	db.prepare(
-		`DELETE FROM coverage WHERE last_updated NOT IN (SELECT last_updated FROM coverage ORDER BY last_updated DESC LIMIT 10)`,
+		`delete from coverage where last_updated not in (select last_updated from coverage order by last_updated desc limit 10) and git_ref != $exception`,
 	)

--- a/packages/recoverage/src/persist-s3.ts
+++ b/packages/recoverage/src/persist-s3.ts
@@ -19,14 +19,14 @@ export async function downloadCoverageDatabaseFromS3(
 	credentials: S3Credentials,
 ): Promise<void> {
 	initS3(credentials)
-	logger.mark?.(`downloading coverage database from R2`)
+	logger.mark?.(`downloading coverage database from S3`)
 	const remote = Bun.s3.file(`coverage.sqlite`)
 	try {
 		await write(`./coverage.sqlite`, remote)
-		logger.mark?.(`downloaded coverage database from R2`)
+		logger.mark?.(`downloaded coverage database from S3`)
 	} catch (error) {
 		console.error(error)
-		logger.mark?.(`downloading coverage database from R2 failed`)
+		logger.mark?.(`downloading coverage database from S3 failed`)
 	}
 }
 
@@ -35,7 +35,7 @@ export async function uploadCoverageDatabaseToS3(
 ): Promise<void> {
 	initS3(credentials)
 	const sqliteFile = Bun.s3.file(`coverage.sqlite`)
-	logger.mark?.(`uploading coverage database to R2`)
+	logger.mark?.(`uploading coverage database to S3`)
 	await sqliteFile.write(Bun.file(`coverage.sqlite`))
-	logger.mark?.(`uploaded coverage database to R2`)
+	logger.mark?.(`uploaded coverage database to S3`)
 }

--- a/packages/recoverage/src/recoverage.ts
+++ b/packages/recoverage/src/recoverage.ts
@@ -70,13 +70,14 @@ export async function capture(
 
 	logger.mark?.(`updated coverage for ${currentGitRef}`)
 
-	deleteAllButLast10Reports(db).run()
-
 	const defaultGitRef = await getDefaultBranchHashRef(
 		git,
 		defaultBranch,
 		logger.mark,
 	)
+
+	deleteAllButLast10Reports(db).run(defaultGitRef)
+
 	logger.mark?.(`retrieved default branch git ref: ${defaultGitRef}`)
 	if (currentGitRef === defaultGitRef) {
 		logger.mark?.(`we're on the default branch`)


### PR DESCRIPTION
### **User description**
- **🔊 fix some logs**
- **✨ make exception in db cleanup for the main ref report**


___

### **PR Type**
- Bug fix
- Enhancement



___

### **Description**
- Updated SQL queries and parameters.

- Modified deletion query to skip default branch.

- Revised log messages from R2 to S3.

- Passed default branch reference to cleanup function.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>database.ts</strong><dd><code>Update SQL delete function with branch exception.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/recoverage/src/database.ts

<li>Converted SELECT and DELETE SQL syntax to lowercase.<br> <li> Added an exception parameter for deleteAllButLast10Reports.<br> <li> Adjusted SQL query to exclude default branch.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3631/files#diff-5f4736faf0965448a9b98063c5f0a6dc5b5b52da25a9b1ed4ea6f496ccb21cf7">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>recoverage.ts</strong><dd><code>Pass default branch ref to cleanup method.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/recoverage/src/recoverage.ts

<li>Passed default branch ref to deletion function.<br> <li> Refactored deleteAllButLast10Reports call.<br> <li> Streamlined branch reference handling.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3631/files#diff-66d510e23cb06dd9a7f340fd3e284fdf93df9ea23cb06d78fbc206c7531ab904">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>persist-s3.ts</strong><dd><code>Revise S3 logging messages.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/recoverage/src/persist-s3.ts

<li>Replaced "R2" with "S3" in download logs.<br> <li> Replaced "R2" with "S3" in upload logs.<br> <li> Improved logging clarity for S3 operations.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3631/files#diff-5b9c659db777a4b2ef913a1e09b4a06b073589fad19ab499ab12d01923ead3b2">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>