### PR TITLE
secret devtools

### DIFF
--- a/.changeset/brown-words-poke.md
+++ b/.changeset/brown-words-poke.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+✨ `atom.io/react-devtools` adds a new hotkey (`ctrl+shift+a`) to toggle hidden mode. This way, they can be embedded into production websites for debugging without confusing users.

--- a/packages/atom.io/__stories__/DevTools.stories.tsx
+++ b/packages/atom.io/__stories__/DevTools.stories.tsx
@@ -12,7 +12,6 @@ import {
 } from "atom.io"
 import { IMPLICIT } from "atom.io/internal"
 import { AtomIODevtools } from "atom.io/react-devtools"
-import { fn } from "storybook/test"
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta: Meta<typeof AtomIODevtools> = {
@@ -38,12 +37,6 @@ const meta: Meta<typeof AtomIODevtools> = {
 	},
 	// This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
 	tags: ["autodocs"],
-	// More on argTypes: https://storybook.js.org/docs/api/argtypes
-	argTypes: {
-		backgroundColor: { control: "color" },
-	},
-	// Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
-	args: { onClick: fn() },
 }
 
 export default meta
@@ -152,7 +145,5 @@ const myTX = transaction<(param: object) => object>({
 
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 export const Primary: Story = {
-	args: {
-		backgroundColor: "#ae5757",
-	},
+	args: {},
 }

--- a/packages/atom.io/__tests__/private/introspection/AtomIODevtools.test.tsx
+++ b/packages/atom.io/__tests__/private/introspection/AtomIODevtools.test.tsx
@@ -492,6 +492,28 @@ describe(`miscellaneous tool behavior`, () => {
 			throw new Error(`Expected element to not be found`)
 		})
 	})
