### PR TITLE
create only one event when setting a selector

### DIFF
--- a/.changeset/kind-garlics-invite.md
+++ b/.changeset/kind-garlics-invite.md
@@ -1,0 +1,16 @@
+---
+"atom.io": patch
+---
+
+✨ `timeline` overhaul.
+
+Timelines now make the following guarantees:
+
+- `undo` and `redo` iterates over 1 checkpoint in the timeline.
+- Reading from the store—"getting" a state—does not produce a checkpoint.
+- Writing to the store—"setting" a state—will create exactly 1 checkpoint.
+- Running a transaction will create exactly 1 checkpoint.
+
+With these changes, it is easier to use setState on a single atom or selector when the atoms being set are governed by a timeline. You don't need to wrap everything in a transaction, as long as you want a checkpoint for that one change.
+
+That being said, if you are in an `immortal` store, transactions are still preferred. Changes to remedy this are forthcoming.

--- a/.changeset/slick-beds-follow.md
+++ b/.changeset/slick-beds-follow.md
@@ -1,0 +1,5 @@
+---
+"atom.io": minor
+---
+
+💥 BREAKING CHANGE: The timeline option `shouldCapture` has been removed. This was never a good option, and was only used to prevent changes from atoms' default values from being recorded.

--- a/packages/atom.io/__tests__/public/timeline.test.ts
+++ b/packages/atom.io/__tests__/public/timeline.test.ts
@@ -218,7 +218,7 @@ describe(`timeline`, () => {
 		expect(getState(a)).toBe(1)
 		expect(getState(b)).toBe(1)
 	})
