### PR TITLE
🚑 don't cache responses from github

### DIFF
--- a/apps/edge/recoverage.cloud/src/cached-fetch.ts
+++ b/apps/edge/recoverage.cloud/src/cached-fetch.ts
@@ -2,12 +2,12 @@ export const cachedFetch: typeof fetch = async (input, init) => {
 	return fetch(input, {
 		...init,
 		cf: {
-			cacheEverything: true,
-			cacheTtlByStatus: {
-				"200-299": 60 * 60 * 24 * 7,
-				"400-499": 1,
-				"500-599": 60 * 60 * 24 * 30,
-			},
+			// cacheEverything: true,
+			// cacheTtlByStatus: {
+			// 	"200-299": 60 * 60 * 24 * 7,
+			// 	"400-499": 1,
+			// 	"500-599": 60 * 60 * 24 * 30,
+			// },
 		},
 	})
 }


### PR DESCRIPTION
### **PR Type**
- Bug fix



___

### **Description**
- Disable GitHub response caching in fetch utility.

- Comment out cacheEverything and cacheTtlByStatus settings.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cached-fetch.ts</strong><dd><code>Remove caching configuration from fetch utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/edge/recoverage.cloud/src/cached-fetch.ts

<li>Commented out caching configuration lines.<br> <li> Removed cache TTL settings for HTTP statuses.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3667/files#diff-c00de44f8c767f79dbe303df2f149f1455e22a319460cc6c1dcf362470e39a3a">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>