+	test(`hiding/un-hiding the devtools`, async () => {
+		const { getByTestId } = scenario()
+
+		await waitFor(() => getByTestId(`devtools`))
+
+		act(() => {
+			fireEvent.keyDown(document.body, {
+				key: `a`,
+				ctrlKey: true,
+				shiftKey: true,
+			})
+		})
+
+		await waitFor(() => {
+			try {
+				getByTestId(`devtools`)
+			} catch (_) {
+				return
+			}
+			throw new Error(`Expected element to not be found`)
+		})
+	})
 })
 
 describe(`devtools multi-expand/collapse`, () => {

--- a/packages/atom.io/src/react-devtools/AtomIODevtools.tsx
+++ b/packages/atom.io/src/react-devtools/AtomIODevtools.tsx
@@ -24,16 +24,19 @@ const AtomIODevtoolsInternal = (): React.ReactNode => {
 	const {
 		atomIndex,
 		selectorIndex,
-		devtoolsAreOpenState,
-		devtoolsViewSelectionState,
-		devtoolsViewOptionsState,
+		devtoolsAreHiddenAtom,
+		devtoolsAreOpenAtom,
+		devtoolsViewSelectionAtom,
+		devtoolsViewOptionsAtom,
 	} = useContext(DevtoolsContext)
 
-	const setDevtoolsAreOpen = useI(devtoolsAreOpenState)
-	const devtoolsAreOpen = useO(devtoolsAreOpenState)
-	const setDevtoolsView = useI(devtoolsViewSelectionState)
-	const devtoolsView = useO(devtoolsViewSelectionState)
-	const devtoolsViewOptions = useO(devtoolsViewOptionsState)
+	const devtoolsAreHidden = useO(devtoolsAreHiddenAtom)
+
+	const setDevtoolsAreOpen = useI(devtoolsAreOpenAtom)
+	const devtoolsAreOpen = useO(devtoolsAreOpenAtom)
+	const setDevtoolsView = useI(devtoolsViewSelectionAtom)
+	const devtoolsView = useO(devtoolsViewSelectionAtom)
+	const devtoolsViewOptions = useO(devtoolsViewOptionsAtom)
 
 	const mouseHasMoved = useRef(false)
 
@@ -60,73 +63,75 @@ const AtomIODevtoolsInternal = (): React.ReactNode => {
 					pointerEvents: `none`,
 				}}
 			/>
-			<motion.main
-				drag
-				dragConstraints={constraintsRef}
-				data-css="atom_io_devtools"
-				transition={{ type: `spring`, bounce: 0.25 }}
-				style={
-					devtoolsAreOpen
-						? {}
-						: {
-								backgroundColor: `#0000`,
-								borderColor: `#0000`,
-								maxHeight: 28,
-								maxWidth: 33,
-							}
-				}
-			>
-				{devtoolsAreOpen ? (
-					<>
-						<motion.header>
-							<h1>atom.io</h1>
-							<nav>
-								{devtoolsViewOptions.map((viewOption) => (
-									<button
-										key={viewOption}
-										type="button"
-										data-testid={`view-${viewOption}`}
-										className={viewOption === devtoolsView ? `active` : ``}
-										onClick={() => {
-											setDevtoolsView(viewOption)
-										}}
-										disabled={viewOption === devtoolsView}
-									>
-										{viewOption}
-									</button>
-								))}
-							</nav>
-						</motion.header>
-						<motion.main>
-							<LayoutGroup>
-								{devtoolsView === `atoms` ? (
-									<StateIndex tokenIndex={atomIndex} />
-								) : devtoolsView === `selectors` ? (
-									<StateIndex tokenIndex={selectorIndex} />
-								) : devtoolsView === `transactions` ? (
-									<TransactionIndex />
-								) : (
-									<TimelineIndex />
-								)}
-							</LayoutGroup>
-						</motion.main>
-					</>
-				) : null}
-				<footer>
-					<button
-						type="button"
-						onMouseDown={() => (mouseHasMoved.current = false)}
-						onMouseMove={() => (mouseHasMoved.current = true)}
-						onMouseUp={() => {
-							if (!mouseHasMoved.current) {
-								setDevtoolsAreOpen((open) => !open)
-							}
-						}}
-					>
-						🔍
-					</button>
-				</footer>
-			</motion.main>
+			{devtoolsAreHidden ? null : (
+				<motion.main
+					drag
+					dragConstraints={constraintsRef}
+					data-css="atom_io_devtools"
+					transition={{ type: `spring`, bounce: 0.25 }}
+					style={
+						devtoolsAreOpen
+							? {}
+							: {
+									backgroundColor: `#0000`,
+									borderColor: `#0000`,
+									maxHeight: 28,
+									maxWidth: 33,
+								}
+					}
+				>
+					{devtoolsAreOpen ? (
+						<>
+							<motion.header>
+								<h1>atom.io</h1>
+								<nav>
+									{devtoolsViewOptions.map((viewOption) => (
+										<button
+											key={viewOption}
+											type="button"
+											data-testid={`view-${viewOption}`}
+											className={viewOption === devtoolsView ? `active` : ``}
+											onClick={() => {
+												setDevtoolsView(viewOption)
+											}}
+											disabled={viewOption === devtoolsView}
+										>
+											{viewOption}
+										</button>
+									))}
+								</nav>
+							</motion.header>
+							<motion.main>
+								<LayoutGroup>
+									{devtoolsView === `atoms` ? (
+										<StateIndex tokenIndex={atomIndex} />
+									) : devtoolsView === `selectors` ? (
+										<StateIndex tokenIndex={selectorIndex} />
+									) : devtoolsView === `transactions` ? (
+										<TransactionIndex />
+									) : (
+										<TimelineIndex />
+									)}
+								</LayoutGroup>
+							</motion.main>
+						</>
+					) : null}
+					<footer>
+						<button
+							type="button"
+							onMouseDown={() => (mouseHasMoved.current = false)}
+							onMouseMove={() => (mouseHasMoved.current = true)}
+							onMouseUp={() => {
+								if (!mouseHasMoved.current) {
+									setDevtoolsAreOpen((open) => !open)
+								}
+							}}
+						>
+							🔍
+						</button>
+					</footer>
+				</motion.main>
+			)}
 		</span>
 	)
 }

