### PR TITLE
support returned errors in varmint

### DIFF
--- a/.changeset/great-crabs-build.md
+++ b/.changeset/great-crabs-build.md
@@ -1,0 +1,5 @@
+---
+"varmint": patch
+---
+
+✨ Squirrel adds special-case support for functions that return `Promise<Error>`. Previously, only JSON values could be safely cached by Squirrel.

--- a/packages/varmint/.varmint/errors/test-error.input.json
+++ b/packages/varmint/.varmint/errors/test-error.input.json
@@ -1,0 +1,3 @@
+[
+	"test error"
+]

--- a/packages/varmint/.varmint/errors/test-error.output.json
+++ b/packages/varmint/.varmint/errors/test-error.output.json
@@ -1,0 +1,7 @@
+ERROR!
+{
+	"name": "Error",
+	"message": "test error",
+	"stack": "Error: test error\n    at /Users/jem/dojo/wayforge/packages/varmint/__tests__/error-interface.test.ts:20:20\n    at Squirrel.write (/Users/jem/dojo/wayforge/packages/varmint/src/squirrel.ts:188:24)\n    at Object.get (/Users/jem/dojo/wayforge/packages/varmint/src/squirrel.ts:244:21)\n    at /Users/jem/dojo/wayforge/packages/varmint/__tests__/error-interface.test.ts:22:53\n    at file:///Users/jem/dojo/wayforge/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11\n    at file:///Users/jem/dojo/wayforge/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26\n    at file:///Users/jem/dojo/wayforge/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20\n    at new Promise (<anonymous>)\n    at runWithTimeout (file:///Users/jem/dojo/wayforge/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)\n    at runTest (file:///Users/jem/dojo/wayforge/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)",
+	"props": {}
+}

--- a/packages/varmint/__tests__/error-interface.test.ts
+++ b/packages/varmint/__tests__/error-interface.test.ts
@@ -1,0 +1,27 @@
+import { Squirrel } from "../src"
+import { parseError, stringifyError } from "../src/error-interface"
+
+describe(`error interface`, () => {
+	test(`can dehydrate and rehydrate an error`, () => {
+		const error = new Error(`test error`)
+		const stringifiedError = stringifyError(error)
+		const parsedError = parseError(stringifiedError)
+		expect(parsedError).toEqual(error)
+		console.log({ error })
+		console.log({ parsedError })
+		console.log({ stringifiedError })
+	})
+})
+
+describe(`Squirrel supports Error-return`, () => {
+	test(`can dehydrate and rehydrate an error`, async () => {
+		const squirrel = new Squirrel(`write`)
+		const getError = squirrel.add(`errors`, (message: string) =>
+			Promise.resolve(new Error(message)),
+		)
+		const myError0 = await getError.for(`test error`).get(`test error`)
+		squirrel.mode = `read`
+		const myError1 = await getError.for(`test error`).get(`test error`)
+		expect(myError1).toEqual(myError0)
+	})
+})

--- a/packages/varmint/__tests__/filebox.test.ts
+++ b/packages/varmint/__tests__/filebox.test.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process"
 import * as fs from "node:fs"
 import * as http from "node:http"
 import path from "node:path"

