### PR TITLE
🐛 fix issue where username changes wouldn't be represented in-game

### DIFF
--- a/apps/tempest.games/src/backend/websockets.ts
+++ b/apps/tempest.games/src/backend/websockets.ts
@@ -1,5 +1,5 @@
 import { type } from "arktype"
-import { findState } from "atom.io"
+import { disposeState, findState, resetState, setState } from "atom.io"
 import { IMPLICIT } from "atom.io/internal"
 import { mutualUsersSelector, type UserKey } from "atom.io/realtime"
 import type { Handshake, UserServerConfig } from "atom.io/realtime-server"
@@ -97,10 +97,13 @@ export const serveSocket = (config: UserServerConfig): (() => void) => {
 			.update(users)
 			.set({ username })
 			.where(eq(users.id, rawUserId))
+		setState(usernameAtoms, consumer, username)
 		socket.emit(`usernameChanged`, username)
 	})
 
 	return () => {
 		for (const unsub of unsubFunctions) unsub()
+		disposeState(usernameAtoms, consumer)
+		disposeState(mutualUsersSelector, consumer)
 	}
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Sync in-game username after DB update

- Update local state via `setState`

- Cleanup per-consumer state on disconnect


___

### Diagram Walkthrough


```mermaid
flowchart LR
  db["DB: users.username updated"]
  state["Atom state: usernameAtoms set"]
  socket["Socket: emit usernameChanged"]
  cleanup["On dispose: clear per-consumer state"]

  db -- "after update" --> state
  state -- "reflect change" --> socket
  socket -- "client notified" --> client["Client UI updates"]
  cleanup -- "dispose" --> usernameAtoms["usernameAtoms"]
  cleanup -- "dispose" --> mutualUsers["mutualUsersSelector"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>websockets.ts</strong><dd><code>Propagate username to atom state and dispose on teardown</code>&nbsp; </dd></summary>
<hr>

apps/tempest.games/src/backend/websockets.ts

<ul><li>Import <code>disposeState</code>, <code>resetState</code>, <code>setState</code>.<br> <li> After DB update, call <code>setState(usernameAtoms, consumer, username)</code>.<br> <li> Emit <code>usernameChanged</code> over socket as before.<br> <li> On teardown, dispose <code>usernameAtoms</code> and <code>mutualUsersSelector</code> for <br>consumer.</ul>


</details>


  </td>
  <td><a href="https://github.com/jeremybanka/wayforge/pull/5719/files#diff-fb5ed11e050e87c8e94789f32b5a0c7a85f162e04700c87d698c2bd16d21466f">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

