### PR TITLE
atom.io recoverage badge

### DIFF
--- a/apps/edge/recoverage.cloud/src/shields.ts
+++ b/apps/edge/recoverage.cloud/src/shields.ts
@@ -69,7 +69,7 @@ shieldsRoutes.get(`/:projectId/:reportRef`, shieldsMiddleware, async (c) => {
 		{
 			schemaVersion: 1,
 			color,
-			style: "for-the-badge",
+			style: `for-the-badge`,
 		} as const,
 		coveragePct === 100
 			? { label: ``, message: `coverage 100%` }

--- a/apps/edge/recoverage.cloud/src/shields.ts
+++ b/apps/edge/recoverage.cloud/src/shields.ts
@@ -69,6 +69,7 @@ shieldsRoutes.get(`/:projectId/:reportRef`, shieldsMiddleware, async (c) => {
 		{
 			schemaVersion: 1,
 			color,
+			style: "for-the-badge",
 		} as const,
 		coveragePct === 100
 			? { label: ``, message: `coverage 100%` }

--- a/packages/atom.io/README.md
+++ b/packages/atom.io/README.md
@@ -1,6 +1,3 @@
-
-
-
 <div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jeremybanka/wayforge/main/packages/atom.io/__assets__/logo-dark-mode.png">
@@ -17,21 +14,18 @@
   Composable, high-performance reactivity for ECMAScript inspired by <a href="https://recoiljs.org/">Recoil</a> 💙
 </h3>
 
-
-
 <h3 align="center">
   <a href="https://atom.io.fyi">📖 Read the docs at atom.io.fyi</a>
 </h3>
 
-
-
-
 ```shell
 npm i atom.io
 ```
+
 ```shell
 pnpm i atom.io
 ```
+
 ```shell
 bun i atom.io
 ```
@@ -50,12 +44,8 @@ bun i atom.io
     <img alt="NPM Version" src="https://img.shields.io/npm/v/atom.io?style=for-the-badge&labelColor=333">
   </a>
   <a aria-label="Coverage" href="https://coveralls.io/github/jeremybanka/wayforge">
-    <img alt="Coverage" src="https://img.shields.io/coverallsCoverage/github/jeremybanka/wayforge?style=for-the-badge&labelColor=333">
+    <img alt="Coverage" src="https://img.shields.io/endpoint?url=https%3A%2F%2Frecoverage.cloud%2Fshields%2FS1ikz1yFmk93qbAI7lLnu%2Fatom.io
+    ">
   </a>
 
 </p>
-
-
-
-
-

--- a/packages/atom.io/README.md
+++ b/packages/atom.io/README.md
@@ -44,8 +44,7 @@ bun i atom.io
     <img alt="NPM Version" src="https://img.shields.io/npm/v/atom.io?style=for-the-badge&labelColor=333">
   </a>
   <a aria-label="Coverage" href="https://coveralls.io/github/jeremybanka/wayforge">
-    <img alt="Coverage" src="https://img.shields.io/endpoint?url=https%3A%2F%2Frecoverage.cloud%2Fshields%2FS1ikz1yFmk93qbAI7lLnu%2Fatom.io
-    ">
+    <img alt="Coverage" src="https://img.shields.io/endpoint?url=https%3A%2F%2Frecoverage.cloud%2Fshields%2FS1ikz1yFmk93qbAI7lLnu%2Fatom.io">
   </a>
 
 </p>


### PR DESCRIPTION
### **User description**
- **📝 document atom.io coverage**
- **💄 for-the-badge**


___

### **PR Type**
- Enhancement
- Documentation



___

### **Description**
- Add "for-the-badge" style to shield response.

- Update Atom.io README installation commands.

- Replace old coverage badge URL with new endpoint.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shields.ts</strong><dd><code>Add badge style property to shield response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/edge/recoverage.cloud/src/shields.ts

<li>Inserted "style: 'for-the-badge'" into badge configuration.<br> <li> Ensures badge rendering consistency.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3653/files#diff-49c03f3e7c7393f3a67753fe90b13e680f3f9b9112bd7c7f2275898d5328bf4f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Revise Atom.io README installation and badge link</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/README.md

<li>Removed extraneous blank lines.<br> <li> Updated install commands from npm to pnpm and bun.<br> <li> Modified coverage badge image source to use new endpoint.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3653/files#diff-52c512b174f8dad24162037e07874acdf4cd4a9f7174284cac88100d775ad219">+4/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>