--- a/packages/atom.io/src/react-devtools/AtomIODevtools.tsx
+++ b/packages/atom.io/src/react-devtools/AtomIODevtools.tsx
@@ -70,6 +70,7 @@ const AtomIODevtoolsInternal = (): React.ReactNode => {
 					drag
 					dragConstraints={constraintsRef}
 					data-css="atom_io_devtools"
+					data-testid="devtools"
 					transition={{ type: `spring`, bounce: 0.25 }}
 					style={
 						devtoolsAreOpen

--- a/packages/atom.io/src/react-devtools/AtomIODevtools.tsx
+++ b/packages/atom.io/src/react-devtools/AtomIODevtools.tsx
@@ -9,10 +9,12 @@ import { attachDevtoolsStates, DevtoolsContext } from "./store"
 import { TimelineIndex } from "./TimelineIndex"
 import { TransactionIndex } from "./TransactionIndex"
 
-export const AtomIODevtools: React.FC = () => {
+export const AtomIODevtools: React.FC<{ hideByDefault?: boolean }> = ({
+	hideByDefault = false,
+}) => {
 	const store = useContext(StoreContext)
 	return (
-		<DevtoolsContext.Provider value={attachDevtoolsStates(store)}>
+		<DevtoolsContext.Provider value={attachDevtoolsStates(store, hideByDefault)}>
 			<AtomIODevtoolsInternal />
 		</DevtoolsContext.Provider>
 	)

--- a/packages/atom.io/src/react-devtools/store.ts
+++ b/packages/atom.io/src/react-devtools/store.ts
@@ -61,7 +61,7 @@ export function attachDevtoolsStates(
 
 	const devtoolsAreOpenAtom = createStandaloneAtom<boolean>(store, {
 		key: `🔍 Devtools Are Open`,
-		default: false,
+		default: true,
 		effects:
 			typeof window === `undefined`
 				? []

--- a/packages/atom.io/src/react-devtools/store.ts
+++ b/packages/atom.io/src/react-devtools/store.ts
@@ -24,9 +24,10 @@ import { createContext } from "react"
 type DevtoolsView = `atoms` | `selectors` | `timelines` | `transactions`
 
 export type DevtoolsStates = {
-	devtoolsAreOpenState: RegularAtomToken<boolean>
-	devtoolsViewSelectionState: RegularAtomToken<DevtoolsView>
-	devtoolsViewOptionsState: RegularAtomToken<DevtoolsView[]>
+	devtoolsAreHiddenAtom: RegularAtomToken<boolean>
+	devtoolsAreOpenAtom: RegularAtomToken<boolean>
+	devtoolsViewSelectionAtom: RegularAtomToken<DevtoolsView>
+	devtoolsViewOptionsAtom: RegularAtomToken<DevtoolsView[]>
 	viewIsOpenAtoms: RegularAtomFamilyToken<boolean, readonly (number | string)[]>
 	openCloseAllTX: TransactionToken<
 		(path: readonly (number | string)[], current?: boolean) => void
@@ -35,19 +36,39 @@ export type DevtoolsStates = {
 
 export function attachDevtoolsStates(
 	store: Store,
+	hideByDefault = false,
 ): DevtoolsStates & IntrospectionStates & { store: Store } {
 	const introspectionStates = attachIntrospectionStates(store)
 
-	const devtoolsAreOpenState = createStandaloneAtom<boolean>(store, {
+	const devtoolsAreHiddenAtom = createStandaloneAtom<boolean>(store, {
+		key: `🔍 Devtools Are Hidden`,
+		default: hideByDefault,
+		effects:
+			typeof window === `undefined`
+				? []
+				: [
+						persistSync(window.localStorage, JSON, `🔍 Devtools Are Hidden`),
+						({ setSelf }) => {
+							window.addEventListener(`keydown`, (e) => {
+								if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === `a`) {
+									e.preventDefault()
+									setSelf((state) => !state)
+								}
+							})
+						},
+					],
+	})
+
+	const devtoolsAreOpenAtom = createStandaloneAtom<boolean>(store, {
 		key: `🔍 Devtools Are Open`,
-		default: true,
+		default: false,
 		effects:
 			typeof window === `undefined`
 				? []
 				: [persistSync(window.localStorage, JSON, `🔍 Devtools Are Open`)],
 	})
 
-	const devtoolsViewSelectionState = createStandaloneAtom<DevtoolsView>(store, {
+	const devtoolsViewSelectionAtom = createStandaloneAtom<DevtoolsView>(store, {
 		key: `🔍 Devtools View Selection`,
 		default: `atoms`,
 		effects:
@@ -56,7 +77,7 @@ export function attachDevtoolsStates(
 				: [persistSync(window.localStorage, JSON, `🔍 Devtools View`)],
 	})
 
-	const devtoolsViewOptionsState = createStandaloneAtom<DevtoolsView[]>(store, {
+	const devtoolsViewOptionsAtom = createStandaloneAtom<DevtoolsView[]>(store, {
 		key: `🔍 Devtools View Options`,
 		default: [`atoms`, `selectors`, `transactions`, `timelines`],
 		effects:
@@ -84,7 +105,7 @@ export function attachDevtoolsStates(
 	>(store, {
 		key: `🔍 Open Close All`,
 		do: ({ get, set }, path, current) => {
-			const currentView = get(devtoolsViewSelectionState)
+			const currentView = get(devtoolsViewSelectionAtom)
 			let states:
 				| WritableTokenIndex<AtomToken<unknown>>
 				| WritableTokenIndex<SelectorToken<unknown>>
@@ -153,9 +174,10 @@ export function attachDevtoolsStates(
 
 	return {
 		...introspectionStates,
-		devtoolsAreOpenState,
-		devtoolsViewSelectionState,
-		devtoolsViewOptionsState,
+		devtoolsAreHiddenAtom,
+		devtoolsAreOpenAtom,
+		devtoolsViewSelectionAtom,
+		devtoolsViewOptionsAtom,
 		viewIsOpenAtoms,
 		openCloseAllTX,
 		store,


### PR DESCRIPTION
### **User description**
- **✨ add ability to hide devtools**
- **🦋**
- **🔧 pass as prop**
- **🔧 updat stories**


___

### **PR Type**
Enhancement


___

### **Description**
- Add hide-by-default mode and hotkey toggle

- Persist devtools hidden/open states in localStorage

- Extend AtomIODevtools with hideByDefault prop

- Update Storybook stories to remove unused args


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DevTools.stories.tsx</strong><dd><code>Simplify Devtools Storybook configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__stories__/DevTools.stories.tsx

<li>Removed unused <code>fn</code> import<br> <li> Cleared <code>argTypes</code> and <code>args</code> definitions<br> <li> Simplified <code>Primary</code> story configuration


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4540/files#diff-db7b098152af675b777ae67d1064b3ff5b6cffd89f2dd0ed936a051db7d537f0">+1/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AtomIODevtools.tsx</strong><dd><code>Support hide-by-default devtools prop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/react-devtools/AtomIODevtools.tsx

<li>Add <code>hideByDefault</code> prop to <code>AtomIODevtools</code><br> <li> Pass <code>hideByDefault</code> into <code>attachDevtoolsStates</code><br> <li> Conditionally render devtools when hidden


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4540/files#diff-f09eaf61588efd58f0d74099a58b28122a1932c7a1478c1f4b3f7b485a630e06">+84/-77</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>store.ts</strong><dd><code>Add hidden-state atom and hotkey toggle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/react-devtools/store.ts

<li>Introduce <code>devtoolsAreHiddenAtom</code> with default <code>hideByDefault</code><br> <li> Add Ctrl+Shift+A listener to toggle hidden state<br> <li> Rename and separate open/hidden atoms, persist states


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4540/files#diff-97eb0b3b2471903f50d7e03fc422a0b907e1bcf0973b6def2c94977642cc2006">+33/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>brown-words-poke.md</strong><dd><code>Add changeset for devtools hide feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/brown-words-poke.md

- Document patch release of hide mode feature


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4540/files#diff-66e508eabfffa5f7d18aea085a8728e8f1576d6f9645fa1edc68add9bae89c03">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>