### PR TITLE
🐛 fix missing utilities

### DIFF
--- a/packages/occlusion/test/perspective.test.ts
+++ b/packages/occlusion/test/perspective.test.ts
@@ -1,5 +1,29 @@
-import { ID } from "../../../apps/core.wayfarer.quest/test/test-utils"
+import { mapObject } from "anvl/object"
+import type { ReadonlyRecord } from "fp-ts/ReadonlyRecord"
+
 import { Perspective } from "../src"
+
+function* createIterator(callback: (idx: number) => string): Generator<string> {
+	let currentIteration = 0
+
+	while (true) {
+		yield callback(currentIteration)
+		currentIteration++
+	}
+}
+
+const IDX_ID = {
+	style_000000_$: (idx: number) => `_${idx}`.padStart(8, `0`),
+	style_$_000000: (idx: number) => `${idx}_`.padEnd(8, `0`),
+} as const
+
+const ID: ReadonlyRecord<keyof typeof IDX_ID, () => () => string> = mapObject(
+	IDX_ID,
+	(callback) => () => {
+		const iterator = createIterator(callback)
+		return () => iterator.next().value
+	},
+)
 
 const idFn = ID.style_000000_$()
 


### PR DESCRIPTION
### **PR Type**
Tests, Bug fix


___

### **Description**
- Added custom ID generator utilities in tests

- Introduced `createIterator` for sequential ID strings

- Removed missing `ID` import from test-utils

- Used `mapObject` to derive reusable ID creators


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>perspective.test.ts`</strong><dd><code>Add custom ID generator utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`packages/occlusion/test/perspective.test.ts`

<li>Imported <code>mapObject</code> and <code>ReadonlyRecord</code> types<br> <li> Added <code>createIterator</code> generator function<br> <li> Defined <code>IDX_ID</code> formatting callbacks<br> <li> Generated <code>ID</code> creators via <code>mapObject</code>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr><tr><td><strong>Additional files</strong></td><td><table>
<tr>
  <td><strong>perspective.test.ts</strong></td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/5106/files#diff-e2dab3f7ebbe087ff9d2582fcedf8f5909fcbba33cbabdd114309257313619ec">+25/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>