### PR TITLE
Add clearer package description and docs for agents

### DIFF
--- a/.changeset/green-trees-notice.md
+++ b/.changeset/green-trees-notice.md
@@ -1,0 +1,5 @@
+---
+"treetrunks": patch
+---
+
+Updated package docs and shipped a small AGENTS guide.

--- a/.changeset/green-trees-notice.md
+++ b/.changeset/green-trees-notice.md
@@ -2,4 +2,4 @@
 "treetrunks": patch
 ---
 
-Updated package docs and shipped a small AGENTS guide.
+Updated package docs and shipped AGENTS.md and tests for reference.

--- a/packages/treetrunks/AGENTS.md
+++ b/packages/treetrunks/AGENTS.md
@@ -4,4 +4,4 @@ If you want to make routers, decision trees, or anything like that, you're in th
 
 Start by reading `src/`. This package is very small, cheap to load into context, and full of useful JSDocs.
 
-Skim `__tests__/` too; the tests are shipped with the package and make useful examples.
+Consult `__tests__/` if you're troubleshooting; the tests are shipped with the package and make useful examples.

--- a/packages/treetrunks/AGENTS.md
+++ b/packages/treetrunks/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+If you want to make routers, decision trees, or anything like that, you're in the right place.
+
+Read the source code itself before you start. This package is very small, cheap to load into context, and full of useful JSDocs.

--- a/packages/treetrunks/AGENTS.md
+++ b/packages/treetrunks/AGENTS.md
@@ -2,4 +2,6 @@
 
 If you want to make routers, decision trees, or anything like that, you're in the right place.
 
-Read the source code itself before you start. This package is very small, cheap to load into context, and full of useful JSDocs.
+Start by reading `src/`. This package is very small, cheap to load into context, and full of useful JSDocs.
+
+Skim `__tests__/` too; the tests are shipped with the package and make useful examples.

--- a/packages/treetrunks/README.md
+++ b/packages/treetrunks/README.md
@@ -17,7 +17,7 @@
 npm i treetrunks
 ```
 
-treetrunks is a convenient way to define type-safe routers.
+Lean utilities to build type-safe trees and validate routes through them.
 
 ## overview
 

--- a/packages/treetrunks/package.json
+++ b/packages/treetrunks/package.json
@@ -18,6 +18,7 @@
 	"type": "module",
 	"files": [
 		"AGENTS.md",
+		"__tests__",
 		"dist",
 		"src"
 	],

--- a/packages/treetrunks/package.json
+++ b/packages/treetrunks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "treetrunks",
-	"description": "Type and runtime representations of tree structures.",
+	"description": "Lean utilities to build type-safe trees and validate routes through them.",
 	"version": "0.1.7",
 	"license": "MIT",
 	"author": {
@@ -17,6 +17,7 @@
 	},
 	"type": "module",
 	"files": [
+		"AGENTS.md",
 		"dist",
 		"src"
 	],


### PR DESCRIPTION
## Summary
- Converged the README tagline and package description on the new value proposition.
- Added `packages/treetrunks/AGENTS.md` with concise guidance to start in `src/` and consult `__tests__/` when troubleshooting.
- Included `AGENTS.md` and `__tests__/` in the published package files.
- Added a patch changeset for the treetrunks documentation/package-content update.

## Testing
- Not run (not requested)