### PR TITLE
fix recoverage cloud persist

### DIFF
--- a/.changeset/huge-bats-enjoy.md
+++ b/.changeset/huge-bats-enjoy.md
@@ -1,0 +1,5 @@
+---
+"recoverage": patch
+---
+
+🚀 Only spawn one git client and retrieve git data once.

--- a/.changeset/ninety-llamas-lose.md
+++ b/.changeset/ninety-llamas-lose.md
@@ -1,0 +1,5 @@
+---
+"recoverage": patch
+---
+
+🐛 Fix bug where an incorrect endpoint on recoverage.cloud would be used when persisting a report.

--- a/packages/recoverage/package.json
+++ b/packages/recoverage/package.json
@@ -26,6 +26,7 @@
 		"recoverage": "bin/recoverage.bin.js"
 	},
 	"scripts": {
+		"dev": "tsup-node --watch",
 		"build": "tsup-node && rm -f dist/*.x.d.ts",
 		"lint:biome": "biome check -- .",
 		"lint:eslint": "eslint -- .",

--- a/packages/recoverage/src/database.ts
+++ b/packages/recoverage/src/database.ts
@@ -20,7 +20,7 @@ export async function initDatabase(): Promise<Database> {
 	database.run(
 		`create table if not exists coverage (git_ref text, coverage text, last_updated text default current_timestamp);`,
 	)
-	logger.mark?.(`set up database`)
+	logger.mark?.(`spawn database`)
 	return database
 }
 

--- a/packages/recoverage/src/git-status.ts
+++ b/packages/recoverage/src/git-status.ts
@@ -9,15 +9,15 @@ import { env } from "./recoverage.env"
 
 export type GitToolkit = {
 	_client: SimpleGit | undefined
-	_baseRef: string | undefined
-	_currentRef: string | undefined
 	get client(): SimpleGit
+	baseRef: string | undefined
+	currentRef: string | undefined
 }
 
 export const gitToolkit: GitToolkit = {
 	_client: undefined,
-	_baseRef: undefined,
-	_currentRef: undefined,
+	baseRef: undefined,
+	currentRef: undefined,
 	get client(): SimpleGit {
 		if (this._client) {
 			return this._client
@@ -29,8 +29,8 @@ export const gitToolkit: GitToolkit = {
 }
 
 export async function getBaseGitRef(defaultBranch: string): Promise<string> {
-	if (gitToolkit._baseRef) {
-		return gitToolkit._baseRef
+	if (gitToolkit.baseRef) {
+		return gitToolkit.baseRef
 	}
 	const { client: git } = gitToolkit
 	if (env.CI) {
@@ -46,13 +46,13 @@ export async function getBaseGitRef(defaultBranch: string): Promise<string> {
 	const sha = await git.revparse([defaultBranch])
 	const baseGitRef = sha.slice(0, 7)
 	logger.mark?.(`base git ref: ${baseGitRef}`)
-	gitToolkit._baseRef = baseGitRef
+	gitToolkit.baseRef = baseGitRef
 	return baseGitRef
 }
 
 export async function getCurrentGitRef(): Promise<string> {
-	if (gitToolkit._currentRef) {
-		return gitToolkit._currentRef
+	if (gitToolkit.currentRef) {
+		return gitToolkit.currentRef
 	}
 	const { client: git } = gitToolkit
 	const { current, branches } = await git.branch()
@@ -82,6 +82,6 @@ export async function getCurrentGitRef(): Promise<string> {
 		logger.mark?.(`git status hash created: ${diffHash}`)
 	}
 	logger.mark?.(`current git ref: ${currentGitRef}`)
-	gitToolkit._currentRef = currentGitRef
+	gitToolkit.currentRef = currentGitRef
 	return currentGitRef
 }

--- a/packages/recoverage/src/git-status.ts
+++ b/packages/recoverage/src/git-status.ts
@@ -2,37 +2,63 @@ import { createHash } from "node:crypto"
 import path from "node:path"
 
 import { file } from "bun"
-import type { SimpleGit } from "simple-git"
+import { type SimpleGit, simpleGit } from "simple-git"
 
+import { logger } from "./logger"
 import { env } from "./recoverage.env"
 
-export async function getDefaultBranchHashRef(
-	git: SimpleGit,
-	defaultBranch: string,
-	mark?: (text: string) => void,
-): Promise<string> {
+export type GitToolkit = {
+	_client: SimpleGit | undefined
+	_baseRef: string | undefined
+	_currentRef: string | undefined
+	get client(): SimpleGit
+}
+
+export const gitToolkit: GitToolkit = {
+	_client: undefined,
+	_baseRef: undefined,
+	_currentRef: undefined,
+	get client(): SimpleGit {
+		if (this._client) {
+			return this._client
+		}
+		this._client = simpleGit(import.meta.dir)
+		logger.mark?.(`spawn git`)
+		return this._client
+	},
+}
+
+export async function getBaseGitRef(defaultBranch: string): Promise<string> {
+	if (gitToolkit._baseRef) {
+		return gitToolkit._baseRef
+	}
+	const { client: git } = gitToolkit
 	if (env.CI) {
 		await git.fetch(
 			`origin`,
 			defaultBranch,
 			env.CI ? { "--depth": `1` } : undefined,
 		)
-		mark?.(`fetched origin/${defaultBranch}`)
+		logger.mark?.(`fetched origin/${defaultBranch}`)
 		const sha = await git.revparse([`origin/${defaultBranch}`])
 		return sha.slice(0, 7)
 	}
 	const sha = await git.revparse([defaultBranch])
-	return sha.slice(0, 7)
+	const baseGitRef = sha.slice(0, 7)
+	logger.mark?.(`base git ref: ${baseGitRef}`)
+	gitToolkit._baseRef = baseGitRef
+	return baseGitRef
 }
 
-export async function hashRepoState(
-	git: SimpleGit,
-	mark?: (text: string) => void,
-): Promise<string> {
+export async function getCurrentGitRef(): Promise<string> {
+	if (gitToolkit._currentRef) {
+		return gitToolkit._currentRef
+	}
+	const { client: git } = gitToolkit
 	const { current, branches } = await git.branch()
 	const gitStatus = await git.status()
 	const gitIsClean = gitStatus.isClean()
-	mark?.(`git status is clean: ${gitIsClean}`)
+	logger.mark?.(`git status is clean: ${gitIsClean}`)
 	let currentGitRef = branches[current].commit.slice(0, 7)
 	if (!gitIsClean) {
 		const gitDiff = await git.diff()
@@ -53,7 +79,9 @@ export async function hashRepoState(
 		const diffHash = gitStatusHash.digest(`hex`).slice(0, currentGitRef.length)
 		currentGitRef = `${currentGitRef}+${diffHash}`
 
-		mark?.(`git status hash created: ${diffHash}`)
+		logger.mark?.(`git status hash created: ${diffHash}`)
 	}
+	logger.mark?.(`current git ref: ${currentGitRef}`)
+	gitToolkit._currentRef = currentGitRef
 	return currentGitRef
 }

--- a/packages/recoverage/src/logger.ts
+++ b/packages/recoverage/src/logger.ts
@@ -55,6 +55,7 @@ export function useMarks({ inline = false }: { inline?: boolean } = {}): {
 			}
 		}
 		logMark(`TOTAL TIME`, overall.duration)
+		console.log()
 	}
 	return { mark, logMarks }
 }

--- a/packages/recoverage/src/persist-cloud.ts
+++ b/packages/recoverage/src/persist-cloud.ts
@@ -39,6 +39,7 @@ export async function uploadCoverageReportToCloud(
 	cloudHost = `https://recoverage.cloud`,
 ): Promise<Error | { success: true }> {
 	const url = new URL(`/reporter/${reportName}`, cloudHost)
+	console.log(`PUT`, url)
 	try {
 		const response = await fetch(url, {
 			method: `PUT`,

--- a/packages/recoverage/src/recoverage.ts
+++ b/packages/recoverage/src/recoverage.ts
@@ -1,6 +1,5 @@
 import { file } from "bun"
 import { createCoverageMap } from "istanbul-lib-coverage"
-import simpleGit from "simple-git"
 
 import {
 	deleteAllButLast10Reports,

--- a/packages/recoverage/src/recoverage.ts
+++ b/packages/recoverage/src/recoverage.ts
@@ -8,7 +8,7 @@ import {
 	initDatabase,
 	saveCoverage,
 } from "./database"
-import { getDefaultBranchHashRef, hashRepoState } from "./git-status"
+import { getBaseGitRef, getCurrentGitRef } from "./git-status"
 import { logDiff, logger, useMarks } from "./logger"
 import { getCoverageJsonSummary, getCoverageTextReport } from "./nyc-coverage"
 import {
@@ -43,19 +43,20 @@ export type JsonSummaryReport = {
 	total: JsonSummary
 }
 
-export async function capture(
-	defaultBranch = `main`,
-	silent = false,
-): Promise<0 | 1> {
+export type RecoverageOptions = {
+	defaultBranch?: string
+	silent?: boolean
+}
+
+export async function capture(options: RecoverageOptions = {}): Promise<0 | 1> {
+	const { defaultBranch = `main`, silent = false } = options
 	if (!silent && !logger.mark) {
 		Object.assign(logger, useMarks({ inline: false }))
 	}
+	logger.mark?.(`start`)
 	logger.mark?.(`called recoverage capture`)
 
-	const git = simpleGit(import.meta.dir)
-	logger.mark?.(`spawn git`)
-	const currentGitRef = await hashRepoState(git, logger.mark)
-	logger.mark?.(`retrieved current git ref: ${currentGitRef}`)
+	const currentGitRef = await getCurrentGitRef()
 
 	const coverageFile = file(`./coverage/coverage-final.json`)
 	const coverageJson = await coverageFile.json()
@@ -68,17 +69,12 @@ export async function capture(
 		$coverage: coverageMapStringified,
 	})
 
-	logger.mark?.(`updated coverage for ${currentGitRef}`)
+	logger.mark?.(`saved local coverage for ${currentGitRef}`)
 
-	const defaultGitRef = await getDefaultBranchHashRef(
-		git,
-		defaultBranch,
-		logger.mark,
-	)
+	const defaultGitRef = await getBaseGitRef(defaultBranch)
 
 	deleteAllButLast10Reports(db).run(defaultGitRef)
 
-	logger.mark?.(`retrieved default branch git ref: ${defaultGitRef}`)
 	if (currentGitRef === defaultGitRef) {
 		logger.mark?.(`we're on the default branch`)
 		if (S3_CREDENTIALS) {
@@ -88,12 +84,19 @@ export async function capture(
 		}
 		if (env.RECOVERAGE_CLOUD_TOKEN) {
 			logger.mark?.(`uploading coverage report to recoverage.cloud`)
-			await uploadCoverageReportToCloud(
-				import.meta.dir,
+			// biome-ignore lint/style/noNonNullAssertion: there's always an element here
+			const packageName = process.cwd().split(`/`).at(-1)!
+			const cloudResponse = await uploadCoverageReportToCloud(
+				packageName,
 				coverageMapStringified,
 				env.RECOVERAGE_CLOUD_TOKEN,
 				env.RECOVERAGE_CLOUD_URL,
 			)
+			if (cloudResponse instanceof Error) {
+				logger.mark?.(`failed to upload coverage report`)
+				console.error(cloudResponse)
+				return 1
+			}
 			logger.mark?.(`uploaded coverage report to recoverage.cloud`)
 		} else {
 			logger.mark?.(`RECOVERAGE_CLOUD_TOKEN not set; skipping upload`)
@@ -102,8 +105,6 @@ export async function capture(
 		logger.mark?.(`we're not on the default branch; no need to persist coverage`)
 	}
 
-	logger.logMarks?.()
-	console.log()
 	return 0
 }
 
@@ -117,104 +118,94 @@ export async function diff(
 
 	logger.mark?.(`called recoverage diff`)
 
-	const git = simpleGit(import.meta.dir)
-	logger.mark?.(`spawn git`)
-	const mainGitRef = await getDefaultBranchHashRef(
-		git,
-		defaultBranch,
-		logger.mark,
-	)
-	logger.mark?.(`main git ref: ${mainGitRef}`)
-	const currentGitRef = await hashRepoState(git, logger.mark)
-	logger.mark?.(`current git ref: ${currentGitRef}`)
+	const baseGitRef = await getBaseGitRef(defaultBranch)
+	const currentGitRef = await getCurrentGitRef()
 
 	const db = await initDatabase()
-	let [mainCoverage] = getCoverage(db).all(mainGitRef)
+	let [baseCoverage] = getCoverage(db).all(baseGitRef)
 	const [currentCoverage] = getCoverage(db).all(currentGitRef)
 
-	if (!mainCoverage) {
+	if (!baseCoverage) {
 		logger.mark?.(`no coverage found for the target branch`)
 		if (!env.RECOVERAGE_CLOUD_TOKEN) {
 			logger.mark?.(
 				`RECOVERAGE_CLOUD_TOKEN not set; cannot download coverage report`,
 			)
-			logger.logMarks?.()
 			return 1
 		}
-		logger.mark?.(`looking for coverage report on recoverage.cloud`)
+		// biome-ignore lint/style/noNonNullAssertion: there's always an element here
+		const packageName = process.cwd().split(`/`).at(-1)!
 		const cloudCoverage = await downloadCoverageReportFromCloud(
-			import.meta.dir,
+			packageName,
 			env.RECOVERAGE_CLOUD_TOKEN,
 			env.RECOVERAGE_CLOUD_URL,
+		)
+		logger.mark?.(
+			`looking for coverage report "${packageName}" on recoverage.cloud`,
 		)
 		if (cloudCoverage instanceof Error) {
 			logger.mark?.(`failed to download coverage report`)
 			console.error(cloudCoverage)
-			logger.logMarks?.()
 			return 1
 		}
-		mainCoverage = {
-			git_ref: mainGitRef,
+		baseCoverage = {
+			git_ref: baseGitRef,
 			coverage: cloudCoverage,
 		}
-		logger.mark?.(`coverage report found on recoverage.cloud`)
+		logger.mark?.(`found report "${packageName}" on recoverage.cloud`)
 		saveCoverage(db).run({
-			$git_ref: mainGitRef,
+			$git_ref: baseGitRef,
 			$coverage: cloudCoverage,
 		})
-		logger.mark?.(`saved coverage for ${mainGitRef}`)
+		logger.mark?.(`downloaded coverage report from recoverage.cloud`)
 	}
+
 	if (!currentCoverage) {
 		logger.mark?.(`no coverage found for the current ref`)
-		logger.logMarks?.()
 		return 1
 	}
-	if (mainGitRef === currentGitRef) {
+	if (baseGitRef === currentGitRef) {
 		logger.mark?.(`you're already on the target branch`)
-		logger.logMarks?.()
 		return 0
 	}
 
 	const [
-		mainCoverageJsonSummary,
+		baseCoverageJsonSummary,
 		currentCoverageJsonSummary,
-		mainCoverageTextReport,
+		baseCoverageTextReport,
 		currentCoverageTextReport,
 	] = await Promise.all([
-		getCoverageJsonSummary(mainCoverage, logger.mark),
+		getCoverageJsonSummary(baseCoverage, logger.mark),
 		getCoverageJsonSummary(currentCoverage, logger.mark),
-		getCoverageTextReport(mainCoverage, logger.mark),
+		getCoverageTextReport(baseCoverage, logger.mark),
 		getCoverageTextReport(currentCoverage, logger.mark),
 	])
 
 	const coverageDifference =
 		currentCoverageJsonSummary.total.statements.pct -
-		mainCoverageJsonSummary.total.statements.pct
+		baseCoverageJsonSummary.total.statements.pct
 
 	if (coverageDifference < 0) {
 		logDiff(
-			mainGitRef,
+			baseGitRef,
 			currentGitRef,
-			mainCoverageTextReport,
+			baseCoverageTextReport,
 			currentCoverageTextReport,
 		)
 		logger.mark?.(`coverage decreased by ${+coverageDifference}%`)
-		logger.logMarks?.()
 		return 1
 	}
 
 	if (coverageDifference > 0) {
 		logDiff(
-			mainGitRef,
+			baseGitRef,
 			currentGitRef,
-			mainCoverageTextReport,
+			baseCoverageTextReport,
 			currentCoverageTextReport,
 		)
 		logger.mark?.(`coverage increased by ${+coverageDifference}%`)
-		logger.logMarks?.()
 		return 0
 	}
 	logger.mark?.(`coverage is the same`)
-	logger.logMarks?.()
 	return 0
 }

--- a/packages/recoverage/src/recoverage.x.ts
+++ b/packages/recoverage/src/recoverage.x.ts
@@ -3,6 +3,7 @@
 import { cli, help, noOptions, optional } from "comline"
 import { z } from "zod"
 
+import { logger } from "./logger"
 import * as Recoverage from "./recoverage"
 
 const parse = cli({
@@ -53,17 +54,21 @@ switch (inputs.case) {
 		{
 			const captureCode = await Recoverage.capture()
 			if (captureCode === 1) {
+				logger.logMarks?.()
 				process.exit(1)
 			}
 			try {
 				const diffCode = await Recoverage.diff(
 					inputs.opts[`default-branch`] ?? `main`,
 				)
+				logger.logMarks?.()
 				if (diffCode === 1) {
 					process.exit(1)
 				}
 			} catch (thrown) {
+				logger.logMarks?.()
 				console.error(thrown)
+				process.exit(1)
 			}
 		}
 		break


### PR DESCRIPTION
### **User description**
- **🐛 fix persistence bug with the cloud features**
- **🦋**
- **🦋**


___

### **PR Type**
- Bug fix
- Enhancement
- Documentation



___

### **Description**
- Spawn a single git client with caching.

- Refactor git ref retrieval functions.

- Update logging messages and cloud endpoint logging.

- Add dev script and changeset documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>database.ts</strong><dd><code>Update database log message wording.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3637/files#diff-5f4736faf0965448a9b98063c5f0a6dc5b5b52da25a9b1ed4ea6f496ccb21cf7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>git-status.ts</strong><dd><code>Introduce gitToolkit and refactor git functions.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3637/files#diff-6d519a8a8fde359837d8b04245cf43076bbc59675ba15f0d6935b15433ce99e1">+42/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>logger.ts</strong><dd><code>Append newline in logMarks routine.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3637/files#diff-95f536489fdaabad8476349dc3485f7a99f2a94cb887877f7673373154766f8c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>recoverage.ts</strong><dd><code>Refactor capture and diff workflows.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3637/files#diff-66d510e23cb06dd9a7f340fd3e284fdf93df9ea23cb06d78fbc206c7531ab904">+47/-56</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>recoverage.x.ts</strong><dd><code>Ensure logMarks are called on exit.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3637/files#diff-eaf7b77b987a7788e23497d4da09fab0d2ec890fb2e181fe5d8b4676e36ebcc6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>package.json</strong><dd><code>Add dev script for tsup-node.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3637/files#diff-4f4525e96a8a9853417e0718980575a25cdd72166ba914129eb2fa675b95f286">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>persist-cloud.ts</strong><dd><code>Log PUT request for cloud upload.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3637/files#diff-069fae94119342b98f2682d76cc75d009ca25fbd34e2d7ae8f097b067f466c07">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ninety-llamas-lose.md</strong><dd><code>Note fix for cloud endpoint bug.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3637/files#diff-c6be351ae170a4eec8da423c3702100d25cff919ad6bd226af0731597b26ba3e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>huge-bats-enjoy.md</strong><dd><code>Document single git client usage.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3637/files#diff-0e5b057584bf2751638b6cc4493f71d15a3e1a5db4f21dd88701324b5e0ed31e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>