### PR TITLE
♻️ refactor packing into static methods

### DIFF
--- a/.changeset/rare-fans-report.md
+++ b/.changeset/rare-fans-report.md
@@ -1,0 +1,5 @@
+---
+"atom.io": patch
+---
+
+♻️ Improve seralization interface for `OList` and `UList`.

--- a/packages/atom.io/__tests__/public/mutability/o-list.test.ts
+++ b/packages/atom.io/__tests__/public/mutability/o-list.test.ts
@@ -1,16 +1,12 @@
 import type { Fn, Subject } from "atom.io/internal"
 import type { ArrayUpdate } from "atom.io/transceivers/o-list"
-import {
-	OList,
-	packArrayUpdate,
-	unpackArrayUpdate,
-} from "atom.io/transceivers/o-list"
+import { OList } from "atom.io/transceivers/o-list"
 
 import * as U from "../../__util__"
 
 function handleUnpacked(subject: Subject<any>, handler: Fn): void {
 	subject.subscribe(`unpack`, (update: any) => {
-		handler(unpackArrayUpdate(update))
+		handler(OList.unpackUpdate(update))
 	})
 }
 
@@ -291,7 +287,7 @@ describe(`OList`, () => {
 	describe(`do and undo`, () => {
 		it(`set (overwrite existing)`, () => {
 			const ol = new OList<string>(`a`)
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `set`,
 				index: 0,
 				next: `b`,
@@ -306,7 +302,7 @@ describe(`OList`, () => {
 		})
 		it(`set (insert new)`, () => {
 			const ol = new OList<string>(`a`)
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `set`,
 				index: 1,
 				next: `b`,
@@ -321,7 +317,7 @@ describe(`OList`, () => {
 		})
 		it(`set (insert new, make sparse)`, () => {
 			const ol = new OList<string>(`a`)
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `set`,
 				index: 9,
 				next: `b`,
@@ -337,7 +333,7 @@ describe(`OList`, () => {
 		})
 		it(`truncate`, () => {
 			const ol = new OList<string>(`a`, `b`, `c`)
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `truncate`,
 				length: 2,
 				items: [`c`],
@@ -355,7 +351,7 @@ describe(`OList`, () => {
 		})
 		it(`extend`, () => {
 			const ol = new OList<string>(`a`, `b`, `c`)
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `extend`,
 				next: 4,
 				prev: 3,
@@ -374,7 +370,7 @@ describe(`OList`, () => {
 		})
 		it(`fill without start/end`, () => {
 			const ol = new OList<string>(`a`, `b`, `c`)
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `fill`,
 				value: `d`,
 				prev: [`a`, `b`, `c`],
@@ -392,7 +388,7 @@ describe(`OList`, () => {
 		})
 		it(`fill with start/end`, () => {
 			const ol = new OList<string>(`a`, `b`, `c`)
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `fill`,
 				value: `d`,
 				start: 1,
@@ -412,7 +408,7 @@ describe(`OList`, () => {
 		})
 		it(`push`, () => {
 			const ol = new OList<string>()
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `push`,
 				items: [`foo`],
 			} satisfies ArrayUpdate<string>)
@@ -423,7 +419,7 @@ describe(`OList`, () => {
 		})
 		it(`pop without value`, () => {
 			const ol = new OList<string>()
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `pop`,
 			} as ArrayUpdate<string>)
 			ol.do(update)
@@ -433,7 +429,7 @@ describe(`OList`, () => {
 		})
 		it(`pop with value`, () => {
 			const ol = new OList<string>(`a`)
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `pop`,
 				value: `a`,
 			} satisfies ArrayUpdate<string>)
@@ -445,7 +441,7 @@ describe(`OList`, () => {
 		})
 		it(`shift without value`, () => {
 			const ol = new OList<string>(`a`)
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `shift`,
 			} as ArrayUpdate<string>)
 			ol.do(update)
@@ -455,7 +451,7 @@ describe(`OList`, () => {
 		})
 		it(`shift with value`, () => {
 			const ol = new OList<string>(`a`)
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `shift`,
 				value: `a`,
 			} satisfies ArrayUpdate<string>)
@@ -467,7 +463,7 @@ describe(`OList`, () => {
 		})
 		it(`unshift`, () => {
 			const ol = new OList<string>()
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `unshift`,
 				items: [`foo`],
 			} satisfies ArrayUpdate<string>)
@@ -478,7 +474,7 @@ describe(`OList`, () => {
 		})
 		it(`reverse`, () => {
 			const ol = new OList<string>(`a`, `b`, `c`)
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `reverse`,
 			} as ArrayUpdate<string>)
 			ol.do(update)
@@ -492,7 +488,7 @@ describe(`OList`, () => {
 		})
 		it(`sort`, () => {
 			const ol = new OList<string>(`a`, `b`, `c`)
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `sort`,
 				next: [`c`, `b`, `a`],
 				prev: [`a`, `b`, `c`],
@@ -508,7 +504,7 @@ describe(`OList`, () => {
 		})
 		it(`splice without deleteCount`, () => {
 			const ol = new OList<string>(`a`, `b`, `c`)
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `splice`,
 				start: 1,
 				deleted: [`b`, `c`],
@@ -526,7 +522,7 @@ describe(`OList`, () => {
 		})
 		it(`splice with deleteCount 0 and items`, () => {
 			const ol = new OList<string>(`a`, `b`, `c`)
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `splice`,
 				start: 1,
 				deleteCount: 0,
@@ -546,7 +542,7 @@ describe(`OList`, () => {
 		})
 		it(`splice with deleteCount 1 and items`, () => {
 			const ol = new OList<string>(`a`, `b`, `c`)
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `splice`,
 				start: 0,
 				deleteCount: 1,
@@ -564,7 +560,7 @@ describe(`OList`, () => {
 		})
 		it(`copyWithin`, () => {
 			const ol = new OList<string>(`a`, `b`, `c`, `d`)
-			const update = packArrayUpdate({
+			const update = OList.packUpdate({
 				type: `copyWithin`,
 				prev: OList.fromJSON([`c`, `d`]),
 				target: 2,

--- a/packages/atom.io/__tests__/public/mutability/u-list.test.ts
+++ b/packages/atom.io/__tests__/public/mutability/u-list.test.ts
@@ -1,6 +1,6 @@
 import type { primitive } from "atom.io/json"
 import type { SetUpdate } from "atom.io/transceivers/u-list"
-import { packSetUpdate, UList } from "atom.io/transceivers/u-list"
+import { UList } from "atom.io/transceivers/u-list"
 
 import * as U from "../../__util__"
 
@@ -93,7 +93,7 @@ describe(`UList`, () => {
 	describe(`do/undo`, () => {
 		it(`should add a value to the ul - strings`, () => {
 			const ul = new UList<string>()
-			const update = packSetUpdate({
+			const update = UList.packUpdate({
 				type: `add`,
 				value: `foo`,
 			} satisfies SetUpdate<string>)
@@ -104,7 +104,7 @@ describe(`UList`, () => {
 		})
 		it(`should add a value to the ul - numbers`, () => {
 			const ul = new UList<number>()
-			const update = packSetUpdate({
+			const update = UList.packUpdate({
 				type: `add`,
 				value: 5,
 			} satisfies SetUpdate<number>)
@@ -115,7 +115,7 @@ describe(`UList`, () => {
 		})
 		it(`should add a value to the ul - null`, () => {
 			const ul = new UList<null>()
-			const update = packSetUpdate({
+			const update = UList.packUpdate({
 				type: `add`,
 				value: null,
 			} satisfies SetUpdate<null>)
@@ -126,7 +126,7 @@ describe(`UList`, () => {
 		})
 		it(`should clear the ul - strings`, () => {
 			const ul = new UList<string>(`y`)
-			const update = packSetUpdate({
+			const update = UList.packUpdate({
 				type: `clear`,
 				values: [`y`],
 			} satisfies SetUpdate<string>)
@@ -137,7 +137,7 @@ describe(`UList`, () => {
 		})
 		it(`should clear the ul - assorted`, () => {
 			const ul = new UList<primitive>([3, `y`, null, false])
-			const update = packSetUpdate({
+			const update = UList.packUpdate({
 				type: `clear`,
 				values: [3, `y`, null, false],
 			} satisfies SetUpdate<primitive>)
@@ -148,7 +148,7 @@ describe(`UList`, () => {
 		})
 		it(`should delete a value from the ul`, () => {
 			const ul = new UList([true])
-			const update = packSetUpdate({
+			const update = UList.packUpdate({
 				type: `delete`,
 				value: true,
 			} satisfies SetUpdate<boolean>)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Convert free pack/unpack to static methods

- Update OList/UList to use static methods

- Replace test calls with static packUpdate/unpackUpdate

- Remove deprecated pack/unpack functions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>o-list.test.ts</strong><dd><code>Use OList static pack/unpack in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/public/mutability/o-list.test.ts

<li>Removed packArrayUpdate/unpackArrayUpdate imports<br> <li> Replaced with <code>OList.packUpdate</code> and <code>OList.unpackUpdate</code><br> <li> Updated all test calls accordingly


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4893/files#diff-4c3b7e7c6da3eb00794c20de807079f8fad2079eeb523e8204e4e7f102a3c061">+21/-25</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>u-list.test.ts</strong><dd><code>Use UList static pack/unpack in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/__tests__/public/mutability/u-list.test.ts

<li>Removed packSetUpdate imports<br> <li> Replaced with <code>UList.packUpdate</code> and <code>UList.unpackUpdate</code><br> <li> Updated test operations to use class methods


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4893/files#diff-1c4403257c52ba47097264f8e6a6d2f1e831c1519ff5399fa6d931322291aa98">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>o-list.ts</strong><dd><code>Move pack/unpack into OList static methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/transceivers/o-list/o-list.ts

<li>Deleted free functions packArrayUpdate/unpackArrayUpdate<br> <li> Added static <code>OList.packUpdate</code> and <code>OList.unpackUpdate</code><br> <li> Updated emit/do/undo to call static methods


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4893/files#diff-4bcb30f533fe34844f14b06042bc44281f4cc892b31554aaf080881f00d30c81">+162/-162</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>u-list.ts</strong><dd><code>Move pack/unpack into UList static methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/atom.io/src/transceivers/u-list/u-list.ts

<li>Removed <code>packSetUpdate</code> and <code>unpackSetUpdate</code> functions<br> <li> Introduced static <code>UList.packUpdate</code> and <code>UList.unpackUpdate</code><br> <li> Adjusted emit/do/undo to use static methods


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/4893/files#diff-bff54e0548fb00989119967d85be3ba16746c9806ecb06cdee7a6bacfc028e87">+24/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>