### PR TITLE
tempest.games fix the other bad intersection

### DIFF
--- a/.changeset/fair-hats-cry.md
+++ b/.changeset/fair-hats-cry.md
@@ -1,0 +1,5 @@
+---
+"tempest.games": patch
+---
+
+🐛 Fixed bug with username validation also causing frontend to break.

--- a/apps/tempest.games/src/library/data-constraints.ts
+++ b/apps/tempest.games/src/library/data-constraints.ts
@@ -12,7 +12,9 @@ export const USERNAME_ALLOWED_CHARS = /^[a-zA-Z0-9_-]+$/
 // 	.regex(USERNAME_ALLOWED_CHARS)
 
 export const usernameType = type(USERNAME_ALLOWED_CHARS)
-	.and(`string > ${USERNAME_MIN_LENGTH} & string < ${USERNAME_MAX_LENGTH}`)
+	.pipe(
+		type(`string > ${USERNAME_MIN_LENGTH} & string < ${USERNAME_MAX_LENGTH}`),
+	)
 	.brand(`username`)
 
 const MINIMUM_PASSWORD_COMPLEXITY = 20


### PR DESCRIPTION
### **User description**
- **🐛 fix bad use of .and, replace with pipe**
- **🦋**


___

### **PR Type**
- Bug fix



___

### **Description**
- Fix incorrect string validation chaining.

- Document frontend fix in changeset.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data-constraints.ts</strong><dd><code>Replace .and with .pipe in usernameType.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/tempest.games/src/library/data-constraints.ts

<li>Replaced <code>.and</code> with <code>.pipe</code> for type validation.<br> <li> Wrapped length check in a type call.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3855/files#diff-e265abbc4290fe1f1d003cb2ebe185f3acbbae3f92a851145661d5ec92e7fccb">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fair-hats-cry.md</strong><dd><code>Add changeset for username validation fix.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/fair-hats-cry.md

<li>Added changeset for patch release.<br> <li> Described fix for username validation issue.


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/3855/files#diff-3ac83782f8327555642894b56ce8d43d7f8182e297bcc9e9009d3f180ecfc648">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>