--- a/packages/varmint/src/error-interface.ts
+++ b/packages/varmint/src/error-interface.ts
@@ -1,0 +1,171 @@
+// Types for JSON-safe data
+type JSONValue = JSONArray | JSONObject | boolean | number | string | null
+interface JSONObject {
+	[k: string]: JSONValue
+}
+type JSONArray = Array<JSONValue>
+
+interface ErrorAsJSON {
+	name: string // "Error", "TypeError", "MyCustomError", ...
+	message: string
+	stack?: string // stringified stack
+	cause?: ErrorAsJSON // nested cause
+	errors?: ErrorAsJSON[] // for AggregateError
+	props?: JSONObject // extra own enumerable props (JSON-safe only)
+}
+
+// Pick which built-ins you want to reconstruct specially
+const ctorByName: Record<
+	string,
+	new (
+		message?: string,
+		options?: { cause?: unknown },
+	) => Error
+> = {
+	Error,
+	TypeError,
+	RangeError,
+	ReferenceError,
+	SyntaxError,
+	URIError,
+	EvalError,
+	AggregateError: AggregateError as unknown as new (
+		message?: string,
+		options?: { cause?: unknown },
+	) => Error,
+}
+
+// Safely convert arbitrary values to JSON-safe shapes (drop functions/symbols/BigInt, avoid cycles)
+function toJSONSafe(value: unknown, seen = new WeakSet()): JSONValue {
+	if (
+		value === null ||
+		typeof value === `string` ||
+		typeof value === `number` ||
+		typeof value === `boolean`
+	) {
+		return value
+	}
+	if (Array.isArray(value)) {
+		if (seen.has(value as object)) return null
+		seen.add(value as object)
+		return value.map((v) => toJSONSafe(v, seen)) as JSONArray
+	}
+	if (typeof value === `object`) {
+		if (!value) return null
+		if (seen.has(value)) return null
+		seen.add(value)
+		const out: JSONObject = {}
+		for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+			const converted = toJSONSafe(v, seen)
+			if (converted !== undefined) out[k] = converted
+		}
+		return out
+	}
+	// drop functions, symbols, bigints, undefined
+	return null
+}
+
+export function errorToJSON(error: Error): ErrorAsJSON {
+	const payload: ErrorAsJSON = {
+		name: error.name || `Error`,
+		message: error.message || ``,
+	}
+	if (`stack` in error) {
+		payload.stack = error.stack
+	}
+	if (error.cause instanceof Error) {
+		payload.cause = errorToJSON(error.cause)
+	}
+	if (typeof AggregateError !== `undefined` && error instanceof AggregateError) {
+		const items = Array.from(error.errors ?? [])
+		payload.errors = items.map(errorToJSON)
+	}
+
+	// Extra own, enumerable props (filter out the ones we already captured)
+	const props: Record<string, unknown> = {}
+	for (const key of Object.keys(error)) {
+		if (
+			key === `name` ||
+			key === `message` ||
+			key === `stack` ||
+			key === `cause` ||
+			key === `errors`
+		)
+			continue
+		props[key] = (error as any)[key]
+	}
+	const jsonProps = toJSONSafe(props)
+	if (jsonProps && typeof jsonProps === `object`) {
+		payload.props = jsonProps as JSONObject
+	}
+
+	return payload
+}
+
+export type StringifiedError = `ERROR!\n${string}`
+export function stringifyError(error: Error): StringifiedError {
+	const payload = errorToJSON(error)
+	const stringifiedPayload = JSON.stringify(payload, null, `\t`)
+	return `ERROR!\n${stringifiedPayload}`
+}
+
+export function parseError(stringifiedError: StringifiedError): Error
+export function parseError(maybeStringifiedError: string): Error | undefined
+export function parseError(maybeStringifiedError: string): Error | undefined {
+	if (!maybeStringifiedError.startsWith(`ERROR!\n`)) return undefined
+
+	const stringifiedPayload = maybeStringifiedError.slice(`ERROR!\n`.length)
+	const payload = JSON.parse(stringifiedPayload)
+
+	const Ctor = ctorByName[payload.name] ?? Error
+
+	// Rehydrate cause first so we can pass it into the constructor
+	const causeErr = payload.cause ? parseError(payload.cause) : undefined
+
+	// AggregateError needs special handling for `errors`; for others, just pass message/cause
+	let err: Error
+	if (Ctor === (AggregateError as unknown)) {
+		const errs = (payload.errors ?? []).map(parseError)
+		// Message displays differently across engines; set it explicitly too
+		err = new (AggregateError as any)(errs, payload.message, { cause: causeErr })
+	} else {
+		err = new Ctor(payload.message, { cause: causeErr })
+	}
+
+	// Preserve the original name if it was custom
+	if (!(payload.name in ctorByName)) {
+		try {
+			err.name = payload.name
+		} catch {
+			/* ignore */
+		}
+	}
+
+	// Restore stack as a non-enumerable property (common engine behavior)
+	if (payload.stack) {
+		try {
+			Object.defineProperty(err, `stack`, {
+				value: payload.stack,
+				writable: true,
+				configurable: true,
+				enumerable: false,
+			})
+		} catch {
+			// fallback: direct assignment (works in most environments)
+			;(err as any).stack = payload.stack
+		}
+	}
+
+	// Reattach extra props
+	if (payload.props && typeof payload.props === `object`) {
+		for (const [k, v] of Object.entries(payload.props)) {
+			try {
+				;(err as any)[k] = v
+			} catch {
+				/* ignore */
+			}
+		}
+	}
+
+	return err
+}


### PR DESCRIPTION
### **User description**
- **✨ add special stringification/parsing rules for errors**
- **🦋**


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add Error JSON serialization/rehydration interface

- Support caching and parsing Error returns

- Update Squirrel read/write logic for Error results

- Include tests and fixtures for error-interface


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>error-interface.test.ts</strong><dd><code>Add tests for error serialization interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4706/files#diff-2d0cfa9baa8f3d9e05201c0e4c55e99d2309770f6d939cdad462c1f532dba5e7">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test-error.input.json</strong><dd><code>Add test input fixture for error-interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4706/files#diff-bac32a2ba06a8c271e47930c3eaf78b7f27fc2384297e7bcbaad10169437941b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test-error.output.json</strong><dd><code>Add test output fixture for error-interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4706/files#diff-5d410dd123d9d6738d95c26b2f0f9b323b4993ff4109f382bc5edc762de8af2a">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>filebox.test.ts</strong><dd><code>Remove unused import in filebox tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4706/files#diff-703db7603a03cecf08a1f8280891f48032de664cbdfbe760f9218f450c57bbc2">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>error-interface.ts</strong><dd><code>Implement JSON serialization/parsing for Error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4706/files#diff-a32b031c6262844863ae68e8c9f9b7ef34d2029faf5d1ccac5508b59d2806b7d">+171/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>squirrel.ts</strong><dd><code>Handle Error results in Squirrel cache logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4706/files#diff-9c13ff70463abbb2f10798088d0c1f77b5ac1bc2ec894bf81c0a223d62e9970b">+13/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>great-crabs-build.md</strong><dd><code>Add changeset for Error return support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4706/files#diff-90cb032b75ae34a3a10e1cfdfbd64ee6e0ef107fe7becca8587a6f475c391789">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>