### PR TITLE
🎨 use NoInfer where possible

### DIFF
--- a/packages/atom.io/src/internal/families/dispose-from-store.ts
+++ b/packages/atom.io/src/internal/families/dispose-from-store.ts
@@ -11,16 +11,16 @@ export function disposeFromStore(
 	token: ReadableToken<any, any, any>,
 ): void
 
-export function disposeFromStore<K extends Canonical, Key extends K>(
+export function disposeFromStore<K extends Canonical>(
 	store: Store,
 	token: ReadableFamilyToken<any, K, any>,
-	key: Key,
+	key: NoInfer<K>,
 ): void
 
-export function disposeFromStore<K extends Canonical, Key extends K>(
+export function disposeFromStore<K extends Canonical>(
 	store: Store,
 	...params:
-		| [token: ReadableFamilyToken<any, K, any>, key: Key]
+		| [token: ReadableFamilyToken<any, K, any>, key: NoInfer<K>]
 		| [token: ReadableToken<any, any, any>]
 ): void
 

--- a/packages/atom.io/src/internal/families/find-in-store.ts
+++ b/packages/atom.io/src/internal/families/find-in-store.ts
@@ -36,49 +36,49 @@ export function findInStore<
 	store: Store,
 	familyToken: MutableAtomFamilyToken<T, K>,
 	key: Key,
-): MutableAtomToken<T, K>
+): MutableAtomToken<T, Key>
 
 export function findInStore<T, K extends Canonical, Key extends K, E>(
 	store: Store,
 	familyToken: RegularAtomFamilyToken<T, K, E>,
 	key: Key,
-): RegularAtomToken<T, K, E>
+): RegularAtomToken<T, Key, E>
 
 export function findInStore<T, K extends Canonical, Key extends K, E>(
 	store: Store,
 	familyToken: AtomFamilyToken<T, K, E>,
 	key: Key,
-): AtomToken<T, K, E>
+): AtomToken<T, Key, E>
 
 export function findInStore<T, K extends Canonical, Key extends K, E>(
 	store: Store,
 	familyToken: WritablePureSelectorFamilyToken<T, K, E>,
 	key: Key,
-): WritablePureSelectorToken<T, K, E>
+): WritablePureSelectorToken<T, Key, E>
 
 export function findInStore<T, K extends Canonical, Key extends K, E>(
 	store: Store,
 	familyToken: ReadonlyPureSelectorFamilyToken<T, K, E>,
 	key: Key,
-): ReadonlyPureSelectorToken<T, K, E>
+): ReadonlyPureSelectorToken<T, Key, E>
 
 export function findInStore<T, K extends Canonical, Key extends K, E>(
 	store: Store,
 	familyToken: SelectorFamilyToken<T, K, E>,
 	key: Key,
-): SelectorToken<T, K, E>
+): SelectorToken<T, Key, E>
 
 export function findInStore<T, K extends Canonical, Key extends K, E>(
 	store: Store,
 	familyToken: WritableFamilyToken<T, K, E>,
 	key: Key,
-): WritableToken<T, K, E>
+): WritableToken<T, Key, E>
 
 export function findInStore<T, K extends Canonical, Key extends K, E>(
 	store: Store,
 	familyToken: ReadableFamilyToken<T, K, E>,
 	key: Key,
-): ReadableToken<T, K, E>
+): ReadableToken<T, Key, E>
 
 export function findInStore(
 	store: Store,

--- a/packages/atom.io/src/internal/get-state/get-fallback.ts
+++ b/packages/atom.io/src/internal/get-state/get-fallback.ts
@@ -8,7 +8,7 @@ export function getFallback<T, K extends Canonical, E>(
 	store: Store,
 	token: ReadableToken<T, K, E>,
 	family: ReadableFamily<T, K, E>,
-	subKey: K,
+	subKey: NoInfer<K>,
 ): ViewOf<E | T> {
 	const disposal = store.disposalTraces.buffer.find(
 		(item) => item?.key === stringifyJson(subKey),

--- a/packages/atom.io/src/internal/get-state/get-from-store.ts
+++ b/packages/atom.io/src/internal/get-state/get-from-store.ts
@@ -16,20 +16,20 @@ export function getFromStore<T, E>(
 export function getFromStore<T, K extends Canonical, E>(
 	store: Store,
 	token: ReadableFamilyToken<T, K, E>,
-	key: K,
+	key: NoInfer<K>,
 ): ViewOf<E | T>
 
-export function getFromStore<T, K extends Canonical, Key extends K, E>(
+export function getFromStore<T, K extends Canonical, E>(
 	store: Store,
 	...params:
-		| [token: ReadableFamilyToken<T, K, E>, key: Key]
+		| [token: ReadableFamilyToken<T, K, E>, key: NoInfer<K>]
 		| [token: ReadableToken<T, any, E>]
 ): ViewOf<E | T>
 
-export function getFromStore<T, K extends Canonical, Key extends K, E>(
+export function getFromStore<T, K extends Canonical, E>(
 	store: Store,
 	...params:
-		| [token: ReadableFamilyToken<T, K, E>, key: Key]
+		| [token: ReadableFamilyToken<T, K, E>, key: NoInfer<K>]
 		| [token: ReadableToken<T, any, E>]
 ): ViewOf<E | T> {
 	const { token, family, subKey } = reduceReference(store, ...params)

--- a/packages/atom.io/src/internal/get-state/reduce-reference.ts
+++ b/packages/atom.io/src/internal/get-state/reduce-reference.ts
@@ -16,12 +16,12 @@ import { withdraw } from "../store"
 export function reduceReference<T, K extends Canonical, E>(
 	store: Store,
 	...params:
-		| [token: ReadableFamilyToken<T, K, E>, key: K]
+		| [token: ReadableFamilyToken<T, K, E>, key: NoInfer<K>]
 		| [token: ReadableToken<T, K, E>]
 ): {
 	token: ReadableToken<T, K, E>
 	family: ReadableFamily<T, K, E> | undefined
-	subKey: K | undefined
+	subKey: NoInfer<K> | undefined
 	isNew: boolean
 } {
 	let existingToken: ReadableToken<T, K, E> | undefined

--- a/packages/atom.io/src/internal/selector/register-selector.ts
+++ b/packages/atom.io/src/internal/selector/register-selector.ts
@@ -67,14 +67,17 @@ export function registerSelector(
 			updateSelectorAtoms(store, selectorType, selectorKey, token, covered)
 			return dependencyValue
 		},
-		set: (<T, K extends Canonical, New extends T, Key extends K>(
+		set: (<T, K extends Canonical>(
 			...params:
 				| [
 						token: WritableFamilyToken<T, K>,
-						key: Key,
-						value: New | ((oldValue: any) => New),
+						key: NoInfer<K>,
+						value: NoInfer<T> | ((oldValue: T) => NoInfer<T>),
 				  ]
-				| [token: WritableToken<T>, value: New | ((oldValue: T) => New)]
+				| [
+						token: WritableToken<T>,
+						value: NoInfer<T> | ((oldValue: T) => NoInfer<T>),
+				  ]
 		) => {
 			const target = newest(store)
 			operateOnStore(target, JOIN_OP, ...params)

--- a/packages/atom.io/src/internal/set-state/operate-on-store.ts
+++ b/packages/atom.io/src/internal/set-state/operate-on-store.ts
@@ -18,32 +18,26 @@ export type ProtoUpdate<T> = { oldValue: T; newValue: T }
 export const OWN_OP: unique symbol = Symbol(`OWN_OP`)
 export const JOIN_OP: unique symbol = Symbol(`JOIN_OP`)
 
-export function operateOnStore<
-	T,
-	K extends Canonical,
-	New extends T,
-	Key extends K,
-	E,
->(
+export function operateOnStore<T, K extends Canonical, E>(
 	store: Store,
 	opMode: typeof JOIN_OP | typeof OWN_OP,
 	...params:
 		| [
 				token: WritableFamilyToken<T, K, E>,
-				key: Key,
-				value: New | typeof RESET_STATE | ((oldValue: T) => New),
+				key: NoInfer<K>,
+				value: NoInfer<T> | typeof RESET_STATE | ((oldValue: T) => NoInfer<T>),
 		  ]
 		| [
-				token: WritableToken<T, Key, E>,
-				value: New | typeof RESET_STATE | ((oldValue: T) => New),
+				token: WritableToken<T, any, E>,
+				value: NoInfer<T> | typeof RESET_STATE | ((oldValue: T) => NoInfer<T>),
 		  ]
 ): void {
-	let existingToken: WritableToken<T, Key, E> | undefined
-	let brandNewToken: WritableToken<T, Key, E> | undefined
-	let token: WritableToken<T, Key, E>
+	let existingToken: WritableToken<T, K, E> | undefined
+	let brandNewToken: WritableToken<T, K, E> | undefined
+	let token: WritableToken<T, K, E>
 	let family: WritableFamily<T, K, E> | undefined
-	let key: Key | null
-	let value: New | typeof RESET_STATE | ((oldValue: T) => New)
+	let key: K | null
+	let value: T | typeof RESET_STATE | ((oldValue: T) => T)
 	if (params.length === 2) {
 		token = params[0]
 		value = params[1]

--- a/packages/atom.io/src/internal/set-state/reset-atom-or-selector.ts
+++ b/packages/atom.io/src/internal/set-state/reset-atom-or-selector.ts
@@ -17,7 +17,7 @@ function resetAtom<T, E>(
 			let def: E | T
 			if (isFn(atom.default)) def = safeCompute(target, atom)
 			else def = atom.default
-			return setAtom(target, atom, def)
+			return setAtom<E | T>(target, atom, def)
 		}
 	}
 }

--- a/packages/atom.io/src/internal/set-state/reset-in-store.ts
+++ b/packages/atom.io/src/internal/set-state/reset-in-store.ts
@@ -14,20 +14,20 @@ export function resetInStore(
 export function resetInStore<K extends Canonical>(
 	store: Store,
 	token: WritableFamilyToken<any, K, any>,
-	key: K,
+	key: NoInfer<K>,
 ): void
 
-export function resetInStore<T, K extends Canonical, Key extends K>(
+export function resetInStore<T, K extends Canonical>(
 	store: Store,
 	...params:
-		| [token: WritableFamilyToken<T, K, any>, key: Key]
+		| [token: WritableFamilyToken<T, K, any>, key: NoInfer<K>]
 		| [token: WritableToken<T, any, any>]
 ): void
 
-export function resetInStore<T, K extends Canonical, Key extends K>(
+export function resetInStore<T, K extends Canonical>(
 	store: Store,
 	...params:
-		| [token: WritableFamilyToken<T, K, any>, key: Key]
+		| [token: WritableFamilyToken<T, K, any>, key: NoInfer<K>]
 		| [token: WritableToken<T, any, any>]
 ): void {
 	const subParams = [...params, RESET_STATE] as const

--- a/packages/atom.io/src/internal/set-state/set-atom-or-selector.ts
+++ b/packages/atom.io/src/internal/set-state/set-atom-or-selector.ts
@@ -8,7 +8,7 @@ import { setSelector } from "./set-selector"
 export const setAtomOrSelector = <T>(
 	target: Store & { operation: OpenOperation },
 	state: WritableState<T, any>,
-	value: T | ((oldValue: T) => T),
+	value: NoInfer<T> | ((oldValue: T) => NoInfer<T>),
 ): ProtoUpdate<T> => {
 	let protoUpdate: ProtoUpdate<T>
 	switch (state.type) {

--- a/packages/atom.io/src/internal/set-state/set-atom.ts
+++ b/packages/atom.io/src/internal/set-state/set-atom.ts
@@ -9,7 +9,7 @@ import type { ProtoUpdate } from "./operate-on-store"
 export const setAtom = <T>(
 	target: Store & { operation: OpenOperation<any> },
 	atom: Atom<T, any>,
-	next: T | ((oldValue: T) => T),
+	next: NoInfer<T> | ((oldValue: T) => NoInfer<T>),
 ): ProtoUpdate<T> => {
 	const oldValue = readOrComputeValue(target, atom, `mut`)
 	let newValue = become(next, oldValue)

--- a/packages/atom.io/src/internal/set-state/set-into-store.ts
+++ b/packages/atom.io/src/internal/set-state/set-into-store.ts
@@ -5,62 +5,44 @@ import type { Store } from "../store"
 import { operateOnStore, OWN_OP } from "./operate-on-store"
 import type { RESET_STATE } from "./reset-in-store"
 
-export function setIntoStore<T, New extends T, E>(
+export function setIntoStore<T, E>(
 	store: Store,
 	token: WritableToken<T, any, E>,
-	value: New | typeof RESET_STATE | ((oldValue: T) => New),
+	value: NoInfer<T> | typeof RESET_STATE | ((oldValue: T) => NoInfer<T>),
 ): void
 
-export function setIntoStore<
-	T,
-	K extends Canonical,
-	New extends T,
-	Key extends K,
-	E,
->(
+export function setIntoStore<T, K extends Canonical, E>(
 	store: Store,
 	token: WritableFamilyToken<T, K, E>,
-	key: Key,
-	value: New | typeof RESET_STATE | ((oldValue: T) => New),
+	key: NoInfer<K>,
+	value: NoInfer<T> | typeof RESET_STATE | ((oldValue: T) => NoInfer<T>),
 ): void
 
-export function setIntoStore<
-	T,
-	K extends Canonical,
-	New extends T,
-	Key extends K,
-	E,
->(
+export function setIntoStore<T, K extends Canonical, E>(
 	store: Store,
 	...params:
 		| [
 				token: WritableFamilyToken<T, K, E>,
-				key: Key,
-				value: New | typeof RESET_STATE | ((oldValue: T) => New),
+				key: NoInfer<K>,
+				value: NoInfer<T> | typeof RESET_STATE | ((oldValue: T) => NoInfer<T>),
 		  ]
 		| [
 				token: WritableToken<T, any, E>,
-				value: New | typeof RESET_STATE | ((oldValue: T) => New),
+				value: NoInfer<T> | typeof RESET_STATE | ((oldValue: T) => NoInfer<T>),
 		  ]
 ): void
 
-export function setIntoStore<
-	T,
-	K extends Canonical,
-	New extends T,
-	Key extends K,
-	E,
->(
+export function setIntoStore<T, K extends Canonical, E>(
 	store: Store,
 	...params:
 		| [
 				token: WritableFamilyToken<T, K, E>,
-				key: Key,
-				value: New | typeof RESET_STATE | ((oldValue: T) => New),
+				key: NoInfer<K>,
+				value: NoInfer<T> | typeof RESET_STATE | ((oldValue: T) => NoInfer<T>),
 		  ]
 		| [
 				token: WritableToken<T, any, E>,
-				value: New | typeof RESET_STATE | ((oldValue: T) => New),
+				value: NoInfer<T> | typeof RESET_STATE | ((oldValue: T) => NoInfer<T>),
 		  ]
 ): void {
 	operateOnStore(store, OWN_OP, ...params)

--- a/packages/atom.io/src/internal/set-state/set-selector.ts
+++ b/packages/atom.io/src/internal/set-state/set-selector.ts
@@ -8,7 +8,7 @@ import type { ProtoUpdate } from "./operate-on-store"
 export function setSelector<T>(
 	target: Store & { operation: OpenOperation<any> },
 	selector: WritableSelector<T, any>,
-	next: T | ((oldValue: T) => T),
+	next: NoInfer<T> | ((oldValue: T) => NoInfer<T>),
 ): ProtoUpdate<T> {
 	let oldValue: T
 	let newValue: T

--- a/packages/atom.io/src/main/atom.ts
+++ b/packages/atom.io/src/main/atom.ts
@@ -78,7 +78,7 @@ export type Effectors<T> = {
 	 * Set the value of the atom
 	 * @param next - The new value of the atom, or a setter function
 	 */
-	setSelf: <New extends T>(next: New | Setter<T, New>) => void
+	setSelf: <New extends T>(next: New | ((old: T) => New)) => void
 	/** Subscribe to changes to the atom */
 	onSet: (callback: (options: StateUpdate<T>) => void) => void
 }

--- a/packages/atom.io/src/main/find-state.ts
+++ b/packages/atom.io/src/main/find-state.ts
@@ -50,7 +50,7 @@ export function findState<
 export function findState<T, K extends Canonical, Key extends K>(
 	token: RegularAtomFamilyToken<T, K>,
 	key: Key,
-): RegularAtomToken<T, K>
+): RegularAtomToken<T, Key>
 /**
  * Finds a {@link WritableSelectorToken} in the store, without accessing its value.
  *
@@ -67,7 +67,7 @@ export function findState<T, K extends Canonical, Key extends K>(
 export function findState<T, K extends Canonical, Key extends K>(
 	token: WritableSelectorFamilyToken<T, K>,
 	key: Key,
-): WritableSelectorToken<T, K>
+): WritableSelectorToken<T, Key>
 /**
  * Finds a {@link ReadonlySelectorToken} in the store, without accessing its value.
  *
@@ -84,7 +84,7 @@ export function findState<T, K extends Canonical, Key extends K>(
 export function findState<T, K extends Canonical, Key extends K>(
 	token: ReadonlySelectorFamilyToken<T, K>,
 	key: Key,
-): ReadonlySelectorToken<T, K>
+): ReadonlySelectorToken<T, Key>
 /**
  * Finds a {@link WritableToken} in the store, without accessing its value.
  *
@@ -101,7 +101,7 @@ export function findState<T, K extends Canonical, Key extends K>(
 export function findState<T, K extends Canonical, Key extends K>(
 	token: WritableFamilyToken<T, K>,
 	key: Key,
-): WritableToken<T, K>
+): WritableToken<T, Key>
 /**
  * Finds a {@link MutableAtomToken} in the store, without accessing its value.
  *
@@ -119,7 +119,7 @@ export function findState<T, K extends Canonical, Key extends K>(
 export function findState<T, K extends Canonical, Key extends K>(
 	token: ReadableFamilyToken<T, K>,
 	key: Key,
-): ReadableToken<T, K>
+): ReadableToken<T, Key>
 
 export function findState(
 	token: ReadableFamilyToken<any, any>,

--- a/packages/atom.io/src/main/get-state.ts
+++ b/packages/atom.io/src/main/get-state.ts
@@ -22,14 +22,14 @@ export function getState<T, E = never>(
  * @return The current value of the state
  * @overload Streamlined
  */
-export function getState<T, K extends Canonical, Key extends K, E = never>(
+export function getState<T, K extends Canonical, E = never>(
 	token: ReadableFamilyToken<T, K, E>,
-	key: Key,
+	key: NoInfer<K>,
 ): ViewOf<E | T>
 
-export function getState<T, K extends Canonical, Key extends K, E = never>(
+export function getState<T, K extends Canonical, E = never>(
 	...params:
-		| [token: ReadableFamilyToken<T, K, E>, key: Key]
+		| [token: ReadableFamilyToken<T, K, E>, key: NoInfer<K>]
 		| [token: ReadableToken<T, any, E>]
 ): ViewOf<E | T> {
 	return getFromStore(IMPLICIT.STORE, ...params)

--- a/packages/atom.io/src/main/set-state.ts
+++ b/packages/atom.io/src/main/set-state.ts
@@ -9,7 +9,7 @@ import type { WritableFamilyToken, WritableToken } from "./tokens"
  * @returns
  * The new value of the state.
  */
-export type Setter<T, New extends T> = (oldValue: T) => New
+export type Setter<T> = (oldValue: T) => T
 
 /**
  * Set the value of a state into the implicit store.
@@ -18,9 +18,9 @@ export type Setter<T, New extends T> = (oldValue: T) => New
  * @overload Default
  * @default
  */
-export function setState<T, New extends T>(
+export function setState<T>(
 	token: WritableToken<T, any, any>,
-	value: New | Setter<T, New>,
+	value: NoInfer<T> | Setter<NoInfer<T>>,
 ): void
 
 /**
@@ -30,20 +30,20 @@ export function setState<T, New extends T>(
  * @param value - The new value of the state.
  * @overload Streamlined
  */
-export function setState<T, K extends Canonical, New extends T, Key extends K>(
+export function setState<T, K extends Canonical>(
 	token: WritableFamilyToken<T, K, any>,
-	key: Key,
-	value: New | Setter<T, New>,
+	key: NoInfer<K>,
+	value: NoInfer<T> | Setter<NoInfer<T>>,
 ): void
 
-export function setState<T, K extends Canonical, New extends T, Key extends K>(
+export function setState<T, K extends Canonical>(
 	...params:
 		| [
 				token: WritableFamilyToken<T, K, any>,
-				key: Key,
-				value: New | Setter<T, New>,
+				key: NoInfer<K>,
+				value: NoInfer<T> | Setter<NoInfer<T>>,
 		  ]
-		| [token: WritableToken<T, any, any>, value: New | Setter<T, New>]
+		| [token: WritableToken<T, any, any>, value: NoInfer<T> | Setter<NoInfer<T>>]
 ): void {
 	setIntoStore(IMPLICIT.STORE, ...params)
 }

--- a/packages/atom.io/src/react/parse-state-overloads.ts
+++ b/packages/atom.io/src/react/parse-state-overloads.ts
@@ -11,17 +11,17 @@ import type { Canonical } from "atom.io/json"
 export function parseStateOverloads<T, K extends Canonical, Key extends K, E>(
 	store: Store,
 	...rest: [WritableFamilyToken<T, K, E>, Key] | [WritableToken<T, any, E>]
-): WritableToken<T, K, E>
+): WritableToken<T, Key, E>
 
 export function parseStateOverloads<T, K extends Canonical, Key extends K, E>(
 	store: Store,
 	...rest: [ReadableFamilyToken<T, K, E>, Key] | [ReadableToken<T, any, E>]
-): ReadableToken<T, K, E>
+): ReadableToken<T, Key, E>
 
 export function parseStateOverloads<T, K extends Canonical, Key extends K, E>(
 	store: Store,
 	...rest: [ReadableFamilyToken<T, K, E>, Key] | [ReadableToken<T, any, E>]
-): ReadableToken<T, K, E> {
+): ReadableToken<T, Key, E> {
 	let token: ReadableToken<any, any, any>
 	if (rest.length === 2) {
 		const family = rest[0]

--- a/packages/atom.io/src/react/use-i.ts
+++ b/packages/atom.io/src/react/use-i.ts
@@ -10,13 +10,15 @@ export function useI<T>(
 	token: WritableToken<T, any, any>,
 ): <New extends T>(next: New | ((old: T) => New)) => void
 
-export function useI<T, K extends Canonical, Key extends K>(
+export function useI<T, K extends Canonical>(
 	token: WritableFamilyToken<T, K, any>,
-	key: Key,
+	key: NoInfer<K>,
 ): <New extends T>(next: New | ((old: T) => New)) => void
 
-export function useI<T, K extends Canonical, Key extends K>(
-	...params: [WritableFamilyToken<T, K, any>, Key] | [WritableToken<T, any, any>]
+export function useI<T, K extends Canonical>(
+	...params:
+		| [WritableFamilyToken<T, K, any>, NoInfer<K>]
+		| [WritableToken<T, any, any>]
 ): <New extends T>(next: New | ((old: T) => New)) => void {
 	const store = React.useContext(StoreContext)
 	const token = parseStateOverloads(store, ...params)

--- a/packages/atom.io/src/react/use-loadable.ts
+++ b/packages/atom.io/src/react/use-loadable.ts
@@ -9,9 +9,9 @@ export function useLoadable<T, E>(
 	token: ReadableToken<Loadable<T>, any, E>,
 ): `LOADING` | { loading: boolean; value: E | T }
 
-export function useLoadable<T, K extends Canonical, Key extends K, E>(
+export function useLoadable<T, K extends Canonical, E>(
 	token: ReadableFamilyToken<Loadable<T>, K, E>,
-	key: Key,
+	key: NoInfer<K>,
 ): `LOADING` | { loading: boolean; value: E | T }
 
 export function useLoadable<T, F extends T, E>(
@@ -19,15 +19,9 @@ export function useLoadable<T, F extends T, E>(
 	fallback: F,
 ): { loading: boolean; value: T; error?: E }
 
-export function useLoadable<
-	T,
-	K extends Canonical,
-	F extends T,
-	Key extends K,
-	E,
->(
+export function useLoadable<T, K extends Canonical, F extends T, E>(
 	token: ReadableFamilyToken<Loadable<T>, K, E>,
-	key: Key,
+	key: NoInfer<K>,
 	fallback: F,
 ): { loading: boolean; value: T; error?: E }
 

--- a/packages/atom.io/src/react/use-o.ts
+++ b/packages/atom.io/src/react/use-o.ts
@@ -8,13 +8,15 @@ import { StoreContext } from "./store-context"
 
 export function useO<T, E>(token: ReadableToken<T, any, E>): E | T
 
-export function useO<T, K extends Canonical, Key extends K, E>(
+export function useO<T, K extends Canonical, E>(
 	token: ReadableFamilyToken<T, K, E>,
-	key: Key,
+	key: NoInfer<K>,
 ): E | T
 
-export function useO<T, K extends Canonical, Key extends K, E>(
-	...params: [ReadableFamilyToken<T, K, E>, Key] | [ReadableToken<T, any, E>]
+export function useO<T, K extends Canonical, E>(
+	...params:
+		| [ReadableFamilyToken<T, K, E>, NoInfer<K>]
+		| [ReadableToken<T, any, E>]
 ): E | T {
 	const store = React.useContext(StoreContext)
 	const token = parseStateOverloads(store, ...params)

--- a/packages/atom.io/src/realtime-react/use-pull-atom-family-member.ts
+++ b/packages/atom.io/src/realtime-react/use-pull-atom-family-member.ts
@@ -10,8 +10,7 @@ import { useRealtimeService } from "./use-realtime-service"
 export function usePullAtomFamilyMember<
 	J extends Json.Serializable,
 	K extends Canonical,
-	Key extends K,
->(family: AtomIO.RegularAtomFamilyToken<J, K>, subKey: Key): J {
+>(family: AtomIO.RegularAtomFamilyToken<J, K>, subKey: NoInfer<K>): J {
 	const store = React.useContext(StoreContext)
 	const token = findInStore(store, family, subKey)
 	useRealtimeService(`pull:${token.key}`, (socket) =>

--- a/packages/atom.io/src/realtime-react/use-pull-mutable-family-member.ts
+++ b/packages/atom.io/src/realtime-react/use-pull-mutable-family-member.ts
@@ -11,8 +11,7 @@ import { useRealtimeService } from "./use-realtime-service"
 export function usePullMutableAtomFamilyMember<
 	T extends Transceiver<any, any, any>,
 	K extends Canonical,
-	Key extends K,
->(familyToken: AtomIO.MutableAtomFamilyToken<T, K>, key: Key): T {
+>(familyToken: AtomIO.MutableAtomFamilyToken<T, K>, key: NoInfer<K>): T {
 	const store = React.useContext(StoreContext)
 	const token = findInStore(store, familyToken, key)
 	useRealtimeService(`pull:${token.key}`, (socket) =>

--- a/packages/atom.io/src/realtime-react/use-pull-selector-family-member.ts
+++ b/packages/atom.io/src/realtime-react/use-pull-selector-family-member.ts
@@ -7,11 +7,10 @@ import * as React from "react"
 
 import { useRealtimeService } from "./use-realtime-service"
 
-export function usePullSelectorFamilyMember<
-	T,
-	K extends Canonical,
-	Key extends K,
->(familyToken: AtomIO.SelectorFamilyToken<T, K>, key: Key): T {
+export function usePullSelectorFamilyMember<T, K extends Canonical>(
+	familyToken: AtomIO.SelectorFamilyToken<T, K>,
+	key: NoInfer<K>,
+): T {
 	const store = React.useContext(StoreContext)
 	const token = findInStore(store, familyToken, key)
 	useRealtimeService(`pull:${token.key}`, (socket) =>


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Apply `NoInfer` to family key parameters across store APIs  

- Simplify generics by removing `Key extends K` and `New extends T`  

- Preserve specific `Key` in returned token types  

- Update React hooks and selector signatures accordingly


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>21 files</summary><table>
<tr>
  <td><strong>dispose-from-store.ts</strong><dd><code>Use NoInfer<K> for `disposeFromStore` keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-d9ee351b0a7af84ced08de505fad8d9dfdfb7123a127a508aa26d5ed8e70588c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>get-fallback.ts</strong><dd><code>Use NoInfer<K> for fallback subKey</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-b769fb3a4349c2abdd666aface2fc3f3b2c74154a213959c6d4d8c12b9626c6d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>get-from-store.ts</strong><dd><code>Replace `K` with `NoInfer<K>` in getFromStore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-0191fa6fe24b870a715c9a9a17a187eace9a1bc72106f4d833a35607aa6edf75">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reduce-reference.ts</strong><dd><code>Switch `subKey` to `NoInfer<K>` in reducer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-4a41fb6e4c5e4672821c308002045af2e0358f727da3f0d0f5e13ddd9305358b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>register-selector.ts</strong><dd><code>Update setter overloads to use NoInfer types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-b9f06da6269f4560f5f3b8698bbd76d97a21203779d60599d67ae919b0f628ea">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>operate-on-store.ts</strong><dd><code>Remove extra generics, use NoInfer in operateOnStore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-74ac7cd3bee556e248dc57d74a84793d3b7d0f32cdd094bdb0e5e7b93b35765c">+10/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>reset-in-store.ts</strong><dd><code>Apply NoInfer<K> in resetInStore overloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-d95ddac7ce732975c05fb7b0f8a9dbd43fbc5770493398764860ef0eadb8d112">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>set-atom-or-selector.ts</strong><dd><code>Use NoInfer<T> for setter values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-18d75d4a5786ce20ea0243335ed94a1a96a5a3c24371ad99698d577c4325cddd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>set-atom.ts</strong><dd><code>Change `next` to NoInfer<T> or setter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-00a1c98a040fa449b89ec26fd9000650930b0cae486d18a408e43e0f95245018">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>set-into-store.ts</strong><dd><code>Standardize overloads with NoInfer<K> and NoInfer<T></code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-0c1e12aaac2a27d012f23e13ac77a72deec606afcbae49b0e53e62eca3ffe064">+13/-31</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>set-selector.ts</strong><dd><code>Use NoInfer<T> for selector `next` values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-c4b3dd98066868b8b43aadf8fc5051e87dedb8cea406ec272652d472f86e28b7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>find-state.ts</strong><dd><code>Return token keyed by `Key` instead of `K`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-98814144d57cc0181ac1386a7daebe85859634cf5c8493351b6525cb1f51e1b0">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>get-state.ts</strong><dd><code>Switch `key` overloads to NoInfer<K></code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-102fe6e61216ed6b9bc506266a95d34f9084e7bd89c6ec9b16f50bfa7e28b920">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>set-state.ts</strong><dd><code>Refine Setter type and apply NoInfer in setState</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-0c60d2e1fdc5c5218023ed0a186aa521c5e69a45e7c2135292b5960066bcbbb6">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>parse-state-overloads.ts</strong><dd><code>Return specific `Key` in parseStateOverloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-5511241d883eaacc98dc94ed4c58a87cfa4ef694d46af658f0e84394101ae64f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>use-i.ts</strong><dd><code>Apply NoInfer<K> in `useI` hook overloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-9dc3a57c952bde960b1dbd8408aed102fc1f5e62c6a720973d6b7a3137288c0c">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>use-loadable.ts</strong><dd><code>Use NoInfer<K> for `useLoadable` families</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-7d0622a92ca3be5d22a436c87d11e78a491f05fa30be4aa599b0b8d99c50434d">+4/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>use-o.ts</strong><dd><code>Update `useO` overloads to NoInfer<K></code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-b5eeb0fb361672daaee15926ce80a4e22e815da930b64aca82f84a2d5fa1a119">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>use-pull-atom-family-member.ts</strong><dd><code>Change subKey param to NoInfer<K></code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-fff6214411470a11c25dff6f99c702915aa52f71460a721bd0dcd5b3e7cabb25">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>use-pull-mutable-family-member.ts</strong><dd><code>Use NoInfer<K> in pull mutable family member</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-19d70a904729afcda65218f8de67e9209f4fab8f0f8d290fa65c44bf51808bfe">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>use-pull-selector-family-member.ts</strong><dd><code>Apply NoInfer<K> in pull selector family hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-a1840f5640e16d28697d7efed060e80d5799f13ada9c0ca799aa58cf3d2f867a">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Types</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>find-in-store.ts</strong><dd><code>Return specific `Key` in `findInStore` overloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-83f71c36238d4d7f24d927bbff7c3bce4dfaf21d0584895769a4b5f695824d61">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>atom.ts</strong><dd><code>Simplify `setSelf` signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-8e45c00372826244b919db627bea15b21ea396e0a4aec9cd19f496b319403a2b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>reset-atom-or-selector.ts</strong><dd><code>Add explicit type param on `setAtom` call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4772/files#diff-413dcb9b6b4ce2346a8bc07b7020a6f5b83ba9aa6ae883acb387bd0acaa3c37b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>