### PR TITLE
🐛 also fix selector rejection caching

### DIFF
--- a/packages/atom.io/src/internal/get-state/read-or-compute-value.ts
+++ b/packages/atom.io/src/internal/get-state/read-or-compute-value.ts
@@ -37,16 +37,16 @@ export function readOrComputeValue<T, E>(
 			try {
 				val = state.getFrom(target)
 				if (val instanceof Promise) {
-					return (val as Promise<E & T>).catch((e) => {
-						target.logger.error(`💥`, state.type, key, `rejected:`, e)
+					return (val as Promise<E & T>).catch((thrown) => {
+						target.logger.error(`💥`, state.type, key, `rejected:`, thrown)
 						if (state.catch) {
 							for (const Class of state.catch) {
-								if (e instanceof Class) {
-									return writeToCache(target, state, e)
+								if (thrown instanceof Class) {
+									return thrown
 								}
 							}
 						}
-						throw e
+						throw thrown
 					}) as E | T
 				}
 			} catch (e) {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Standardize catch variable naming

- Avoid improper caching of rejections

- Return errors on matching catch types

- Consistently rethrow unmatched errors


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>read-or-compute-value.ts</strong><dd><code>Refactor selector error catch logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/internal/get-state/read-or-compute-value.ts

<li>Renamed catch variable from <code>e</code> to <code>thrown</code><br> <li> Removed <code>writeToCache</code>, now returns errors<br> <li> Unified error logging and rethrow behavior


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4763/files#diff-23abed7636667985d50557c2ddc62d7f6eea37cce682e059d5b6f5d720fe4ed3">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>