### PR TITLE
reduce testing flakiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"fmt:fix": "biome format --write .",
 		"build": "turbo run build",
 		"bench": "cd lib && vitest bench",
-		"test": "cross-env CI=true turbo run test:once --concurrency=2",
+		"test": "cross-env CI=true turbo run test:once --concurrency=1",
 		"test:coverage:increased": "cross-env CI=true turbo run test:coverage:increased",
 		"test:semver": "cross-env CI=true turbo run test:semver",
 		"release": "bun run build && changeset publish",

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
@@ -209,7 +209,7 @@ describe(`mutable atoms in continuity`, () => {
 		)
 	}
 	test(`mutable initialization`, async () => {
-		const { client, server, addItemTX, myListAtom } = scenario()
+		const { client, server, addItemTX, myListAtom, teardown } = scenario()
 		const clientApp = client.init()
 		// clientApp.enableLogging()
 		await waitFor(() => {
@@ -232,5 +232,7 @@ describe(`mutable atoms in continuity`, () => {
 			Utils.throwUntil(() => server.silo.getState(myListAtom).has(`world`))
 		})
 		if (DEBUG_LOGGING) console.log(`📝 took ${performance.now() - time}ms`)
+
+		await teardown()
 	})
 })

--- a/packages/atom.io/__tests__/private/async-data.test.ts
+++ b/packages/atom.io/__tests__/private/async-data.test.ts
@@ -72,6 +72,10 @@ describe(`complex async setup`, () => {
 	})
 	server.listen(PORT)
 
+	afterAll(() => {
+		server.close()
+	})
+
 	test(`complex chain of async selectors`, async () => {
 		const urlState = AtomIO.atom<AtomIO.Loadable<URL>>({
 			key: `url`,

--- a/packages/atom.io/__tests__/public/async-state.test.ts
+++ b/packages/atom.io/__tests__/public/async-state.test.ts
@@ -128,6 +128,11 @@ describe(`async selector`, () => {
 			})
 	})
 	server.listen(PORT)
+
+	afterAll(() => {
+		server.close()
+	})
+
 	test(`selector as a caching mechanism for async data`, async () => {
 		const { atom, selector, getState /* store */ } = new AtomIO.Silo({
 			name: `math`,

--- a/packages/atom.io/vitest.config.ts
+++ b/packages/atom.io/vitest.config.ts
@@ -1,3 +1,4 @@
+import { cpus } from "node:os"
 import { resolve } from "node:path"
 
 import type { UserConfig } from "vite"
@@ -37,6 +38,12 @@ const vitestConfig: UserConfig = defineConfig({
 		target: `es2022`,
 	},
 	test: {
+		pool: `vmThreads`,
+		poolOptions: {
+			vmThreads: {
+				maxThreads: cpus().length - 1,
+			},
+		},
 		globals: true,
 		environment: `happy-dom`,
 		coverage: {


### PR DESCRIPTION
### **User description**
- **🐛 always dispose at the end of tests**
- **🔧 use vmThreads; limit concurrency to cpus - 1**
- **🔧 limit turbo test concurrency to 1**


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Add teardown call in continuity tests

- Close HTTP server after async suites

- Configure Vitest vmThreads and thread limit

- Limit turbo test concurrency to one


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>realtime-continuity.test.tsx</strong><dd><code>Add teardown invocation to continuity test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx

<li>Destructure <code>teardown</code> from scenario()<br> <li> Invoke <code>await teardown()</code> after test


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4783/files#diff-4f1c176a31b9dff3ac3aea98ff0474ca2328dacd84a7821b215adbf33f198844">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>async-data.test.ts</strong><dd><code>Close HTTP server after async-data tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/private/async-data.test.ts

- Add `afterAll` hook closing HTTP server


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4783/files#diff-b29932023d2ca6f7e4dcb801a6946c6d11465f155ae363650fad8998cb1eddd0">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>async-state.test.ts</strong><dd><code>Close HTTP server after async-state tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/public/async-state.test.ts

- Add `afterAll` hook closing HTTP server


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4783/files#diff-3c0592098839f0a7e88cbf5bebd85e703a77816a844913bd091b61bb80d29f42">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vitest.config.ts</strong><dd><code>Limit Vitest threads using vmThreads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/vitest.config.ts

<li>Import <code>cpus</code> from <code>node:os</code><br> <li> Set Vitest <code>pool</code> to <code>vmThreads</code><br> <li> Limit threads to <code>cpus().length - 1</code>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4783/files#diff-531096bafc532104ab1a2676f94cb11df96c9f459ff91edaf9e2df285a77e4a0">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Limit turbo test concurrency to one</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Reduce test concurrency to 1 in script


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4783/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>