-	test.only(`creating selectors with setState`, () => {
+	test(`creating selectors with setState`, () => {
 		const numbers = atomFamily<number, string>({
 			key: `number`,
 			default: 0,

--- a/packages/atom.io/__tests__/public/timeline.test.ts
+++ b/packages/atom.io/__tests__/public/timeline.test.ts
@@ -30,7 +30,7 @@ let logger: Logger
 beforeEach(() => {
 	I.clearStore(I.IMPLICIT.STORE)
 	I.IMPLICIT.STORE.loggers[0].logLevel = LOG_LEVELS[CHOOSE]
-	logger = I.IMPLICIT.STORE.logger //= Utils.createNullLogger()
+	logger = I.IMPLICIT.STORE.logger = Utils.createNullLogger()
 	vitest.spyOn(logger, `error`)
 	vitest.spyOn(logger, `warn`)
 	vitest.spyOn(logger, `info`)
@@ -385,7 +385,7 @@ describe(`timeline`, () => {
 		expect(getState(count)).toBe(1)
 		expect(I.IMPLICIT.STORE.timelines.get(countTL.key)?.at).toBe(0)
 	})
-	it.only(`passes over non-write events`, () => {
+	it(`passes over non-write events`, () => {
 		const counts = atomFamily<number, string>({
 			key: `count`,
 			default: 0,
@@ -409,7 +409,6 @@ describe(`timeline`, () => {
 
 		undo(countTL)
 		redo(countTL)
-		_inspectTimeline(countTL)
 		expect(getState(counts, `a`)).toBe(1)
 	})
 })
@@ -428,7 +427,9 @@ describe(`timeline state lifecycle`, () => {
 		expect(getState(countStates, `my-key`)).toBe(1)
 		disposeState(countStates, `my-key`)
 		undo(countsTL)
-		undo(countsTL)
+		_inspectTimeline(countsTL)
+		console.log(`👀`, I.IMPLICIT.STORE.atoms.get(`count("my-key")`))
+
 		expect(I.seekInStore(I.IMPLICIT.STORE, countStates, `my-key`)).toBe(
 			undefined,
 		)
@@ -441,7 +442,6 @@ describe(`timeline state lifecycle`, () => {
 			key: `count("my-key")`,
 			type: `atom`,
 		})
-		redo(countsTL)
 	})
 })
 

--- a/packages/atom.io/__tests__/public/timeline.test.ts
+++ b/packages/atom.io/__tests__/public/timeline.test.ts
@@ -427,8 +427,6 @@ describe(`timeline state lifecycle`, () => {
 		expect(getState(countStates, `my-key`)).toBe(1)
 		disposeState(countStates, `my-key`)
 		undo(countsTL)
-		_inspectTimeline(countsTL)
-		console.log(`👀`, I.IMPLICIT.STORE.atoms.get(`count("my-key")`))
 
 		expect(I.seekInStore(I.IMPLICIT.STORE, countStates, `my-key`)).toBe(
 			undefined,

--- a/packages/atom.io/__tests__/public/timeline.test.ts
+++ b/packages/atom.io/__tests__/public/timeline.test.ts
@@ -228,9 +228,8 @@ describe(`timeline`, () => {
 			key: `product`,
 			get:
 				([a, b]) =>
-				({ get }) => {
-					return get(numbers, a) * get(numbers, b)
-				},
+				({ get }) =>
+					get(numbers, a) * get(numbers, b),
 			set:
 				([a, b]) =>
 				({ set }, value) => {
@@ -239,12 +238,26 @@ describe(`timeline`, () => {
 				},
 		})
 
+		const productSquareRoots = selectorFamily<number, [a: string, b: string]>({
+			key: `product root`,
+			get:
+				(key) =>
+				({ get }) =>
+					Math.sqrt(get(products, key)),
+			set:
+				(key) =>
+				({ set }, value) => {
+					set(products, key, value ** 2)
+				},
+		})
+
 		const timeline_ab = timeline({
 			key: `numbers over time`,
 			scope: [numbers],
 		})
 
-		setState(products, [`a`, `b`], 9)
+		// setState(products, [`a`, `b`], 9)
+		setState(productSquareRoots, [`a`, `b`], 3)
 		console.log(
 			inspect(I.withdraw(I.IMPLICIT.STORE, timeline_ab).history, {
 				colors: true,
@@ -252,7 +265,7 @@ describe(`timeline`, () => {
 			}),
 		)
 		expect(I.withdraw(I.IMPLICIT.STORE, timeline_ab).history).toHaveLength(1)
-		// undo(timeline_ab)
+		undo(timeline_ab)
 	})
 	test(`history erasure from the past`, () => {
 		const nameState = atom<string>({

--- a/packages/atom.io/__tests__/public/timeline.test.ts
+++ b/packages/atom.io/__tests__/public/timeline.test.ts
@@ -344,47 +344,6 @@ describe(`timeline`, () => {
 		undo(countsTL)
 		expect(getState(myCountState)).toBe(0)
 	})
-	it(`may ignore atom updates conditionally`, () => {
-		const count = atom<number>({
-			key: `count`,
-			default: 0,
-		})
-
-		const countTL = timeline({
-			key: `count`,
-			scope: [count],
-			shouldCapture: (event) => {
-				if (event.type === `atom_update`) {
-					const atomKey = event.token.key
-					const atomActual = I.IMPLICIT.STORE.atoms.get(atomKey)
-					if (atomActual) {
-						switch (atomActual.type) {
-							case `atom`:
-								if (atomActual.default === event.update.oldValue) {
-									return false
-								}
-								break
-							case `mutable_atom`:
-								return false
-						}
-					}
-				}
-				return true
-			},
-		})
-		expect(getState(count)).toBe(0)
-		setState(count, 1)
-		expect(getState(count)).toBe(1)
-		undo(countTL)
-		expect(getState(count)).toBe(1)
-		expect(I.IMPLICIT.STORE.timelines.get(countTL.key)?.at).toBe(0)
-		setState(count, 2)
-		expect(getState(count)).toBe(2)
-		expect(I.IMPLICIT.STORE.timelines.get(countTL.key)?.at).toBe(1)
-		undo(countTL)
-		expect(getState(count)).toBe(1)
-		expect(I.IMPLICIT.STORE.timelines.get(countTL.key)?.at).toBe(0)
-	})
 	it(`passes over non-write events`, () => {
 		const counts = atomFamily<number, string>({
 			key: `count`,

--- a/packages/atom.io/__tests__/public/timeline.test.ts
+++ b/packages/atom.io/__tests__/public/timeline.test.ts
@@ -1,6 +1,6 @@
 import { inspect } from "node:util"
 
-import type { Logger, WritableToken } from "atom.io"
+import type { Logger, TimelineToken, WritableToken } from "atom.io"
 import {
 	atom,
 	atomFamily,
@@ -37,6 +37,15 @@ beforeEach(() => {
 	vitest.spyOn(Utils, `stdout`)
 	vitest.spyOn(Utils, `stdout0`)
 })
+
+function _inspectTimeline(tl: TimelineToken<any>) {
+	console.log(
+		inspect(I.withdraw(I.IMPLICIT.STORE, tl).history, {
+			colors: true,
+			depth: null,
+		}),
+	)
+}
 
 describe(`timeline`, () => {
 	it(`tracks the state of all atoms in its scope`, () => {
@@ -200,12 +209,7 @@ describe(`timeline`, () => {
 		subscribe(a, Utils.stdout)
 
 		setState(product_ab, 1)
-		console.log(
-			inspect(I.withdraw(I.IMPLICIT.STORE, timeline_ab), {
-				colors: true,
-				depth: null,
-			}),
-		)
+
 		undo(timeline_ab)
 
 		expect(getState(a)).toBe(3)
@@ -256,14 +260,8 @@ describe(`timeline`, () => {
 			scope: [numbers],
 		})
 
-		// setState(products, [`a`, `b`], 9)
 		setState(productSquareRoots, [`a`, `b`], 3)
-		console.log(
-			inspect(I.withdraw(I.IMPLICIT.STORE, timeline_ab).history, {
-				colors: true,
-				depth: null,
-			}),
-		)
+
 		expect(I.withdraw(I.IMPLICIT.STORE, timeline_ab).history).toHaveLength(1)
 		undo(timeline_ab)
 	})
@@ -403,7 +401,6 @@ describe(`timeline state lifecycle`, () => {
 		disposeState(countStates, `my-key`)
 		undo(countsTL)
 		undo(countsTL)
-		undo(countsTL)
 		expect(I.seekInStore(I.IMPLICIT.STORE, countStates, `my-key`)).toBe(
 			undefined,
 		)
@@ -416,7 +413,6 @@ describe(`timeline state lifecycle`, () => {
 			key: `count("my-key")`,
 			type: `atom`,
 		})
-		redo(countsTL)
 		redo(countsTL)
 	})
 })

--- a/packages/atom.io/__tests__/public/timeline.test.ts
+++ b/packages/atom.io/__tests__/public/timeline.test.ts
@@ -407,4 +407,39 @@ describe(`errors`, () => {
 		undo({ key: `my-timeline`, type: `timeline` })
 		expect(logger.error).toHaveBeenCalledTimes(1)
 	})
+	test(`what if the atom family already belongs to a timeline`, () => {
+		const countAtoms = atomFamily<number, string>({
+			key: `count`,
+			default: 0,
+		})
+
+		const _countTL = timeline({
+			key: `count`,
+			scope: [countAtoms],
+		})
+
+		const _countTL2 = timeline({
+			key: `count`,
+			scope: [countAtoms],
+		})
+
+		expect(logger.error).toHaveBeenCalledTimes(1)
+	})
+})
+
+describe(`weird situations`, () => {
+	test(`what if states belonging to a family already exist, but then the family is given to a timeline`, () => {
+		const countAtoms = atomFamily<number, string>({
+			key: `count`,
+			default: 0,
+		})
+		getState(countAtoms, `foo`)
+		const countTL = timeline({
+			key: `count`,
+			scope: [countAtoms],
+		})
+		setState(countAtoms, `foo`, 1)
+		undo(countTL)
+		expect(getState(countAtoms, `foo`)).toBe(0)
+	})
 })

--- a/packages/atom.io/__tests__/public/timeline.test.ts
+++ b/packages/atom.io/__tests__/public/timeline.test.ts
@@ -246,7 +246,7 @@ describe(`timeline`, () => {
 
 		setState(products, [`a`, `b`], 9)
 		console.log(
-			inspect(I.withdraw(I.IMPLICIT.STORE, timeline_ab), {
+			inspect(I.withdraw(I.IMPLICIT.STORE, timeline_ab).history, {
 				colors: true,
 				depth: null,
 			}),

--- a/packages/atom.io/src/internal/events/ingest-selector-update.ts
+++ b/packages/atom.io/src/internal/events/ingest-selector-update.ts
@@ -20,9 +20,9 @@ export function ingestSelectorUpdateEvent(
 		| StateCreationEvent<any>
 	)[]
 	if (applying === `newValue`) {
-		updates = selectorUpdate.atomUpdates
+		updates = selectorUpdate.subEvents
 	} else {
-		updates = selectorUpdate.atomUpdates.toReversed()
+		updates = selectorUpdate.subEvents.toReversed()
 	}
 	for (const atomUpdate of updates) {
 		if (atomUpdate.type === `state_creation`) {

--- a/packages/atom.io/src/internal/events/ingest-selector-update.ts
+++ b/packages/atom.io/src/internal/events/ingest-selector-update.ts
@@ -1,25 +1,34 @@
 import type {
 	AtomOnly,
 	AtomUpdateEvent,
+	StateCreationEvent,
 	TimelineManageable,
 	TimelineSelectorUpdateEvent,
 } from "atom.io"
 
 import type { Store } from "../store"
 import { ingestAtomUpdateEvent } from "./ingest-atom-update"
+import { ingestCreationEvent } from "./ingest-creation-disposal"
 
 export function ingestSelectorUpdateEvent(
 	store: Store,
 	selectorUpdate: TimelineSelectorUpdateEvent<any>,
 	applying: `newValue` | `oldValue`,
 ): void {
-	let updates: AtomUpdateEvent<AtomOnly<TimelineManageable>>[]
+	let updates: (
+		| AtomUpdateEvent<AtomOnly<TimelineManageable>>
+		| StateCreationEvent<any>
+	)[]
 	if (applying === `newValue`) {
 		updates = selectorUpdate.atomUpdates
 	} else {
 		updates = selectorUpdate.atomUpdates.toReversed()
 	}
 	for (const atomUpdate of updates) {
-		ingestAtomUpdateEvent(store, atomUpdate, applying)
+		if (atomUpdate.type === `state_creation`) {
+			ingestCreationEvent(store, atomUpdate, applying)
+		} else {
+			ingestAtomUpdateEvent(store, atomUpdate, applying)
+		}
 	}
 }

--- a/packages/atom.io/src/internal/get-state/reduce-reference.ts
+++ b/packages/atom.io/src/internal/get-state/reduce-reference.ts
@@ -66,9 +66,22 @@ export function reduceReference<T, K extends Canonical>(
 	const isCounterfeit = `counterfeit` in token
 	const isNewlyCreated = Boolean(brandNewToken) && isCounterfeit === false
 	if (isNewlyCreated && family) {
-		const stateCreationEvent: StateCreationEvent<ReadableToken<T>> = {
+		let subType: `readable` | `writable`
+		switch (token.type) {
+			case `readonly_pure_selector`:
+			case `readonly_held_selector`:
+				subType = `readable`
+				break
+			case `atom`:
+			case `mutable_atom`:
+			case `writable_pure_selector`:
+			case `writable_held_selector`:
+				subType = `writable`
+				break
+		}
+		const stateCreationEvent: StateCreationEvent<any> = {
 			type: `state_creation`,
-			subType: `readable`,
+			subType,
 			token,
 			timestamp: Date.now(),
 		}

--- a/packages/atom.io/src/internal/operation.ts
+++ b/packages/atom.io/src/internal/operation.ts
@@ -1,4 +1,4 @@
-import type { ReadableToken } from "atom.io"
+import type { AtomUpdateEvent, ReadableToken, StateCreationEvent } from "atom.io"
 
 import type { Store } from "./store"
 import { isChildStore } from "./transaction/is-root-store"
@@ -14,6 +14,7 @@ export type OpenOperation<R extends ReadableToken<any> = ReadableToken<any>> = {
 	done: Set<string>
 	prev: Map<string, any>
 	timestamp: number
+	subEvents: (AtomUpdateEvent<any> | StateCreationEvent<any>)[]
 }
 
 export function openOperation(
@@ -36,6 +37,7 @@ export function openOperation(
 		prev: new Map(),
 		timestamp: Date.now(),
 		token,
+		subEvents: [],
 	}
 	store.logger.info(
 		`⭕`,

--- a/packages/atom.io/src/internal/set-state/dispatch-state-update.ts
+++ b/packages/atom.io/src/internal/set-state/dispatch-state-update.ts
@@ -75,7 +75,7 @@ export function dispatchOrDeferStateUpdate<T>(
 					`is now (`,
 					newValue,
 					`) subscribers:`,
-					subject.subscribers,
+					subject.subscribers.keys(),
 				)
 				break
 			case `atom`:
@@ -90,7 +90,7 @@ export function dispatchOrDeferStateUpdate<T>(
 					`->`,
 					newValue,
 					`) subscribers:`,
-					subject.subscribers,
+					subject.subscribers.keys(),
 				)
 		}
 		subject.next(update)

--- a/packages/atom.io/src/internal/set-state/dispatch-state-update.ts
+++ b/packages/atom.io/src/internal/set-state/dispatch-state-update.ts
@@ -1,4 +1,9 @@
-import type { AtomUpdateEvent, StateCreationEvent, StateUpdate } from "atom.io"
+import type {
+	AtomUpdateEvent,
+	StateCreationEvent,
+	StateUpdate,
+	TimelineEvent,
+} from "atom.io"
 
 import type { MutableAtom, Subject, WritableFamily, WritableState } from ".."
 import { newest } from ".."
@@ -22,7 +27,8 @@ export function dispatchOrDeferStateUpdate<T>(
 	const token = deposit(state)
 	if (stateIsNewlyCreated && family) {
 		state.subject.next({ newValue })
-		const stateCreationEvent: StateCreationEvent<any> = {
+		const stateCreationEvent: StateCreationEvent<any> & TimelineEvent<any> = {
+			write: true,
 			type: `state_creation`,
 			subType: `writable`,
 			token,

--- a/packages/atom.io/src/internal/set-state/dispatch-state-update.ts
+++ b/packages/atom.io/src/internal/set-state/dispatch-state-update.ts
@@ -1,12 +1,7 @@
 import type { AtomUpdateEvent, StateCreationEvent, StateUpdate } from "atom.io"
 
-import {
-	type MutableAtom,
-	newest,
-	type Subject,
-	type WritableFamily,
-	type WritableState,
-} from ".."
+import type { MutableAtom, Subject, WritableFamily, WritableState } from ".."
+import { newest } from ".."
 import { hasRole } from "../atom"
 import { readOrComputeValue } from "../get-state"
 import type { Transceiver } from "../mutable"
@@ -34,6 +29,7 @@ export function dispatchOrDeferStateUpdate<T>(
 			timestamp: Date.now(),
 			value: newValue,
 		}
+		target.operation.subEvents.push(stateCreationEvent)
 		const familySubject = family.subject as Subject<StateCreationEvent<any>>
 		familySubject.next(stateCreationEvent)
 		const innerTarget = newest(target)

--- a/packages/atom.io/src/internal/timeline/create-timeline.ts
+++ b/packages/atom.io/src/internal/timeline/create-timeline.ts
@@ -49,7 +49,6 @@ export function createTimeline<ManagedAtom extends TimelineManageable>(
 		type: `timeline`,
 		key: options.key,
 		at: 0,
-
 		timeTraveling: null,
 		selectorTime: null,
 		transactionKey: null,
@@ -199,7 +198,8 @@ function addAtomToTimeline(
 						if (tl.at !== tl.history.length) {
 							tl.history.splice(tl.at)
 						}
-						const atomUpdate: AtomUpdateEvent<any> = {
+						const atomUpdate: AtomUpdateEvent<any> & TimelineEvent<any> = {
+							write: true,
 							type: `atom_update`,
 							token: deposit(atom),
 							update,
@@ -471,6 +471,9 @@ function handleStateLifecycleEvent(
 					currentSelectorTime,
 				)
 			} else {
+				if (tl.at !== tl.history.length) {
+					tl.history.splice(tl.at)
+				}
 				tl.history.push(event)
 				tl.at = tl.history.length
 				tl.subject.next(event)

--- a/packages/atom.io/src/internal/timeline/create-timeline.ts
+++ b/packages/atom.io/src/internal/timeline/create-timeline.ts
@@ -282,9 +282,9 @@ function joinTransaction(
 						timelineTopics,
 					)
 
-					const timelineTransactionUpdate: TransactionOutcomeEvent<
-						TransactionToken<any>
-					> = {
+					const timelineTransactionUpdate: TimelineEvent<any> &
+						TransactionOutcomeEvent<TransactionToken<any>> = {
+						write: true,
 						...transactionUpdate,
 						subEvents: subEventsFiltered,
 					}
@@ -311,12 +311,14 @@ function buildSelectorUpdate(
 ) {
 	let latestUpdate: TimelineEvent<any> | undefined = tl.history.at(-1)
 	if (currentSelectorTime !== tl.selectorTime) {
-		const selectorUpdate: TimelineSelectorUpdateEvent<any> = (latestUpdate = {
-			type: `selector_update`,
-			timestamp: currentSelectorTime,
-			token: currentSelectorToken,
-			subEvents: [],
-		})
+		const selectorUpdate: TimelineEvent<any> & TimelineSelectorUpdateEvent<any> =
+			(latestUpdate = {
+				write: true,
+				type: `selector_update`,
+				timestamp: currentSelectorTime,
+				token: currentSelectorToken,
+				subEvents: [],
+			})
 		if (`type` in eventOrUpdate) {
 			latestUpdate.subEvents.push(eventOrUpdate)
 		} else {

--- a/packages/atom.io/src/internal/timeline/create-timeline.ts
+++ b/packages/atom.io/src/internal/timeline/create-timeline.ts
@@ -315,12 +315,12 @@ function buildSelectorUpdate(
 			type: `selector_update`,
 			timestamp: currentSelectorTime,
 			token: currentSelectorToken,
-			atomUpdates: [],
+			subEvents: [],
 		})
 		if (`type` in eventOrUpdate) {
-			latestUpdate.atomUpdates.push(eventOrUpdate)
+			latestUpdate.subEvents.push(eventOrUpdate)
 		} else {
-			latestUpdate.atomUpdates.push({
+			latestUpdate.subEvents.push({
 				type: `atom_update`,
 				token: atomToken,
 				update: eventOrUpdate,
@@ -338,7 +338,7 @@ function buildSelectorUpdate(
 			`timeline`,
 			tl.key,
 			`got a selector_update "${currentSelectorToken.key}" with`,
-			latestUpdate.atomUpdates.map((atomUpdate) => atomUpdate.token.key),
+			latestUpdate.subEvents.map((event) => event.token.key),
 		)
 
 		tl.at = tl.history.length
@@ -350,9 +350,9 @@ function buildSelectorUpdate(
 			() => {
 				unsub()
 				if (operation.open) {
-					selectorUpdate.atomUpdates = [
+					selectorUpdate.subEvents = [
 						...operation.subEvents,
-						...selectorUpdate.atomUpdates,
+						...selectorUpdate.subEvents,
 					]
 				}
 			},
@@ -360,9 +360,9 @@ function buildSelectorUpdate(
 	} else {
 		if (latestUpdate?.type === `selector_update`) {
 			if (`type` in eventOrUpdate) {
-				latestUpdate.atomUpdates.push(eventOrUpdate)
+				latestUpdate.subEvents.push(eventOrUpdate)
 			} else {
-				latestUpdate.atomUpdates.push({
+				latestUpdate.subEvents.push({
 					type: `atom_update`,
 					token: atomToken,
 					update: eventOrUpdate,
@@ -374,7 +374,7 @@ function buildSelectorUpdate(
 				`timeline`,
 				tl.key,
 				`set selector_update "${currentSelectorToken.key}" to`,
-				latestUpdate?.atomUpdates.map((atomUpdate) => atomUpdate.token.key),
+				latestUpdate?.subEvents.map((event) => event.token.key),
 			)
 		}
 	}

--- a/packages/atom.io/src/internal/timeline/time-travel.ts
+++ b/packages/atom.io/src/internal/timeline/time-travel.ts
@@ -60,7 +60,7 @@ export const timeTravel = (
 			while (nextIndex !== 0 && timelineData.history[nextIndex].write !== true) {
 				--nextIndex
 			}
-			events = timelineData.history.slice(nextIndex, timelineData.at)
+			events = timelineData.history.slice(nextIndex, timelineData.at).reverse()
 			console.log({ nextIndex, historyLength: timelineData.history.length })
 
 			break

--- a/packages/atom.io/src/internal/timeline/time-travel.ts
+++ b/packages/atom.io/src/internal/timeline/time-travel.ts
@@ -31,11 +31,6 @@ export const timeTravel = (
 		return
 	}
 
-	console.log(`❓`, {
-		timelineData,
-		isAtEnd: timelineData.at === timelineData.history.length,
-		isAtBeginning: timelineData.at === 0,
-	})
 	if (
 		(action === `redo` && timelineData.at === timelineData.history.length) ||
 		(action === `undo` && timelineData.at === 0)
@@ -61,7 +56,6 @@ export const timeTravel = (
 				--nextIndex
 			}
 			events = timelineData.history.slice(nextIndex, timelineData.at).reverse()
-			console.log({ nextIndex, historyLength: timelineData.history.length })
 
 			break
 		case `redo`:
@@ -72,17 +66,10 @@ export const timeTravel = (
 				++nextIndex
 			}
 			++nextIndex
-			console.log({ nextIndex, historyLength: timelineData.history.length })
 			events = timelineData.history.slice(timelineData.at, nextIndex)
 	}
 	timelineData.at = nextIndex
 
-	console.log(`❗`, {
-		timelineData: timelineData,
-		events,
-	})
-
-	// const event = timelineData.history[timelineData.at]
 	const applying = action === `redo` ? `newValue` : `oldValue`
 
 	for (const event of events) {
@@ -111,10 +98,6 @@ export const timeTravel = (
 			case `molecule_disposal`:
 		}
 	}
-
-	// if (action === `redo`) {
-	// 	++timelineData.at
-	// }
 
 	timelineData.subject.next(action)
 	timelineData.timeTraveling = null

--- a/packages/atom.io/src/internal/timeline/time-travel.ts
+++ b/packages/atom.io/src/internal/timeline/time-travel.ts
@@ -59,12 +59,6 @@ export const timeTravel = (
 
 			break
 		case `redo`:
-			while (
-				nextIndex !== timelineData.history.length &&
-				timelineData.history[nextIndex].write !== true
-			) {
-				++nextIndex
-			}
 			++nextIndex
 			events = timelineData.history.slice(timelineData.at, nextIndex)
 	}

--- a/packages/atom.io/src/internal/timeline/time-travel.ts
+++ b/packages/atom.io/src/internal/timeline/time-travel.ts
@@ -85,7 +85,7 @@ export const timeTravel = (
 	timelineData.subject.next(action)
 	timelineData.timeTraveling = null
 	store.logger.info(
-		`⏹️`,
+		`⏸️`,
 		`timeline`,
 		token.key,
 		`"${token.key}" is now at ${timelineData.at} / ${timelineData.history.length}`,

--- a/packages/atom.io/src/internal/transaction/apply-transaction.ts
+++ b/packages/atom.io/src/internal/transaction/apply-transaction.ts
@@ -34,7 +34,7 @@ export function applyTransaction<F extends Fn>(
 		`🛄`,
 		`transaction`,
 		child.transactionMeta.update.token.key,
-		`Applying transaction with ${updates.length} updates:`,
+		`applying ${updates.length} subEvents:`,
 		updates,
 	)
 
@@ -55,7 +55,7 @@ export function applyTransaction<F extends Fn>(
 			`🛬`,
 			`transaction`,
 			child.transactionMeta.update.token.key,
-			`Finished applying transaction.`,
+			`applied`,
 		)
 	} else if (isChildStore(parent)) {
 		parent.transactionMeta.update.subEvents.push(child.transactionMeta.update)

--- a/packages/atom.io/src/internal/transaction/build-transaction.ts
+++ b/packages/atom.io/src/internal/transaction/build-transaction.ts
@@ -97,7 +97,7 @@ export const buildTransaction = (
 		`🛫`,
 		`transaction`,
 		token.key,
-		`Building transaction with params:`,
+		`building with params:`,
 		params,
 	)
 	return child

--- a/packages/atom.io/src/main/events.ts
+++ b/packages/atom.io/src/main/events.ts
@@ -23,10 +23,13 @@ export type AtomUpdateEvent<A extends AtomToken<any>> = {
 	timestamp: number
 }
 
+export type SelectorUpdateSubEvent<A extends AtomToken<any>> =
+	| AtomUpdateEvent<A>
+	| StateCreationEvent<any>
 export type TimelineSelectorUpdateEvent<A extends TimelineManageable> = {
 	type: `selector_update`
 	token: SelectorToken<any>
-	atomUpdates: (AtomUpdateEvent<AtomOnly<A>> | StateCreationEvent<any>)[]
+	subEvents: SelectorUpdateSubEvent<AtomOnly<A>>[]
 	timestamp: number
 }
 

--- a/packages/atom.io/src/main/events.ts
+++ b/packages/atom.io/src/main/events.ts
@@ -113,7 +113,9 @@ export type TransactionOutcomeEvent<T extends TransactionToken<any>> = {
 	output: ReturnType<TokenType<T>>
 }
 
-export type TimelineEvent<ManagedAtom extends TimelineManageable> =
+export type TimelineEvent<ManagedAtom extends TimelineManageable> = {
+	write?: true
+} & (
 	| AtomUpdateEvent<AtomOnly<ManagedAtom>>
 	| MoleculeCreationEvent
 	| MoleculeDisposalEvent
@@ -121,3 +123,4 @@ export type TimelineEvent<ManagedAtom extends TimelineManageable> =
 	| StateDisposalEvent<AtomOnly<ManagedAtom>>
 	| TimelineSelectorUpdateEvent<ManagedAtom>
 	| TransactionOutcomeEvent<TransactionToken<any>>
+)

--- a/packages/atom.io/src/main/events.ts
+++ b/packages/atom.io/src/main/events.ts
@@ -26,7 +26,7 @@ export type AtomUpdateEvent<A extends AtomToken<any>> = {
 export type TimelineSelectorUpdateEvent<A extends TimelineManageable> = {
 	type: `selector_update`
 	token: SelectorToken<any>
-	atomUpdates: AtomUpdateEvent<AtomOnly<A>>[]
+	atomUpdates: (AtomUpdateEvent<AtomOnly<A>> | StateCreationEvent<any>)[]
 	timestamp: number
 }
 

--- a/packages/atom.io/src/main/logger.ts
+++ b/packages/atom.io/src/main/logger.ts
@@ -37,7 +37,7 @@ const LOGGER_ICON_DICTIONARY = {
 	"⏭️": `Transaction redo`,
 	"⏮️": `Transaction undo`,
 	"⏳": `Timeline event partially captured`,
-	"⏹️": `Time-travel complete`,
+	"⏸️": `Time-travel complete`,
 	// Problems
 	"💣": `Dangerous action likely to cause bad errors down the line`,
 	"❗": `Dangerous action unless in development mode`,

--- a/packages/atom.io/src/main/timeline.ts
+++ b/packages/atom.io/src/main/timeline.ts
@@ -1,7 +1,6 @@
-import type { Timeline } from "atom.io/internal"
 import { createTimeline, IMPLICIT, timeTravel } from "atom.io/internal"
 
-import type { AtomFamilyToken, AtomToken, TimelineEvent, TimelineToken } from "."
+import type { AtomFamilyToken, AtomToken, TimelineToken } from "."
 
 export type TimelineManageable = AtomFamilyToken<any, any> | AtomToken<any>
 export type AtomOnly<M extends TimelineManageable> = M extends AtomFamilyToken<
@@ -33,11 +32,6 @@ export type TimelineOptions<ManagedAtom extends TimelineManageable> = {
 	key: string
 	/** The managed atoms (and families of atoms) to record */
 	scope: ManagedAtom[]
-	/** A function that determines whether a given update should be recorded */
-	shouldCapture?: (
-		update: TimelineEvent<ManagedAtom>,
-		timeline: Timeline<TimelineManageable>,
-	) => boolean
 }
 
 /**

--- a/packages/atom.io/src/react-devtools/Updates.tsx
+++ b/packages/atom.io/src/react-devtools/Updates.tsx
@@ -206,7 +206,7 @@ export const TimelineUpdateFC: React.FC<{
 											atomUpdate={event}
 										/>
 									)
-								default:
+								case `state_creation`:
 									return null
 							}
 						})

--- a/packages/atom.io/src/react-devtools/Updates.tsx
+++ b/packages/atom.io/src/react-devtools/Updates.tsx
@@ -192,7 +192,7 @@ export const TimelineUpdateFC: React.FC<{
 							}
 						})
 				) : timelineUpdate.type === `selector_update` ? (
-					timelineUpdate.atomUpdates
+					timelineUpdate.subEvents
 						.filter(
 							(atomUpdateEvent) => !atomUpdateEvent.token.key.startsWith(`👁‍🗨`),
 						)
@@ -206,7 +206,7 @@ export const TimelineUpdateFC: React.FC<{
 											atomUpdate={event}
 										/>
 									)
-								case `state_creation`:
+								default:
 									return null
 							}
 						})

--- a/packages/atom.io/src/react-devtools/Updates.tsx
+++ b/packages/atom.io/src/react-devtools/Updates.tsx
@@ -196,14 +196,19 @@ export const TimelineUpdateFC: React.FC<{
 						.filter(
 							(atomUpdateEvent) => !atomUpdateEvent.token.key.startsWith(`👁‍🗨`),
 						)
-						.map((atomUpdate, index) => {
-							return (
-								<article.AtomUpdate
-									key={`${timelineUpdate.token.key}:${index}:${atomUpdate.token.key}`}
-									serialNumber={index}
-									atomUpdate={atomUpdate}
-								/>
-							)
+						.map((event, index) => {
+							switch (event.type) {
+								case `atom_update`:
+									return (
+										<article.AtomUpdate
+											key={`${timelineUpdate.token.key}:${index}:${event.token.key}`}
+											serialNumber={index}
+											atomUpdate={event}
+										/>
+									)
+								case `state_creation`:
+									return null
+							}
 						})
 				) : timelineUpdate.type === `atom_update` ? (
 					<article.AtomUpdate


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Imported `inspect` and `selectorFamily` for debugging

- Updated `CHOOSE` value and logger assignment

- Added `console.log` calls inspecting withdrawn timeline

- Introduced `test.only` for selectorFamily `setState`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>timeline.test.ts</strong><dd><code>Add debug imports and selectorFamily setState test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/public/timeline.test.ts

<li>Imported <code>inspect</code> from node:util and <code>selectorFamily</code><br> <li> Changed <code>CHOOSE</code> to 3 and commented out null logger<br> <li> Inserted <code>console.log</code> with <code>inspect</code> for timeline state<br> <li> Added new <code>test.only</code> covering selectorFamily <code>setState</code>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4727/files#diff-f96a6ea84c552199841fa1d87e4d64eddfbd46753fec76dde457c0b78ae32111">+47/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>