### PR TITLE
hardening

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Install Mise
-      uses: jdx/mise-action@v4.0.1
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
         version: 2026.5.6
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 9
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - run: pnpm fmt
       - run: pnpm lint:biome
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 9
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - run: pnpm lint:deps
 
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 9
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - run: pnpm lint:eslint
 
@@ -49,6 +49,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 9
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - run: pnpm lint:types

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,15 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  TURBO_API: ${{ secrets.TURBO_API }}
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAMID: ${{ vars.TURBO_TEAMID }}
-
-permissions:
-  contents: write
-  id-token: write
-
 jobs:
   Release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: ["main"]
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,8 +14,17 @@ jobs:
     timeout-minutes: 9
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
         with:
-          token: ${{ secrets.CHANGESETS_GITHUB_PAT }}
+          client-id: ${{ vars.CHANGESETS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CHANGESETS_APP_PRIVATE_KEY }}
+          owner: jeremybanka
+          repositories: wayforge
+          permission-contents: write
+          permission-pull-requests: write
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - uses: ./.github/actions/setup
       - uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         id: changesets
@@ -27,8 +33,7 @@ jobs:
           publish: pnpm release
           version: ./lib/version.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.CHANGESETS_GITHUB_PAT }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       # - name: klaxon
       #   if: steps.changesets.outputs.hasChangesets == 'false'
       #   run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 9
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           token: ${{ secrets.CHANGESETS_GITHUB_PAT }}
       - uses: ./.github/actions/setup
-      - uses: changesets/action@v1.8.0
+      - uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         id: changesets
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CHANGESETS_GITHUB_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: klaxon
-        if: steps.changesets.outputs.hasChangesets == 'false'
-        run: |
-          bun ./packages/flightdeck/src/klaxon.x.ts \
-          --packageConfig='{"tempest.games":{"endpoint":"https://flightdeck.tempest.games/"}}' \
-          --secretsConfig='${{ secrets.FLIGHTDECK_SECRETS }}' \
-          --publishedPackages='${{ steps.changesets.outputs.publishedPackages }}' \
-          -- scramble
+      # - name: klaxon
+      #   if: steps.changesets.outputs.hasChangesets == 'false'
+      #   run: |
+      #     bun ./packages/flightdeck/src/klaxon.x.ts \
+      #     --packageConfig='{"tempest.games":{"endpoint":"https://flightdeck.tempest.games/"}}' \
+      #     --secretsConfig='${{ secrets.FLIGHTDECK_SECRETS }}' \
+      #     --publishedPackages='${{ steps.changesets.outputs.publishedPackages }}' \
+      #     -- scramble

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -26,6 +26,16 @@ jobs:
     name: Discover Upgrades
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.RENOVATE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+          owner: jeremybanka
+          repositories: wayforge
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         env:
@@ -34,4 +44,4 @@ jobs:
           RENOVATE_REPOSITORIES: jeremybanka/wayforge
         with:
           configurationFile: renovate.json
-          token: ${{ secrets.RENOVATE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,8 +23,8 @@ jobs:
     name: Discover Upgrades
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: renovatebot/github-action@v46.1.14
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         env:
           LOG_LEVEL: debug
           RENOVATE_ALLOW_PLUGINS: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,13 +73,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
-      - run: |
-          printenv > packages/atom.io/.env
-          printenv > packages/treetrunks/.env
-        env:
-          RECOVERAGE_CLOUD_TOKEN: ${{ secrets.RECOVERAGE_CLOUD_TOKEN }}
       - run: git rev-parse HEAD > git.sha
       - run: pnpm test:coverage:increased
+        env:
+          RECOVERAGE_CLOUD_TOKEN: ${{ secrets.RECOVERAGE_CLOUD_TOKEN }}
 
   BreakCheck:
     name: Break Check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,10 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 1s --health-timeout 0.5s --health-retries 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - run: pnpm run test
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:
           name: Varmint
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 9
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - run: pnpm run build
 
@@ -68,7 +68,7 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 1s --health-timeout 0.5s --health-retries 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - run: |
           printenv > packages/atom.io/.env
@@ -94,6 +94,6 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 1s --health-timeout 0.5s --health-retries 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - run: pnpm test:semver

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,3 +13,4 @@ allowBuilds:
   "sharp": true
   "unrs-resolver": true
   "workerd": true
+blockExoticSubdeps: true

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
 			"customType": "regex",
 			"managerFilePatterns": ["/^\\.github\\/actions\\/setup\\/action\\.yml$/"],
 			"matchStrings": [
-				"uses: jdx\\/mise-action@v\\S+\\s+      with:\\s+        version: (?<currentValue>\\S+)"
+				"uses: jdx\\/mise-action@\\S+(?:\\s+#.*)?\\s+      with:\\s+        version: (?<currentValue>\\S+)"
 			],
 			"depNameTemplate": "jdx/mise",
 			"datasourceTemplate": "github-releases",

--- a/turbo.json
+++ b/turbo.json
@@ -53,7 +53,8 @@
 		},
 		"test:coverage:increased": {
 			"dependsOn": ["test:coverage:once"],
-			"cache": false
+			"cache": false,
+			"passThroughEnv": ["RECOVERAGE_CLOUD_TOKEN"]
 		},
 		"test:semver": {
 			"dependsOn": ["^build"],


### PR DESCRIPTION
- **📍 pin exact SHAs of actions**
- **🔧 block exotic subdeps with pnpm 11**
- **🔧 only allow GITHUB_TOKEN in workflows to read**
- **♻️ pass RECOVERAGE_CLOUD_TOKEN directly, not via printenv**
- **♻️ create an app token instead of using a PAT for renovate**
- **🥅 don't build from turbo cache when preparing release**
- **🔧 disable klaxon for now while tempest.games is offline**
- **♻️ create an app token for release.yml also**
