### PR TITLE
♻️ remove manual port-passing in realtime tests

### DIFF
--- a/packages/atom.io/__tests__/experimental/realtime-ipc/game-servers.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime-ipc/game-servers.test.tsx
@@ -39,9 +39,8 @@ afterAll(async () => {
 })
 
 describe(`multi-process realtime server`, () => {
-	const scenario = (port: number) => {
+	const scenario = () => {
 		const { server, client, teardown } = RTTest.singleClient({
-			port,
 			server: SystemServer,
 			client: BrowserGame,
 		})
@@ -49,7 +48,7 @@ describe(`multi-process realtime server`, () => {
 	}
 
 	it(`permits manual creation and deletion of rooms`, async () => {
-		const { client, teardown } = scenario(6361)
+		const { client, teardown } = scenario()
 		const app = client.init()
 		const createRoomButton = await app.renderResult.findByTestId(`create-room`)
 		act(() => {
@@ -64,7 +63,7 @@ describe(`multi-process realtime server`, () => {
 		await teardown()
 	})
 	it(`permits join and leave`, async () => {
-		const { client, teardown } = scenario(6362)
+		const { client, teardown } = scenario()
 		const app = client.init()
 		const createRoomButton = await app.renderResult.findByTestId(`create-room`)
 		act(() => {

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-action-receiver.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-action-receiver.test.tsx
@@ -16,7 +16,6 @@ const incrementTX = AtomIO.transaction({
 describe(`running transactions`, () => {
 	const scenario = () =>
 		RTTest.multiClient({
-			port: 2925,
 			server: ({ socket, silo: { store } }) => {
 				const exposeSingle = RTS.realtimeStateProvider({ socket, store })
 				const receiveTransaction = RTS.realtimeActionReceiver({ socket, store })

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-continuity.test.tsx
@@ -40,7 +40,6 @@ describe(`synchronizing transactions`, () => {
 
 		return Object.assign(
 			RTTest.multiClient({
-				port: 5465,
 				immortal: { server: true },
 				server: ({ socket, silo: { store } }) => {
 					// enableLogging()
@@ -189,7 +188,6 @@ describe(`mutable atoms in continuity`, () => {
 
 		return Object.assign(
 			RTTest.singleClient({
-				port: 5475,
 				server: ({ socket, silo: { store } }) => {
 					// enableLogging()
 					const exposeContinuity = RTS.prepareToExposeRealtimeContinuity({

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-mutable-family.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-mutable-family.test.tsx
@@ -34,7 +34,6 @@ const addToNumbersCollectionTX = AtomIO.transaction<
 describe(`running transactions`, () => {
 	const scenario = () =>
 		RTTest.multiClient({
-			port: 2775,
 			server: ({ socket, silo: { store } }) => {
 				const exposeMutableFamily = RTS.realtimeMutableFamilyProvider({
 					socket,

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-mutable.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-mutable.test.tsx
@@ -25,7 +25,6 @@ const addToNumbersCollectionTX = AtomIO.transaction({
 describe(`running transactions`, () => {
 	const scenario = () =>
 		RTTest.multiClient({
-			port: 5445,
 			server: ({ socket, silo: { store } }) => {
 				const exposeMutable = RTS.realtimeMutableProvider({ socket, store })
 				const receiveTransaction = RTS.realtimeActionReceiver({ socket, store })

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-pull-regular-atom-family.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-pull-regular-atom-family.test.tsx
@@ -50,7 +50,6 @@ function RealtimeDisplay(): React.ReactNode {
 describe(`running transactions`, () => {
 	const scenario = () =>
 		RTTest.multiClient({
-			port: 4915,
 			server: ({ socket, silo: { store } }) => {
 				const exposeFamily = RTS.realtimeAtomFamilyProvider({
 					socket,

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-pull-writable-selector.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-pull-writable-selector.test.tsx
@@ -21,7 +21,6 @@ const countHundredfoldState = AtomIO.selector<number>({
 describe(`pull atom, observe selector`, () => {
 	const scenario = () =>
 		RTTest.singleClient({
-			port: 5775,
 			server: ({ socket, silo: { store } }) => {
 				const exposeSingle = RTS.realtimeStateProvider({ socket, store })
 				exposeSingle(countState)
@@ -55,7 +54,6 @@ describe(`pull atom, observe selector`, () => {
 describe(`pull selector, observe atom`, () => {
 	const scenario = () =>
 		RTTest.singleClient({
-			port: 5725,
 			server: ({ socket, silo: { store } }) => {
 				const exposeSingle = RTS.realtimeStateProvider({ socket, store })
 				exposeSingle(countState)

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-push-regular-atom.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-push-regular-atom.test.tsx
@@ -10,7 +10,6 @@ const countState = AtomIO.atom<number>({ key: `count`, default: 0 })
 describe(`pushing state`, () => {
 	const scenario = () =>
 		RTTest.multiClient({
-			port: 3385,
 			server: ({ socket, silo: { store } }) => {
 				const provideState = RTS.realtimeStateProvider({ socket, store })
 				const receiveState = RTS.realtimeStateReceiver({ socket, store })

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-setup-multiple.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-setup-multiple.test.tsx
@@ -10,7 +10,6 @@ const countState = AtomIO.atom<number>({ key: `count`, default: 0 })
 describe(`multi-client scenario`, () => {
 	const scenario = () =>
 		RTTest.multiClient({
-			port: 8325,
 			server: ({ socket, silo: { store } }) => {
 				const exposeSingle = RTS.realtimeStateProvider({ socket, store })
 				exposeSingle(countState)

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-setup-single.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-setup-single.test.tsx
@@ -10,7 +10,6 @@ const countState = AtomIO.atom<number>({ key: `count`, default: 0 })
 describe(`single-client scenario`, () => {
 	const scenario = () => {
 		const { server, client, teardown } = RTTest.singleClient({
-			port: 6865,
 			server: ({ socket, silo: { store } }) => {
 				const exposeSingle = RTS.realtimeStateProvider({ socket, store })
 				exposeSingle(countState)

--- a/packages/atom.io/__tests__/experimental/realtime/realtime-timeline.test.tsx
+++ b/packages/atom.io/__tests__/experimental/realtime/realtime-timeline.test.tsx
@@ -10,7 +10,6 @@ describe(`undo/redo`, () => {
 	const countTL = AtomIO.timeline({ key: `countTL`, scope: [countState] })
 	const scenario = () =>
 		RTTest.singleClient({
-			port: 2855,
 			server: ({ socket, silo: { store } }) => {
 				const exposeSingle = RTS.realtimeStateProvider({ socket, store })
 				exposeSingle(countState)

--- a/packages/atom.io/src/realtime-testing/setup-realtime-test.tsx
+++ b/packages/atom.io/src/realtime-testing/setup-realtime-test.tsx
@@ -16,7 +16,6 @@ import {
 } from "atom.io/internal"
 import { toEntries } from "atom.io/json"
 import * as AR from "atom.io/react"
-import * as RT from "atom.io/realtime"
 import * as RTC from "atom.io/realtime-client"
 import * as RTR from "atom.io/realtime-react"
 import * as RTS from "atom.io/realtime-server"
@@ -69,7 +68,6 @@ function prefixLogger(store: Store, prefix: string) {
 }
 
 export type TestSetupOptions = {
-	port: number
 	immortal?: { server?: boolean }
 	server: (tools: {
 		socket: SocketIO.Socket
@@ -130,11 +128,11 @@ export const setupRealtimeTestServer = (
 		},
 		IMPLICIT.STORE,
 	)
-	prefixLogger(silo.store, `server`)
+	// prefixLogger(silo.store, `server`)
 	const socketRealm = new AtomIO.Realm<RTS.SocketSystemHierarchy>(silo.store)
 
 	const httpServer = http.createServer((_, res) => res.end(`Hello World!`))
-	const address = httpServer.listen(options.port).address()
+	const address = httpServer.listen().address()
 	const port =
 		typeof address === `string` ? null : address === null ? null : address.port
 	if (port === null) throw new Error(`Could not determine port for test server`)


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Export `unique-port` in test utilities

- Remove manual `port` arguments from realtime tests

- Drop `port` field in TestSetupOptions type

- Use ephemeral ports in setupRealtimeTestServer


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>index.ts</strong><dd><code>Add `unique-port` export to test utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4797/files#diff-358ed47c4a2f9b92a03257764d04b7c3f55e86c9a1c7c2fe5e18417754b13637">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>game-servers.test.tsx</strong><dd><code>Remove manual `port` from scenario call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4797/files#diff-502d7c24cfde9b5035cb85903f13afea67ab2155f22e8927a6e7e733beecb6e2">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>realtime-action-receiver.test.tsx</strong><dd><code>Omit fixed `port` in multiClient scenario</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4797/files#diff-35e4c769e042c3541a060aef8dcb6f5518a821b7c6261aab7d90597045f07248">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>realtime-continuity.test.tsx</strong><dd><code>Remove hardcoded `port` in continuity tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4797/files#diff-4f1c176a31b9dff3ac3aea98ff0474ca2328dacd84a7821b215adbf33f198844">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>realtime-mutable-family.test.tsx</strong><dd><code>Drop explicit `port` for mutable family tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4797/files#diff-d1399eb58ab20d40d659906c73aef43f9d373c13604526f489a67b376326a054">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>realtime-mutable.test.tsx</strong><dd><code>Remove `port` parameter in mutable tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4797/files#diff-a8f92ea808733fb2560ae6735e35936cdad34fde071616b86a2ae35717454ac3">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>realtime-pull-regular-atom-family.test.tsx</strong><dd><code>Eliminate fixed `port` in atom-family pull tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4797/files#diff-a1295556da9ffd1f68069d2c2f7fdaad2a7e407305ff3c0bf14d752083a31da5">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>realtime-pull-writable-selector.test.tsx</strong><dd><code>Omit manual `port` in selector observation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4797/files#diff-f1f0d278c6ba9440728d8ec1d6677be7efb50874eb614790a727fe1bcd0679b0">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>realtime-push-regular-atom.test.tsx</strong><dd><code>Remove explicit `port` in push-state tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4797/files#diff-2dbad91da021ef3fc03c29655bc028eb6c7c424679bdc389011f2904d66f844c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>realtime-setup-multiple.test.tsx</strong><dd><code>Drop `port` arg in multi-client setup test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4797/files#diff-b3082b74a39c128c107b02ffbefa47e369cbd7129f2901d6d5648daff1b87833">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>realtime-setup-single.test.tsx</strong><dd><code>Remove `port` from single-client setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4797/files#diff-30e0aa302854f65e7d80228aac6ebb589aa8fc3424c1be6c2e1b6b2b3492ea18">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>realtime-timeline.test.tsx</strong><dd><code>Remove `port` from timeline undo/redo tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4797/files#diff-b037c96607854e3c897c7b2093f04c66e7598200f6b93ca38259cbb76a64e216">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>setup-realtime-test.tsx</strong><dd><code>Drop `port` option and use ephemeral ports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4797/files#diff-96ad0eb99c97d5e8f57344e5836bfdbe849c403f00ba65306fefe81d8e1f4e92">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>