### PR TITLE
🐛 fix bug where only the secret would copy

### DIFF
--- a/apps/edge/recoverage.cloud/src/project.tsx
+++ b/apps/edge/recoverage.cloud/src/project.tsx
@@ -307,7 +307,7 @@ export function ProjectToken(props: DivProjectTokenProps): JSX.Element {
 										{id}.{secretShownOnce}
 									</code>
 								</span>
-								<button.copy text={secretShownOnce} />
+								<button.copy text={`${id}.${secretShownOnce}`} />
 							</div>
 							<div class={css`font-size: 12px; text-align: right;`}>
 								^ copy this code and put it somewhere safe. it will not be shown


### PR DESCRIPTION
### **PR Type**
- Bug fix



___

### **Description**
- Update button copy text with full identifier.

- Concatenate `id` and `secretShownOnce` properly.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>project.tsx</strong><dd><code>Update copy button to include id with secret.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/edge/recoverage.cloud/src/project.tsx

<li>Replace copy button text prop.<br> <li> Append <code>id</code> to <code>secretShownOnce</code>.<br> <li> Ensure full secret code is copied.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3652/files#diff-7bf991cb41fe47fea913b82e85d8338f9b2d07dacf2e23b7ca0230f245dbc079">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>