### PR TITLE
recoverage perf minor

### DIFF
--- a/packages/recoverage/src/git-status.ts
+++ b/packages/recoverage/src/git-status.ts
@@ -41,7 +41,9 @@ export async function getBaseGitRef(defaultBranch: string): Promise<string> {
 		)
 		logger.mark?.(`fetched origin/${defaultBranch}`)
 		const sha = await git.revparse([`origin/${defaultBranch}`])
-		return sha.slice(0, 7)
+		const baseGitRef = sha.slice(0, 7)
+		gitToolkit.baseRef = baseGitRef
+		return baseGitRef
 	}
 	const sha = await git.revparse([defaultBranch])
 	const baseGitRef = sha.slice(0, 7)

--- a/packages/recoverage/src/persist-cloud.ts
+++ b/packages/recoverage/src/persist-cloud.ts
@@ -39,7 +39,6 @@ export async function uploadCoverageReportToCloud(
 	cloudHost = `https://recoverage.cloud`,
 ): Promise<Error | { success: true }> {
 	const url = new URL(`/reporter/${reportName}`, cloudHost)
-	console.log(`PUT`, url)
 	try {
 		const response = await fetch(url, {
 			method: `PUT`,

--- a/packages/recoverage/src/recoverage.ts
+++ b/packages/recoverage/src/recoverage.ts
@@ -85,9 +85,11 @@ export async function capture(options: RecoverageOptions = {}): Promise<0 | 1> {
 			logger.mark?.(`uploaded coverage database to S3`)
 		}
 		if (env.RECOVERAGE_CLOUD_TOKEN) {
-			logger.mark?.(`uploading coverage report to recoverage.cloud`)
 			// biome-ignore lint/style/noNonNullAssertion: there's always an element here
 			const packageName = process.cwd().split(`/`).at(-1)!
+			logger.mark?.(
+				`uploading coverage report "${packageName}" to recoverage.cloud`,
+			)
 			const cloudResponse = await uploadCoverageReportToCloud(
 				packageName,
 				coverageMapStringified,
@@ -171,7 +173,7 @@ export async function diff(
 		return 1
 	}
 	if (baseGitRef === currentGitRef) {
-		logger.mark?.(`you're already on the target branch`)
+		logger.mark?.(`no diff (we're already on the target branch)`)
 		return 0
 	}
 
@@ -181,13 +183,13 @@ export async function diff(
 	)
 
 	const baseCoverageJsonSummary = getCoverageJsonSummary(baseCoverageMap)
-	logger.mark?.(`got base coverage json summary`)
+	logger.mark?.(`got json summary for ${baseGitRef}`)
 	const currentCoverageJsonSummary = getCoverageJsonSummary(currentCoverageMap)
-	logger.mark?.(`got current coverage json summary`)
+	logger.mark?.(`got json summary for ${currentGitRef}`)
 	const baseCoverageTextReport = getCoverageTextReport(baseCoverageMap)
-	logger.mark?.(`got base coverage text report`)
+	logger.mark?.(`got text report for ${baseGitRef}`)
 	const currentCoverageTextReport = getCoverageTextReport(currentCoverageMap)
-	logger.mark?.(`got current coverage text report`)
+	logger.mark?.(`got text report for ${currentGitRef}`)
 
 	const coverageDifference =
 		currentCoverageJsonSummary.total.statements.pct -
@@ -200,7 +202,7 @@ export async function diff(
 			baseCoverageTextReport,
 			currentCoverageTextReport,
 		)
-		logger.mark?.(`coverage decreased by ${+coverageDifference}%`)
+		logger.mark?.(`coverage decreased by ${-coverageDifference}%`)
 		return 1
 	}
 


### PR DESCRIPTION
### **User description**
- **🚀 don't fetch origin/<default> twice in ci**
- **🔇 remove extra noisy log**
- **🔊 improve logs**


___

### **PR Type**
- Enhancement



___

### **Description**
- Set and cache the base Git reference for toolkit reuse.

- Remove redundant debug log in cloud uploader.

- Update log messages for coverage reporting clarity.

- Fix coverage difference log sign error.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>git-status.ts</strong><dd><code>Cache base Git reference in toolkit.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/recoverage/src/git-status.ts

<li>Cached sliced Git SHA in gitToolkit.baseRef.<br> <li> Assigned baseGitRef variable before returning.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3642/files#diff-6d519a8a8fde359837d8b04245cf43076bbc59675ba15f0d6935b15433ce99e1">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>persist-cloud.ts</strong><dd><code>Remove redundant debug logging.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/recoverage/src/persist-cloud.ts

<li>Removed console log printing PUT and URL.<br> <li> Streamlined logging in cloud uploader.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3642/files#diff-069fae94119342b98f2682d76cc75d009ca25fbd34e2d7ae8f097b067f466c07">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>recoverage.ts</strong><dd><code>Update and clarify coverage reporting logs.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/recoverage/src/recoverage.ts

<li>Updated log to include package name in upload message.<br> <li> Revised log texts for base and current JSON/text reports.<br> <li> Modified diff branch log message for clarity.<br> <li> Corrected coverage difference sign in log.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3642/files#diff-66d510e23cb06dd9a7f340fd3e284fdf93df9ea23cb06d78fbc206c7531ab904">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>