### PR TITLE
atom.io reset self

### DIFF
--- a/.changeset/blue-wings-tie.md
+++ b/.changeset/blue-wings-tie.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+✨ Add `resetState` to the atom `Effectors`.

--- a/packages/atom.io/__tests__/public/atom-effects.test.ts
+++ b/packages/atom.io/__tests__/public/atom-effects.test.ts
@@ -75,6 +75,26 @@ describe(`atom effects`, () => {
 		expect(logger.warn).not.toHaveBeenCalled()
 		expect(logger.error).not.toHaveBeenCalled()
 	})
+	it(`resets itself`, () => {
+		const mySubject = new Internal.Subject<string>()
+		const nameState = atom<string>({
+			key: `name`,
+			default: ``,
+			effects: [
+				({ resetSelf }) => {
+					mySubject.subscribe(`waiting to reset`, () => {
+						resetSelf()
+					})
+				},
+			],
+		})
+		setState(nameState, `Mavis`)
+		expect(getState(nameState)).toBe(`Mavis`)
+		mySubject.next(`reset`)
+		expect(getState(nameState)).toBe(``)
+		expect(logger.warn).not.toHaveBeenCalled()
+		expect(logger.error).not.toHaveBeenCalled()
+	})
 })
 
 describe(`atom effect cleanup`, () => {

--- a/packages/atom.io/__tests__/public/atom-effects.test.ts
+++ b/packages/atom.io/__tests__/public/atom-effects.test.ts
@@ -10,6 +10,7 @@ import {
 	setState,
 } from "atom.io"
 import * as Internal from "atom.io/internal"
+import { SetRTX } from "atom.io/transceivers/set-rtx"
 import tmp from "tmp"
 import { vitest } from "vitest"
 
@@ -92,6 +93,27 @@ describe(`atom effects`, () => {
 		expect(getState(nameState)).toBe(`Mavis`)
 		mySubject.next(`reset`)
 		expect(getState(nameState)).toBe(``)
+		expect(logger.warn).not.toHaveBeenCalled()
+		expect(logger.error).not.toHaveBeenCalled()
+	})
+	it(`resets itself (mutable)`, () => {
+		const mySubject = new Internal.Subject<string>()
+		const nameState = atom<SetRTX<string>>({
+			key: `name`,
+			default: () => new SetRTX(),
+			effects: [
+				({ resetSelf }) => {
+					mySubject.subscribe(`waiting to reset`, () => {
+						resetSelf()
+					})
+				},
+			],
+		})
+		setState(nameState, (current) => current.add(`Cat`))
+		const setOriginal = getState(nameState)
+		mySubject.next(`reset`)
+		const setNew = getState(nameState)
+		expect(setNew).not.toBe(setOriginal)
 		expect(logger.warn).not.toHaveBeenCalled()
 		expect(logger.error).not.toHaveBeenCalled()
 	})

--- a/packages/atom.io/__tests__/public/atom-effects.test.ts
+++ b/packages/atom.io/__tests__/public/atom-effects.test.ts
@@ -10,6 +10,7 @@ import {
 	setState,
 } from "atom.io"
 import * as Internal from "atom.io/internal"
+import type { SetRTXJson } from "atom.io/transceivers/set-rtx"
 import { SetRTX } from "atom.io/transceivers/set-rtx"
 import tmp from "tmp"
 import { vitest } from "vitest"
@@ -98,8 +99,9 @@ describe(`atom effects`, () => {
 	})
 	it(`resets itself (mutable)`, () => {
 		const mySubject = new Internal.Subject<string>()
-		const nameState = atom<SetRTX<string>>({
+		const nameState = atom<SetRTX<string>, SetRTXJson<string>>({
 			key: `name`,
+			mutable: true,
 			default: () => new SetRTX(),
 			effects: [
 				({ resetSelf }) => {
@@ -108,6 +110,8 @@ describe(`atom effects`, () => {
 					})
 				},
 			],
+			toJson: (set) => set.toJSON(),
+			fromJson: (json) => SetRTX.fromJSON(json),
 		})
 		setState(nameState, (current) => current.add(`Cat`))
 		const setOriginal = getState(nameState)

--- a/packages/atom.io/src/internal/atom/create-regular-atom.ts
+++ b/packages/atom.io/src/internal/atom/create-regular-atom.ts
@@ -5,7 +5,7 @@ import type {
 	UpdateHandler,
 } from "atom.io"
 
-import { type RegularAtom, setIntoStore } from ".."
+import { type RegularAtom, resetInStore, setIntoStore } from ".."
 import { cacheValue } from "../caching"
 import { newest } from "../lineage"
 import type { Store } from "../store"
@@ -62,6 +62,9 @@ export function createRegularAtom<T>(
 		const cleanupFunctions: (() => void)[] = []
 		for (const effect of options.effects) {
 			const cleanup = effect({
+				resetSelf: () => {
+					resetInStore(store, token)
+				},
 				setSelf: (next) => {
 					setIntoStore(store, token, next)
 				},

--- a/packages/atom.io/src/internal/mutable/create-mutable-atom.ts
+++ b/packages/atom.io/src/internal/mutable/create-mutable-atom.ts
@@ -8,7 +8,7 @@ import type { Json } from "atom.io/json"
 import { selectJson } from "atom.io/json"
 
 import type { MutableAtom } from ".."
-import { cacheValue, setIntoStore } from ".."
+import { cacheValue, resetInStore, setIntoStore } from ".."
 import { newest } from "../lineage"
 import { deposit, type Store } from "../store"
 import { Subject } from "../subject"
@@ -65,6 +65,9 @@ export function createMutableAtom<
 		const cleanupFunctions: (() => void)[] = []
 		for (const effect of options.effects) {
 			const cleanup = effect({
+				resetSelf: () => {
+					resetInStore(store, token)
+				},
 				setSelf: (next) => {
 					setIntoStore(store, token, next)
 				},

--- a/packages/atom.io/src/internal/set-state/reset-atom-or-selector.ts
+++ b/packages/atom.io/src/internal/set-state/reset-atom-or-selector.ts
@@ -1,4 +1,5 @@
-import { type Atom, traceAllSelectorAtoms, type WritableState } from ".."
+import type { Atom, WritableState } from ".."
+import { traceAllSelectorAtoms } from ".."
 import type { Store } from "../store"
 import { setAtom } from "./set-atom"
 

--- a/packages/atom.io/src/main/atom.ts
+++ b/packages/atom.io/src/main/atom.ts
@@ -41,6 +41,10 @@ export function atom(
 /** @public */
 export type Effectors<T> = {
 	/**
+	 * Reset the value of the atom to its default
+	 */
+	resetSelf: () => void
+	/**
 	 * Set the value of the atom
 	 * @param next - The new value of the atom, or a setter function
 	 */


### PR DESCRIPTION
### **User description**
- **✨ resetSelf**
- **✅ reset self**
- **✅ test resetSelf**
- **🦋**


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `resetSelf` effector to atom API

- Implement `resetSelf` in regular and mutable atoms

- Update `Effectors` type to include `resetSelf`

- Add tests covering `resetSelf` functionality


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>atom-effects.test.ts</strong><dd><code>Add resetSelf tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/public/atom-effects.test.ts

<li>Import <code>SetRTX</code> for mutable reset tests<br> <li> Add <code>it('resets itself')</code> test for regular atom<br> <li> Add <code>it('resets itself (mutable)')</code> test using <code>SetRTX</code><br> <li> Trigger <code>resetSelf</code> via <code>Subject</code>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4553/files#diff-bebe2e66c49237d1d71dd71da7f3322fb88be71ef3df6c932c1111d632c449d3">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-regular-atom.ts</strong><dd><code>Implement resetSelf in createRegularAtom</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/internal/atom/create-regular-atom.ts

<li>Import <code>resetInStore</code><br> <li> Add <code>resetSelf</code> in effect context<br> <li> Call <code>resetInStore</code> to reset atom state


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4553/files#diff-c52e57faa85fb193efd21dec23ea6e188c0795234bba761b1de409405812b601">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create-mutable-atom.ts</strong><dd><code>Implement resetSelf in createMutableAtom</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/internal/mutable/create-mutable-atom.ts

<li>Import <code>resetInStore</code><br> <li> Add <code>resetSelf</code> in effect context<br> <li> Use <code>resetInStore</code> for mutable atoms reset


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4553/files#diff-f9e76471b8c4e94a70b06e642e0d0aa6ba466627a32dc7631813d053cdbf024d">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reset-atom-or-selector.ts</strong><dd><code>Refactor imports in reset-atom-or-selector</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/internal/set-state/reset-atom-or-selector.ts

<li>Separate type import for <code>Atom</code> and <code>WritableState</code><br> <li> Move <code>traceAllSelectorAtoms</code> to actual imports


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4553/files#diff-413dcb9b6b4ce2346a8bc07b7020a6f5b83ba9aa6ae883acb387bd0acaa3c37b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>atom.ts</strong><dd><code>Add resetSelf to Effectors type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/main/atom.ts

<li>Add <code>resetSelf</code> to <code>Effectors</code> type<br> <li> Document <code>resetSelf</code> in doc comment


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4553/files#diff-8e45c00372826244b919db627bea15b21ea396e0a4aec9cd19f496b319403a2b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>blue-wings-tie.md</strong><dd><code>Add changeset for resetSelf</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.changeset/blue-wings-tie.md

<li>Add changeset for <code>resetState</code> patch<br> <li> Document addition of <code>resetState</code> effector


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4553/files#diff-5d1c6ea1caa694fe9caad3c554abec7672de44376c2d2ec62b97eac16a27f6fb">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>