### PR TITLE
✏️ fix typo in held selector patchnotes

### DIFF
--- a/.changeset/bitter-webs-own.md
+++ b/.changeset/bitter-webs-own.md
@@ -30,4 +30,4 @@ const mySelector = selector<{
 });
 ```
 
-A held selector requires a `const` value to be initialized. The `get` function for a held selector passes the held value of the selector to the setter function as a second parameter following the `GetterToolkit` interface. The expectation is that the getter mutates the held value and returns `void`.
+A held selector requires a `const` value to be initialized. The `get` function for a held selector passes the held value of the selector to the getter function as a second parameter following the `GetterToolkit` interface. The expectation is that the getter mutates the held value and returns `void`.


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Fix typo in held selector documentation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitter-webs-own.md</strong><dd><code>Correct function name in held selector docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/bitter-webs-own.md

<li>Updated “setter function” to “getter function” reference<br> <li> Clarified getter mutates held value and returns void


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4095/files#diff-9a3660dc223a3a5d24238674fb255cab6906b1a2260f3dca5bb33378f913833c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>