### PR TITLE
🔧 use a timeout assignable to a 32-bit integer

### DIFF
--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -5,7 +5,7 @@
 		"type": "node-terminal",
 		"request": "launch",
 		"program": "pnpm",
-		"args": ["vitest", "run", "--testTimeout=Infinity", "${ZED_FILENAME}"],
+		"args": ["vitest", "run", "--testTimeout=999999999", "${ZED_FILENAME}"],
 		"skipFiles": ["<node_internals>/**", "**/node_modules/**"],
 		"cwd": "${ZED_DIRNAME}"
 	}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replace Infinity timeout with large integer in Vitest debug


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>debug.json</strong><dd><code>Update Vitest debug testTimeout setting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.zed/debug.json

<li>Changed <code>--testTimeout</code> value from <code>Infinity</code> to <code>999999999</code><br> <li> Ensures timeout fits within 32-bit integer limits


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4671/files#diff-74478476fa6601da759a4f54aae4ffe8f445159833fda8ea232876405c41f1bb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>