### PR TITLE
node launch homebrew

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,10 +2,10 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
+			"name": "Debug Vitest with /opt/homebrew/bin/node",
 			"type": "node",
 			"request": "launch",
 			"runtimeExecutable": "/opt/homebrew/bin/node",
-			"name": "Debug Current Test File",
 			"autoAttachChildProcesses": true,
 			"skipFiles": ["<node_internals>/**", "**/node_modules/**"],
 			"cwd": "${workspaceRoot}/packages/atom.io",
@@ -15,9 +15,9 @@
 			"console": "integratedTerminal"
 		},
 		{
+			"name": "Debug Bun",
 			"type": "bun",
 			"request": "launch",
-			"name": "Debug Bun",
 			"program": "${file}",
 			"args": [],
 			"cwd": "${workspaceFolder}",
@@ -30,14 +30,14 @@
 			"runtimeArgs": []
 		},
 		{
+			"name": "Attach to Bun",
 			"type": "bun",
 			"request": "attach",
-			"name": "Attach to Bun",
 			"url": "ws://localhost:6499/"
 		},
 		{
+			"name": "Astro Development Server",
 			"command": "./node_modules/.bin/astro dev",
-			"name": "Development server",
 			"request": "launch",
 			"type": "node-terminal"
 		}


### PR DESCRIPTION
### **User description**
- **🔧 use direct path to node runtime executable**
- **🔧 cleanup and better naming**


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Add Node path for Vitest debugging

- Rename launch configurations for clarity

- Keep Bun and Astro entries consistent

- Improve VS Code launch usability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VS Code launch.json"] -- "set runtimeExecutable" --> B["/opt/homebrew/bin/node for Vitest"]
  A -- "rename configs" --> C["Debug Bun, Attach to Bun, Astro Dev"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>launch.json</strong><dd><code>Specify Homebrew Node and tidy launch names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.vscode/launch.json

<ul><li>Set <code>runtimeExecutable</code> to <code>/opt/homebrew/bin/node</code> for Vitest.<br> <li> Rename Node config to <code>Debug Vitest with /opt/homebrew/bin/node</code>.<br> <li> Normalize names: <code>Debug Bun</code>, <code>Attach to Bun</code>, <code>Astro Development Server</code>.<br> <li> Remove redundant/old <code>name</code> fields and adjust ordering.</ul>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/5474/files#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

