### PR TITLE
fix writable selector cache bug

### DIFF
--- a/.changeset/red-tips-tap.md
+++ b/.changeset/red-tips-tap.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+🐛 Fixed bug where getting a writable, loadable selector could return a stale Promise.

--- a/packages/atom.io/src/internal/selector/create-writable-pure-selector.ts
+++ b/packages/atom.io/src/internal/selector/create-writable-pure-selector.ts
@@ -42,7 +42,7 @@ export const createWritablePureSelector = <T>(
 		const cached = writeToCache(innerTarget, mySelector, value)
 		store.logger.info(`✨`, type, key, `=`, cached)
 		covered.clear()
-		return value
+		return cached
 	}
 
 	const setSelf = (next: T | ((oldValue: T) => T)): void => {


### PR DESCRIPTION
- **🐛 return cached value when setting writable selector**
- **🦋**
