### PR TITLE
atom.io fix family member defaults

### DIFF
--- a/.changeset/short-mirrors-build.md
+++ b/.changeset/short-mirrors-build.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 Fixed an issue where resetting states that belong to a family wouldn't cause them to re-execute their `default` function, in the case `default` is defined as a function `(key) => T`.

--- a/packages/atom.io/src/internal/families/create-regular-atom-family.ts
+++ b/packages/atom.io/src/internal/families/create-regular-atom-family.ts
@@ -51,7 +51,7 @@ export function createRegularAtomFamily<T, K extends Canonical>(
 		const def = options.default
 		const individualOptions: RegularAtomOptions<T> = {
 			key: fullKey,
-			default: def instanceof Function ? def(key) : def,
+			default: def instanceof Function ? () => def(key) : def,
 		}
 		if (options.effects) {
 			individualOptions.effects = options.effects(key)


### PR DESCRIPTION
### **User description**
- **🐛 if the family default is a function, so should be the defaults of its members**
- **✅ test resetting loadable family members**
- **🦋**


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Wrap function defaults in atomFamily correctly

- Refactor async-state tests: clean logs, rename atoms

- Add assertions for Future states in tests

- Add resetState tests for atomFamily re-execution


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>async-state.test.ts</strong><dd><code>Refactor tests and add resetState assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/public/async-state.test.ts

<li>Removed debug console.log statements<br> <li> Renamed atomFamily instances (indexSelectors → indexAtoms)<br> <li> Added extensive expect assertions for Future states<br> <li> Introduced resetState tests for atomFamily members


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4527/files#diff-3c0592098839f0a7e88cbf5bebd85e703a77816a844913bd091b61bb80d29f42">+76/-92</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-regular-atom-family.ts</strong><dd><code>Wrap default def in function for families</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/internal/families/create-regular-atom-family.ts

<li>Wrapped function defaults in closure for atomFamily members<br> <li> Ensured defaults remain functions when provided


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4527/files#diff-d33ca1dbc2da2a4f8362779f68fbb065b969af7cee41a11c818b0c019bf6d038">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>short-mirrors-build.md</strong><dd><code>Add changeset for atom.io patch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/short-mirrors-build.md

<li>Added changeset entry for atom.io patch<br> <li> Documented bug fix behavior for family member defaults


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4527/files#diff-6b98308e5fe136e0bbb0e60c09bc2c7b7af6bf4525f87c8f536593c3f6bc18e8">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>