### PR TITLE
🐛 pct is number not int

### DIFF
--- a/apps/edge/recoverage.cloud/src/reporter.ts
+++ b/apps/edge/recoverage.cloud/src/reporter.ts
@@ -193,7 +193,7 @@ export const coverageEvalType: Type<CoverageEval> = type({
 	total: `number.integer`,
 	covered: `number.integer`,
 	skipped: `number.integer`,
-	pct: `number.integer`,
+	pct: `number`,
 })
 
 export const jsonSummaryType: Type<CoverageSummary> = type({


### PR DESCRIPTION
### **PR Type**
- Bug fix



___

### **Description**
- Fix type definition for `pct` property.

- Update from stricter integer to general number type.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reporter.ts</strong><dd><code>Update pct property type validation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/edge/recoverage.cloud/src/reporter.ts

<li>Changed <code>pct</code> type from <code>number.integer</code> to <code>number</code>.<br> <li> Corrected type mismatch in coverage summary.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3651/files#diff-5017fc0bfdcd66d9e049626e35f3bbac93a76b4b69b18b76c4b6e81f0985df13">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>