### PR TITLE
atom.io fix loadable bug

### DIFF
--- a/.changeset/cruel-carrots-draw.md
+++ b/.changeset/cruel-carrots-draw.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 Previously, there were problems when creating synchronous states downstream from asynchronous ones. Now, this is better supported.

--- a/.changeset/small-dancers-guess.md
+++ b/.changeset/small-dancers-guess.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🚀 Improve performance with async states; create fewer Promise objects under the hood.

--- a/packages/atom.io/__tests__/private/introspection/AtomIODevtools.test.tsx
+++ b/packages/atom.io/__tests__/private/introspection/AtomIODevtools.test.tsx
@@ -104,7 +104,7 @@ describe(`editing an object atom`, () => {
 			default: { a: 1, b: 2 },
 		})
 
-		const { getByTestId /* debug */ } = scenario()
+		const { getByTestId, debug } = scenario()
 
 		await waitFor(() => getByTestId(`open-close-state-myObject`))
 
@@ -121,8 +121,11 @@ describe(`editing an object atom`, () => {
 			})
 		})
 
-		await waitFor(() => getByTestId(`myObject-state-editor-property-c`))
+		await waitFor(() =>
+			getByTestId(`myObject-state-editor-property-c-number-input`),
+		)
 
+		debug()
 		expect($.getState(objectAtom)).toEqual({ b: 2, c: 1 })
 
 		act(() => {

--- a/packages/atom.io/__tests__/public/async-state.test.ts
+++ b/packages/atom.io/__tests__/public/async-state.test.ts
@@ -71,10 +71,13 @@ describe(`async atom`, async () => {
 				})
 			},
 		})
+		console.log(`👀`, Internal.IMPLICIT.STORE.valueMap.get(`doubled`))
 		expect(Internal.IMPLICIT.STORE.valueMap.get(`doubled`)).toBeInstanceOf(
 			Internal.Future,
 		)
 		AtomIO.setState(countState, 1)
+		console.log(`set state`)
+		console.log(Internal.IMPLICIT.STORE.valueMap)
 		expect(Internal.IMPLICIT.STORE.valueMap.get(`doubled`)).toBeInstanceOf(
 			Internal.Future,
 		)
@@ -327,6 +330,12 @@ describe(`downstream from async`, () => {
 			},
 		})
 
