### PR TITLE
🏷️  use TT extends T, then breaking to setter or value union

### DIFF
--- a/packages/atom.io/src/internal/set-state/operate-on-store.ts
+++ b/packages/atom.io/src/internal/set-state/operate-on-store.ts
@@ -1,4 +1,4 @@
-import type { WritableFamilyToken, WritableToken } from "atom.io"
+import type { Setter, WritableFamilyToken, WritableToken } from "atom.io"
 import { type Canonical, parseJson } from "atom.io/json"
 
 import { seekInStore } from "../families"
@@ -18,18 +18,18 @@ export type ProtoUpdate<T> = { oldValue: T; newValue: T }
 export const OWN_OP: unique symbol = Symbol(`OWN_OP`)
 export const JOIN_OP: unique symbol = Symbol(`JOIN_OP`)
 
-export function operateOnStore<T, K extends Canonical, E>(
+export function operateOnStore<T, TT extends T, K extends Canonical, E>(
 	store: Store,
 	opMode: typeof JOIN_OP | typeof OWN_OP,
 	...params:
 		| [
 				token: WritableFamilyToken<T, K, E>,
 				key: NoInfer<K>,
-				value: NoInfer<T> | typeof RESET_STATE | ((oldValue: T) => NoInfer<T>),
+				value: Setter<TT> | TT | typeof RESET_STATE,
 		  ]
 		| [
 				token: WritableToken<T, any, E>,
-				value: NoInfer<T> | typeof RESET_STATE | ((oldValue: T) => NoInfer<T>),
+				value: Setter<TT> | TT | typeof RESET_STATE,
 		  ]
 ): void {
 	let existingToken: WritableToken<T, K, E> | undefined
@@ -37,7 +37,7 @@ export function operateOnStore<T, K extends Canonical, E>(
 	let token: WritableToken<T, K, E>
 	let family: WritableFamily<T, K, E> | undefined
 	let key: K | null
-	let value: T | typeof RESET_STATE | ((oldValue: T) => T)
+	let value: Setter<TT> | TT | typeof RESET_STATE
 	if (params.length === 2) {
 		token = params[0]
 		value = params[1]

--- a/packages/atom.io/src/internal/set-state/set-into-store.ts
+++ b/packages/atom.io/src/internal/set-state/set-into-store.ts
@@ -1,48 +1,48 @@
-import type { WritableFamilyToken, WritableToken } from "atom.io"
+import type { Setter, WritableFamilyToken, WritableToken } from "atom.io"
 import type { Canonical } from "atom.io/json"
 
 import type { Store } from "../store"
 import { operateOnStore, OWN_OP } from "./operate-on-store"
 import type { RESET_STATE } from "./reset-in-store"
 
-export function setIntoStore<T, E>(
+export function setIntoStore<T, TT extends T>(
 	store: Store,
-	token: WritableToken<T, any, E>,
-	value: NoInfer<T> | typeof RESET_STATE | ((oldValue: T) => NoInfer<T>),
+	token: WritableToken<T, any, any>,
+	value: Setter<TT> | TT | typeof RESET_STATE,
 ): void
 
-export function setIntoStore<T, K extends Canonical, E>(
+export function setIntoStore<T, TT extends T, K extends Canonical>(
 	store: Store,
-	token: WritableFamilyToken<T, K, E>,
+	token: WritableFamilyToken<T, K, any>,
 	key: NoInfer<K>,
-	value: NoInfer<T> | typeof RESET_STATE | ((oldValue: T) => NoInfer<T>),
+	value: Setter<TT> | TT | typeof RESET_STATE,
 ): void
 
-export function setIntoStore<T, K extends Canonical, E>(
+export function setIntoStore<T, TT extends T, K extends Canonical>(
 	store: Store,
 	...params:
 		| [
-				token: WritableFamilyToken<T, K, E>,
+				token: WritableFamilyToken<T, K, any>,
 				key: NoInfer<K>,
-				value: NoInfer<T> | typeof RESET_STATE | ((oldValue: T) => NoInfer<T>),
+				value: Setter<TT> | TT | typeof RESET_STATE,
 		  ]
 		| [
-				token: WritableToken<T, any, E>,
-				value: NoInfer<T> | typeof RESET_STATE | ((oldValue: T) => NoInfer<T>),
+				token: WritableToken<T, any, any>,
+				value: Setter<TT> | TT | typeof RESET_STATE,
 		  ]
 ): void
 
-export function setIntoStore<T, K extends Canonical, E>(
+export function setIntoStore<T, TT extends T, K extends Canonical>(
 	store: Store,
 	...params:
 		| [
-				token: WritableFamilyToken<T, K, E>,
+				token: WritableFamilyToken<T, K, any>,
 				key: NoInfer<K>,
-				value: NoInfer<T> | typeof RESET_STATE | ((oldValue: T) => NoInfer<T>),
+				value: Setter<TT> | TT | typeof RESET_STATE,
 		  ]
 		| [
-				token: WritableToken<T, any, E>,
-				value: NoInfer<T> | typeof RESET_STATE | ((oldValue: T) => NoInfer<T>),
+				token: WritableToken<T, any, any>,
+				value: Setter<TT> | TT | typeof RESET_STATE,
 		  ]
 ): void {
 	operateOnStore(store, OWN_OP, ...params)

--- a/packages/atom.io/src/main/set-state.ts
+++ b/packages/atom.io/src/main/set-state.ts
@@ -18,9 +18,9 @@ export type Setter<T> = (oldValue: T) => T
  * @overload Default
  * @default
  */
-export function setState<T>(
+export function setState<T, TT extends T>(
 	token: WritableToken<T, any, any>,
-	value: NoInfer<T> | Setter<NoInfer<T>>,
+	value: Setter<TT> | TT,
 ): void
 
 /**
@@ -30,20 +30,20 @@ export function setState<T>(
  * @param value - The new value of the state.
  * @overload Streamlined
  */
-export function setState<T, K extends Canonical>(
+export function setState<T, TT extends T, K extends Canonical>(
 	token: WritableFamilyToken<T, K, any>,
 	key: NoInfer<K>,
-	value: NoInfer<T> | Setter<NoInfer<T>>,
+	value: Setter<TT> | TT,
 ): void
 
-export function setState<T, K extends Canonical>(
+export function setState<T, TT extends T, K extends Canonical>(
 	...params:
 		| [
 				token: WritableFamilyToken<T, K, any>,
 				key: NoInfer<K>,
-				value: NoInfer<T> | Setter<NoInfer<T>>,
+				value: Setter<TT> | TT,
 		  ]
-		| [token: WritableToken<T, any, any>, value: NoInfer<T> | Setter<NoInfer<T>>]
+		| [token: WritableToken<T, any, any>, value: Setter<TT> | TT]
 ): void {
 	setIntoStore(IMPLICIT.STORE, ...params)
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduce `TT extends T` generic for setter inference

- Replace `NoInfer<T>` unions with `Setter<TT> | TT`

- Update `operateOnStore` and `setIntoStore` signatures

- Refine `setState` overloads with new type parameters


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operate-on-store.ts</strong><dd><code>Enhance operateOnStore with Setter<TT></code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/internal/set-state/operate-on-store.ts

<li>Import <code>Setter</code> from atom.io<br> <li> Add <code>TT extends T</code> to <code>operateOnStore</code> signature<br> <li> Change <code>value</code> type to <code>Setter<TT> | TT | RESET_STATE</code>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4775/files#diff-74ac7cd3bee556e248dc57d74a84793d3b7d0f32cdd094bdb0e5e7b93b35765c">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>set-into-store.ts</strong><dd><code>Update setIntoStore to use Setter<TT></code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/internal/set-state/set-into-store.ts

<li>Import <code>Setter</code> type and add to imports<br> <li> Add <code>TT extends T</code> to <code>setIntoStore</code> overloads<br> <li> Replace <code>NoInfer<T></code> with <code>Setter<TT> | TT | RESET_STATE</code>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4775/files#diff-0c1e12aaac2a27d012f23e13ac77a72deec606afcbae49b0e53e62eca3ffe064">+17/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>set-state.ts</strong><dd><code>Refine setState generics for setters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/main/set-state.ts

<li>Add <code>TT extends T</code> generic to <code>setState</code> overloads<br> <li> Change <code>value</code> parameter to <code>Setter<TT> | TT</code>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4775/files#diff-0c60d2e1fdc5c5218023ed0a186aa521c5e69a45e7c2135292b5960066bcbbb6">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>