### PR TITLE
ipc socket test parameterization

### DIFF
--- a/apps/core.wayfarer.quest/src/room.server.ts
+++ b/apps/core.wayfarer.quest/src/room.server.ts
@@ -7,7 +7,7 @@ import { generateHeapSnapshot } from "bun"
 
 import { heartsContinuity } from "./store/game/hearts"
 
-const parentSocket = new RTS.ParentSocket()
+const parentSocket = new RTS.ParentSocket(process)
 // const TIMESTAMP = Date.now()
 // const LOG_FILEPATH = `./logs/${TIMESTAMP}.txt`
 

--- a/apps/tempest.games/src/backend.worker.game.bun.ts
+++ b/apps/tempest.games/src/backend.worker.game.bun.ts
@@ -2,7 +2,7 @@
 
 import { ParentSocket } from "atom.io/realtime-server"
 
-const parent = new ParentSocket()
+const parent = new ParentSocket(process)
 Object.assign(console, parent.logger, { log: parent.logger.info })
 
 parent.on(`timeToStop`, function gracefulExit() {

--- a/apps/tempest.games/src/backend.worker.tribunal.bun.ts
+++ b/apps/tempest.games/src/backend.worker.tribunal.bun.ts
@@ -6,7 +6,7 @@ import { OpenAiSafeGenerator } from "safegen/openai"
 import { tribunal } from "./backend/tribunal/tribunal"
 import { env } from "./library/env"
 
-const parent = new ParentSocket()
+const parent = new ParentSocket(process)
 Object.assign(console, parent.logger, { log: parent.logger.info })
 
 process.on(`SIGINT`, () => {

--- a/apps/tempest.games/src/backend/logger.ts
+++ b/apps/tempest.games/src/backend/logger.ts
@@ -2,7 +2,7 @@ import { ParentSocket } from "atom.io/realtime-server"
 
 import { env } from "../library/env"
 
-export const parentSocket = new ParentSocket()
+export const parentSocket = new ParentSocket(process)
 
 export const logger = (
 	env.RUN_WORKERS_FROM_SOURCE ? console : parentSocket.logger

--- a/apps/tempest.games/src/frontend.bun.ts
+++ b/apps/tempest.games/src/frontend.bun.ts
@@ -15,7 +15,7 @@ import {
 	serverIssueType,
 } from "./library/response-dictionary"
 
-const parentSocket = new ParentSocket()
+const parentSocket = new ParentSocket(process)
 const { logger } = parentSocket
 Object.assign(console, logger, { log: logger.info })
 logger.info(`ready`)

--- a/packages/atom.io/__tests__/experimental/realtime-ipc/game-instance.bun.ts
+++ b/packages/atom.io/__tests__/experimental/realtime-ipc/game-instance.bun.ts
@@ -7,7 +7,7 @@ import { gameContinuity, letterAtoms } from "./game-store"
 
 const LOGGING = false
 
-const parentSocket = new RTS.ParentSocket()
+const parentSocket = new RTS.ParentSocket(process)
 const ipcLog = {
 	info: (...args: unknown[]) => {
 		parentSocket.logger.info(...args)

--- a/packages/atom.io/__tests__/experimental/realtime-ipc/game-servers.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime-ipc/game-servers.test.tsx
@@ -28,7 +28,7 @@ afterEach(async () => {
 	console.log(`KILLING ROOMS`, [...ROOMS.keys()])
 	for (const [roomId, room] of ROOMS) {
 		console.log(`KILLING ROOM ${roomId}`)
-		room.process.kill()
+		room.proc.kill()
 	}
 
 	await dbManager.dropSampleTables()

--- a/packages/atom.io/__tests__/experimental/realtime-ipc/system-server.node.ts
+++ b/packages/atom.io/__tests__/experimental/realtime-ipc/system-server.node.ts
@@ -85,7 +85,7 @@ export const SystemServer = ({
 			if (payload) toRoom(payload)
 		}
 
-		roomSocket.process.on(`close`, (code) => {
+		roomSocket.on(`close`, (code) => {
 			console.info(`[${shortId}]:${username}`, `room "${roomId}" closing`)
 			socket.emit(`room-close`, roomId, code)
 			actUponStore(store, RTS.destroyRoomTX, arbitrary())(roomId)

--- a/packages/atom.io/__tests__/experimental/realtime/ipc-socket.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/ipc-socket.test.tsx
@@ -1,5 +1,5 @@
 import { ParentSocket } from "atom.io/realtime-server"
 
 it(`ParentSocket`, () => {
-	expect(() => new ParentSocket()).not.toThrow()
+	expect(() => new ParentSocket(process)).not.toThrow()
 })

--- a/packages/atom.io/__tests__/experimental/realtime/ipc-socket.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/ipc-socket.test.tsx
@@ -1,5 +1,37 @@
-import { ParentSocket } from "atom.io/realtime-server"
+import { PassThrough } from "node:stream"
 
-it(`ParentSocket`, () => {
-	expect(() => new ParentSocket(process)).not.toThrow()
+import { ChildSocket, ParentSocket } from "atom.io/realtime-server"
+
+const logger: Pick<Console, `error` | `info` | `warn`> = console
+
+beforeEach(() => {
+	vitest.spyOn(logger, `error`)
+	vitest.spyOn(logger, `warn`)
+	vitest.spyOn(logger, `info`)
+})
+
+test(`inter-process communication`, () => {
+	const parentToChild = new PassThrough()
+	const childToParent = new PassThrough()
+	const childLogs = new PassThrough()
+	const parentLogs = new PassThrough()
+
+	const pid = 1
+
+	const child = new ChildSocket(
+		{
+			stdin: parentToChild,
+			stdout: childToParent,
+			stderr: childLogs,
+			pid,
+			kill: () => true,
+		},
+		`child-socket`,
+	)
+	const parent = new ParentSocket({
+		stdin: childToParent,
+		stdout: parentToChild,
+		stderr: parentLogs,
+		pid,
+	})
 })

--- a/packages/atom.io/__tests__/experimental/realtime/ipc-socket.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/ipc-socket.test.tsx
@@ -10,28 +10,59 @@ beforeEach(() => {
 	vitest.spyOn(logger, `info`)
 })
 
-test(`inter-process communication`, () => {
-	const parentToChild = new PassThrough()
-	const childToParent = new PassThrough()
-	const childLogs = new PassThrough()
-	const parentLogs = new PassThrough()
-
+test(`inter-process communication`, async () => {
+	const stdin = new PassThrough()
+	const stdout = new PassThrough()
+	const stderr = new PassThrough()
 	const pid = 1
 
-	const child = new ChildSocket(
+	const parentsInterfaceToChild = new ChildSocket(
 		{
-			stdin: parentToChild,
-			stdout: childToParent,
-			stderr: childLogs,
+			stdin,
+			stdout,
+			stderr,
 			pid,
 			kill: () => true,
 		},
 		`child-socket`,
 	)
-	const parent = new ParentSocket({
-		stdin: childToParent,
-		stdout: parentToChild,
-		stderr: parentLogs,
+
+	const childsInterfaceToParent = new ParentSocket({
+		stdin,
+		stdout,
+		stderr,
 		pid,
+		exit: () => {
+			console.log(`exited`)
+		},
 	})
+
+	const gotPing = new Promise<[string]>((resolve) => {
+		childsInterfaceToParent.on(`ping`, (msg: string) => {
+			resolve([msg])
+		})
+	})
+
+	parentsInterfaceToChild.emit(`ping`, `hello from parent`)
+
+	const [ping] = await gotPing
+
+	console.log(`⛔⛔⛔⛔⛔ gotPing`, ping)
+
+	expect(ping).toBe(`hello from parent`)
+
+	// and now test the reverse
+	const gotPong = new Promise<[string]>((resolve) => {
+		parentsInterfaceToChild.on(`pong`, (msg: string) => {
+			resolve([msg])
+		})
+	})
+
+	childsInterfaceToParent.emit(`pong`, `hello from child`)
+
+	const [pong] = await gotPong
+
+	console.log(`⛔⛔⛔⛔⛔ gotPing`, pong)
+
+	expect(pong).toBe(`hello from child`)
 })

--- a/packages/atom.io/src/realtime-server/ipc-sockets/child-socket.ts
+++ b/packages/atom.io/src/realtime-server/ipc-sockets/child-socket.ts
@@ -19,7 +19,7 @@ export class ChildSocket<
 
 	public id = `#####`
 
-	public process: {
+	public proc: {
 		pid?: number | undefined
 		stdin: Writable
 		stdout: Readable
@@ -63,17 +63,17 @@ export class ChildSocket<
 			const stringifiedEvent = JSON.stringify([event, ...args]) + `\x03`
 			const errorHandler = (err: { code: string }) => {
 				if (err.code === `EPIPE`) {
-					console.error(`EPIPE error during write`, this.process.stdin)
+					console.error(`EPIPE error during write`, this.proc.stdin)
 				}
-				this.process.stdin.removeListener(`error`, errorHandler)
+				this.proc.stdin.removeListener(`error`, errorHandler)
 			}
 
-			this.process.stdin.once(`error`, errorHandler)
-			this.process.stdin.write(stringifiedEvent)
+			this.proc.stdin.once(`error`, errorHandler)
+			this.proc.stdin.write(stringifiedEvent)
 
 			return this
 		})
-		this.process = proc
+		this.proc = proc
 		this.key = key
 		this.logger = logger ?? {
 			info: (...args: unknown[]) => {
@@ -86,13 +86,13 @@ export class ChildSocket<
 				console.error(this.id, this.key, ...args)
 			},
 		}
-		this.process.stdout.on(
+		this.proc.stdout.on(
 			`data`,
 			<Event extends keyof I>(buffer: EventBuffer<string, I[Event]>) => {
 				const chunk = buffer.toString()
 
 				if (chunk === `ALIVE`) {
-					// console.log(chunk)
+					console.log(chunk)
 					return
 				}
 				this.unprocessedEvents.push(...chunk.split(`\x03`))
@@ -126,7 +126,7 @@ export class ChildSocket<
 				}
 			},
 		)
-		this.process.stderr.on(`data`, (buf) => {
+		this.proc.stderr.on(`data`, (buf) => {
 			const chunk = buf.toString()
 			this.unprocessedLogs.push(...chunk.split(`\x03`))
 			// console.log(`🤫`, chunk.length)

--- a/packages/atom.io/src/realtime-server/ipc-sockets/child-socket.ts
+++ b/packages/atom.io/src/realtime-server/ipc-sockets/child-socket.ts
@@ -1,4 +1,4 @@
-import type { ChildProcessWithoutNullStreams } from "node:child_process"
+import type { Readable, Writable } from "node:stream"
 
 import type { Json } from "atom.io/json"
 import { parseJson } from "atom.io/json"
@@ -19,10 +19,13 @@ export class ChildSocket<
 
 	public id = `#####`
 
-	public process: Pick<
-		ChildProcessWithoutNullStreams,
-		`pid` | `stderr` | `stdin` | `stdout`
-	>
+	public process: {
+		pid?: number | undefined
+		stdin: Writable
+		stdout: Readable
+		stderr: Readable
+		kill: (signal?: NodeJS.Signals | number) => boolean
+	}
 	public key: string
 	public logger: Pick<Console, `error` | `info` | `warn`>
 
@@ -46,10 +49,13 @@ export class ChildSocket<
 	}
 
 	public constructor(
-		proc: Pick<
-			ChildProcessWithoutNullStreams,
-			`pid` | `stderr` | `stdin` | `stdout`
-		>,
+		proc: {
+			pid?: number | undefined
+			stdin: Writable
+			stdout: Readable
+			stderr: Readable
+			kill: (signal?: NodeJS.Signals | number) => boolean
+		},
 		key: string,
 		logger?: Pick<Console, `error` | `info` | `warn`>,
 	) {

--- a/packages/atom.io/src/realtime-server/ipc-sockets/child-socket.ts
+++ b/packages/atom.io/src/realtime-server/ipc-sockets/child-socket.ts
@@ -19,7 +19,10 @@ export class ChildSocket<
 
 	public id = `#####`
 
-	public process: ChildProcessWithoutNullStreams
+	public process: Pick<
+		ChildProcessWithoutNullStreams,
+		`pid` | `stderr` | `stdin` | `stdout`
+	>
 	public key: string
 	public logger: Pick<Console, `error` | `info` | `warn`>
 
@@ -43,7 +46,10 @@ export class ChildSocket<
 	}
 
 	public constructor(
-		process: ChildProcessWithoutNullStreams,
+		proc: Pick<
+			ChildProcessWithoutNullStreams,
+			`pid` | `stderr` | `stdin` | `stdout`
+		>,
 		key: string,
 		logger?: Pick<Console, `error` | `info` | `warn`>,
 	) {
@@ -61,7 +67,7 @@ export class ChildSocket<
 
 			return this
 		})
-		this.process = process
+		this.process = proc
 		this.key = key
 		this.logger = logger ?? {
 			info: (...args: unknown[]) => {
@@ -140,8 +146,8 @@ export class ChildSocket<
 				console.error(`❌❌❌️`)
 			}
 		})
-		if (process.pid) {
-			this.id = process.pid.toString()
+		if (proc.pid) {
+			this.id = proc.pid.toString()
 		}
 	}
 }

--- a/packages/atom.io/src/realtime-server/ipc-sockets/parent-socket.ts
+++ b/packages/atom.io/src/realtime-server/ipc-sockets/parent-socket.ts
@@ -54,7 +54,7 @@ export class ParentSocket<
 	protected relayServices: ((
 		socket: SubjectSocket<any, any>,
 	) => (() => void) | void)[]
-	protected process: NodeJS.Process
+	protected process: Pick<NodeJS.Process, `pid` | `stderr` | `stdin` | `stdout`>
 
 	public id = `#####`
 
@@ -81,13 +81,15 @@ export class ParentSocket<
 		},
 	}
 
-	public constructor() {
+	public constructor(
+		proc: Pick<NodeJS.Process, `pid` | `stderr` | `stdin` | `stdout`>,
+	) {
 		super((event, ...args) => {
 			const stringifiedEvent = JSON.stringify([event, ...args])
 			this.process.stdout.write(stringifiedEvent + `\x03`)
 			return this
 		})
-		this.process = process
+		this.process = proc
 		this.process.stdin.resume()
 		this.relays = new Map()
 		this.relayServices = []

--- a/packages/atom.io/src/realtime-server/ipc-sockets/parent-socket.ts
+++ b/packages/atom.io/src/realtime-server/ipc-sockets/parent-socket.ts
@@ -1,3 +1,5 @@
+import type { Readable, Writable } from "node:stream"
+
 import { Subject } from "atom.io/internal"
 import type { Json } from "atom.io/json"
 import { parseJson, stringifyJson } from "atom.io/json"
@@ -54,7 +56,13 @@ export class ParentSocket<
 	protected relayServices: ((
 		socket: SubjectSocket<any, any>,
 	) => (() => void) | void)[]
-	protected process: Pick<NodeJS.Process, `pid` | `stderr` | `stdin` | `stdout`>
+	// protected process: Pick<NodeJS.Process, `pid` | `stderr` | `stdin` | `stdout`>
+	protected process: {
+		pid: number
+		stdin: Readable
+		stdout: Writable
+		stderr: Writable
+	}
 
 	public id = `#####`
 
@@ -82,7 +90,13 @@ export class ParentSocket<
 	}
 
 	public constructor(
-		proc: Pick<NodeJS.Process, `pid` | `stderr` | `stdin` | `stdout`>,
+		// proc: Pick<NodeJS.Process, `pid` | `stderr` | `stdin` | `stdout`>,
+		proc: {
+			pid: number
+			stdin: Readable
+			stdout: Writable
+			stderr: Writable
+		},
 	) {
 		super((event, ...args) => {
 			const stringifiedEvent = JSON.stringify([event, ...args])

--- a/packages/flightdeck/__tests__/fixtures/app@v0.ts
+++ b/packages/flightdeck/__tests__/fixtures/app@v0.ts
@@ -4,7 +4,7 @@ import { ParentSocket } from "atom.io/realtime-server"
 import { serve } from "bun"
 
 const PORT = process.argv[2] ?? 4444
-const parentSocket = new ParentSocket()
+const parentSocket = new ParentSocket(process)
 serve({
 	port: PORT,
 	fetch(req) {

--- a/packages/flightdeck/__tests__/fixtures/app@v1.ts
+++ b/packages/flightdeck/__tests__/fixtures/app@v1.ts
@@ -4,7 +4,7 @@ import { ParentSocket } from "atom.io/realtime-server"
 import { serve } from "bun"
 
 const PORT = process.argv[2] ?? 4444
-const parentSocket = new ParentSocket()
+const parentSocket = new ParentSocket(process)
 serve({
 	port: PORT,
 	fetch(req) {


### PR DESCRIPTION
- **♻️ parameterize process when building parent socket**
- **🏷️ require less from the process object given to child socket, for easier mocking**
- **🏗️ build out test harness with passthrough streams**
- **♻️ use 'proc' to avoid shadowing 'process'; remove exit management**
- **✅ unit test for ipc**