+		AtomIO.subscribe(allItemsSelector, ({ newValue, oldValue }) => {
+			console.log(`subscriber`, { newValue, oldValue })
+			console.count(`subscriber`)
+			Utils.stdout({ newValue, oldValue })
+		})
+
 		console.log({
 			orgId: AtomIO.getState(orgIdAtom),
 			itemIds: AtomIO.getState(indexSelectors, 0),
@@ -376,7 +385,9 @@ describe(`downstream from async`, () => {
 			item3: AtomIO.getState(itemSelectors, 3),
 			allItems: AtomIO.getState(allItemsSelector),
 		})
+		console.log(`❗❗❗ loadItems[3]()`)
 		loadItems[3]()
+		console.log(`post ❗❗❗ loadItems[3]()`)
 		await new Promise((resolve) => setImmediate(resolve))
 		console.log({
 			orgId: AtomIO.getState(orgIdAtom),

--- a/packages/atom.io/src/internal/caching.ts
+++ b/packages/atom.io/src/internal/caching.ts
@@ -32,7 +32,6 @@ export function cacheValue<T>(
 	const currentValue = target.valueMap.get(key)
 	if (currentValue instanceof Future) {
 		const future = currentValue
-		void future.use(value)
 		if (value instanceof Promise) {
 			return future
 		}
@@ -94,7 +93,7 @@ export const evictCachedValue = (key: string, target: Store): void => {
 		const selector =
 			target.writableSelectors.get(key) ?? target.readonlySelectors.get(key)
 		if (selector) {
-			void future.use(selector.get())
+			future.use(selector.get())
 		}
 		return
 	}

--- a/packages/atom.io/src/internal/future.ts
+++ b/packages/atom.io/src/internal/future.ts
@@ -27,7 +27,7 @@ export class Future<T> extends Promise<T> {
 		})
 		this.resolve = superResolve as (value: T) => void
 		this.reject = superReject as (reason?: any) => void
-		void this.use(executor instanceof Promise ? executor : new Promise(executor))
+		this.use(executor instanceof Promise ? executor : new Promise(executor))
 	}
 
 	private pass(promise: Promise<T>, value: T) {
@@ -43,7 +43,7 @@ export class Future<T> extends Promise<T> {
 		}
 	}
 
-	public use(value: Promise<T> | T): this {
+	public use(value: Promise<T> | T): void {
 		if (value instanceof Promise) {
 			const promise = value
 			this.fate = promise
@@ -59,6 +59,5 @@ export class Future<T> extends Promise<T> {
 			this.resolve(value)
 			this.fate = undefined
 		}
-		return this
 	}
 }

--- a/packages/atom.io/src/internal/future.ts
+++ b/packages/atom.io/src/internal/future.ts
@@ -27,7 +27,7 @@ export class Future<T> extends Promise<T> {
 		})
 		this.resolve = superResolve as (value: T) => void
 		this.reject = superReject as (reason?: any) => void
-		this.use(executor instanceof Promise ? executor : new Promise(executor))
+		void this.use(executor instanceof Promise ? executor : new Promise(executor))
 	}
 
 	private pass(promise: Promise<T>, value: T) {
@@ -43,7 +43,7 @@ export class Future<T> extends Promise<T> {
 		}
 	}
 
-	public use(value: Promise<T> | T): void {
+	public use(value: Promise<T> | T): this {
 		if (value instanceof Promise) {
 			const promise = value
 			this.fate = promise
@@ -59,5 +59,6 @@ export class Future<T> extends Promise<T> {
 			this.resolve(value)
 			this.fate = undefined
 		}
+		return this
 	}
 }

--- a/packages/atom.io/src/internal/operation.ts
+++ b/packages/atom.io/src/internal/operation.ts
@@ -1,4 +1,4 @@
-import type { WritableToken } from "atom.io"
+import type { ReadableToken } from "atom.io"
 
 import type { Store } from "./store"
 import { isChildStore } from "./transaction/is-root-store"
@@ -12,12 +12,12 @@ export type OperationProgress =
 			done: Set<string>
 			prev: Map<string, any>
 			time: number
-			token: WritableToken<any>
+			token: ReadableToken<any>
 	  }
 
 export const openOperation = (
 	store: Store,
-	token: WritableToken<any>,
+	token: ReadableToken<any>,
 ): number | undefined => {
 	if (store.operation.open) {
 		const rejectionTime = performance.now()

--- a/packages/atom.io/src/internal/set-state/evict-downstream.ts
+++ b/packages/atom.io/src/internal/set-state/evict-downstream.ts
@@ -40,9 +40,11 @@ export function evictDownStreamFromSelector(
 	selector: Selector<any>,
 ): void {
 	const target = newest(store)
-	const relationEntries = target.selectorGraph.getRelationEntries({
-		upstreamSelectorKey: selector.key,
-	})
+	const relationEntries = target.selectorGraph
+		.getRelationEntries({
+			upstreamSelectorKey: selector.key,
+		})
+		.filter(([_, { source }]) => source === selector.key)
 	for (const [downstreamSelectorKey] of relationEntries) {
 		if (isDone(target, downstreamSelectorKey)) {
 			continue


### PR DESCRIPTION
### **User description**
- **🚧**
- **commit for sending you this on the plane**


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Add tests for async downstream selectors

- Test loadable index and atomFamily behavior

- Evict downstream caches on promise resolution

- Introduce selector-based eviction helper


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>async-state.test.ts</strong><dd><code>Add extensive async downstream selector tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/public/async-state.test.ts

<li>Imported and used motion client (<code>i</code>)<br> <li> Added tests for sync selectors downstream from async atoms<br> <li> Added tests for async selector downstream chains<br> <li> Added loadable index and itemFamily revalidation tests


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4400/files#diff-3c0592098839f0a7e88cbf5bebd85e703a77816a844913bd091b61bb80d29f42">+183/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>caching.ts</strong><dd><code>Trigger downstream eviction after promise resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/internal/caching.ts

<li>Imported <code>openOperation</code>, <code>closeOperation</code>, eviction helpers<br> <li> On promise resolution, open operation and evict downstream<br> <li> Support eviction for both atoms and selectors


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4400/files#diff-e2291b4d1e35f0335c06b6ed4e16d866a16d62136429822c2a128d1f5de6a0e9">+20/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>operation.ts</strong><dd><code>Use ReadableToken in openOperation signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/internal/operation.ts

<li>Changed <code>openOperation</code> token type to <code>ReadableToken</code><br> <li> Updated imports to reflect new token type


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4400/files#diff-8fec8bd65a7ecf755eb2ac12c832c8dce270a143a77f10e080f8da880d1ab738">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>evict-downstream.ts</strong><dd><code>Add selector-based downstream eviction helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/internal/set-state/evict-downstream.ts

<li>Refactored <code>evictDownStream</code> signature to function form<br> <li> Added <code>evictDownStreamFromSelector</code> helper<br> <li> Use <code>isDone</code> and <code>markDone</code> for selector eviction


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4400/files#diff-4c7b1d1a0253e5523cbbbc89982a9408dc92bafc99be5090ae62d97068801ef1">+19/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>