### PR TITLE
comline allows missing equals sign

### DIFF
--- a/.changeset/smart-comline-switches.md
+++ b/.changeset/smart-comline-switches.md
@@ -1,0 +1,7 @@
+---
+"comline": minor
+---
+
+Allow long switches and short flags to accept values from the following command
+line argument, so `--option value` and `-o value` work the same as
+`--option=value` and `-o=value`.

--- a/.changeset/standard-comline-schema.md
+++ b/.changeset/standard-comline-schema.md
@@ -1,0 +1,6 @@
+---
+"comline": minor
+---
+
+Use Standard Schema and Standard JSON Schema as the shared integration point for
+schema validation, help output, JSON Schema export, and option arity detection.

--- a/packages/comline/README.md
+++ b/packages/comline/README.md
@@ -110,15 +110,15 @@ greet(inputs.opts.name, inputs.opts.age)
 
 - [x] switches (`--age`)
   - `""` will be provided to the option parser for `age` in this case
-- [x] switches with values (`--age=1`)
+- [x] switches with values (`--age=1`, `--age 1`)
   - `"1"` will be provided to the option parser for `age` in this case
-- [x] multiple instances of the same switch (`--age=1 --age=2`)
+- [x] multiple instances of the same switch (`--age=1 --age 2`)
   - `"1,2"` will be provided to the option parser for `age` in this case
 - [x] flags (`-a`)
   - `""` will be provided to the option parser for `age` in this case
 - [x] multiple instances of the same flag (`-aa`)
   - `","` will be provided to the option parser for `age` in this case
-- [x] flags with values (`-a=1`)
+- [x] flags with values (`-a=1`, `-a 1`)
   - `"1"` will be provided to the option parser for `age` in this case
 - [x] combined flags (`-na`)
   - `""` will be provided to the option parser for `name` in this case
@@ -179,5 +179,4 @@ comline exports these parser helpers:
 ## limitations
 
 - comline supports positional arguments, but only following the `--` convention.
-- comline supports options with values, but only when using `=` to separate the option name from the value.
 - flags are supported, but they must be single characters, either uppercase or lowercase.

--- a/packages/comline/README.md
+++ b/packages/comline/README.md
@@ -120,6 +120,12 @@ greet(inputs.opts.name, inputs.opts.age)
   - `","` will be provided to the option parser for `age` in this case
 - [x] flags with values (`-a=1`, `-a 1`)
   - `"1"` will be provided to the option parser for `age` in this case
+- [ ] JSON Schema composition in value-consuming option heuristics
+  - recognize boolean-like option schemas through wrappers like `anyOf`, `oneOf`,
+    and `allOf`
+  - for example, a CLI author could model a nullable boolean option as
+    `z.boolean().nullable().optional()` and still have `my-cli --dry-run start`
+    treat `--dry-run` as a bare boolean switch instead of consuming `start`
 - [x] combined flags (`-na`)
   - `""` will be provided to the option parser for `name` in this case
   - `""` will be provided to the option parser for `age` in this case

--- a/packages/comline/__tests__/config-file.test.ts
+++ b/packages/comline/__tests__/config-file.test.ts
@@ -4,6 +4,7 @@ import path from "node:path"
 
 import { type } from "arktype"
 import { required } from "treetrunks"
+import z from "zod"
 
 import { cli, options } from "../src/cli"
 import { parseStringOption } from "../src/option-parsers"
@@ -59,21 +60,28 @@ describe(`options from file`, () => {
 })
 
 describe(`creating a config schema`, () => {
-	const testCli = cli({
+	const optionConfigs = {
+		foo: {
+			description: `foo`,
+			example: `--foo=hello`,
+			flag: `f` as const,
+			parse: parseStringOption,
+			required: true,
+		},
+	}
+	const arktypeTestCli = cli({
 		cliName: `my-cli`,
 		routeOptions: {
-			"": options(`blah`, type({ foo: `string` }), {
-				foo: {
-					description: `foo`,
-					example: `--foo=hello`,
-					flag: `f`,
-					parse: parseStringOption,
-					required: true,
-				},
-			}),
+			"": options(`blah`, type({ foo: `string` }), optionConfigs),
 		},
 	})
-	test(`happy: export a schema`, () => {
+	const zodTestCli = cli({
+		cliName: `my-cli`,
+		routeOptions: {
+			"": options(`blah`, z.object({ foo: z.string() }), optionConfigs),
+		},
+	})
+	function expectWritesExampleSchema(testCli: ReturnType<typeof cli>): void {
 		const { writeJsonSchema } = testCli([`--foo=hello`])
 		writeJsonSchema(`${tempDir}`)
 		const jsonSchemaContents = JSON.parse(
@@ -89,5 +97,11 @@ describe(`creating a config schema`, () => {
 		)
 		const jsonSchemaFixture = JSON.parse(jsonSchemaFixtureContentsString)
 		expect(jsonSchemaContents).toEqual(jsonSchemaFixture)
+	}
+	test(`happy: export an arktype schema`, () => {
+		expectWritesExampleSchema(arktypeTestCli)
+	})
+	test(`happy: export a zod schema`, () => {
+		expectWritesExampleSchema(zodTestCli)
 	})
 })

--- a/packages/comline/__tests__/options.test.ts
+++ b/packages/comline/__tests__/options.test.ts
@@ -37,6 +37,20 @@ describe(`options from cli`, () => {
 			bar: 1,
 		})
 	})
+	test(`happy: all options without equals signs`, () => {
+		const { inputs } = testCli([`--foo`, `hello`, `--bar`, `1`])
+		expect(inputs.opts).toEqual({
+			foo: `hello`,
+			bar: 1,
+		})
+	})
+	test(`happy: flags with values without equals signs`, () => {
+		const { inputs } = testCli([`-f`, `hello`, `-b`, `1`])
+		expect(inputs.opts).toEqual({
+			foo: `hello`,
+			bar: 1,
+		})
+	})
 	test(`happy: missing optional options`, () => {
 		const { inputs } = testCli([`--foo=hello`, `-bb`, `--help`])
 		expect(inputs.opts).toEqual({
@@ -44,11 +58,21 @@ describe(`options from cli`, () => {
 			bar: 2,
 		})
 	})
+	test(`happy: bare options remain bare before other options`, () => {
+		const { inputs } = testCli([`--foo`, `--bar`, `1`])
+		expect(inputs.opts).toEqual({
+			foo: ``,
+			bar: 1,
+		})
+	})
 	test(`error: missing required options`, () => {
 		expect(() => testCli([`--bar=1`])).toThrow()
 	})
 	test(`error: wrong types`, () => {
 		expect(() => testCli([`--foo=hello`, `--bar=hello`])).toThrow()
+	})
+	test(`error: switch names must match exactly`, () => {
+		expect(() => testCli([`--foobar=hello`])).toThrow()
 	})
 })
 
@@ -69,6 +93,14 @@ describe(`complex options`, () => {
 	})
 	test(`happy: all options`, () => {
 		const { inputs } = testCli([`--rules={"rule0": ["a", "b"]}`])
+		expect(inputs.opts).toEqual({
+			rules: {
+				rule0: [`a`, `b`],
+			},
+		})
+	})
+	test(`happy: all options without equals signs`, () => {
+		const { inputs } = testCli([`--rules`, `{"rule0": ["a", "b"]}`])
 		expect(inputs.opts).toEqual({
 			rules: {
 				rule0: [`a`, `b`],

--- a/packages/comline/__tests__/options.test.ts
+++ b/packages/comline/__tests__/options.test.ts
@@ -44,6 +44,20 @@ describe(`options from cli`, () => {
 			bar: 1,
 		})
 	})
+	test(`happy: negative number values without equals signs`, () => {
+		const { inputs } = testCli([`--foo`, `hello`, `--bar`, `-1`])
+		expect(inputs.opts).toEqual({
+			foo: `hello`,
+			bar: -1,
+		})
+	})
+	test(`happy: dash-prefixed string values without equals signs`, () => {
+		const { inputs } = testCli([`--foo`, `-literal`, `--bar`, `1`])
+		expect(inputs.opts).toEqual({
+			foo: `-literal`,
+			bar: 1,
+		})
+	})
 	test(`happy: repeated options with mixed value separators`, () => {
 		const { inputs } = testCli([`--foo`, `one`, `--foo=two`])
 		expect(inputs.opts).toEqual({

--- a/packages/comline/__tests__/options.test.ts
+++ b/packages/comline/__tests__/options.test.ts
@@ -44,6 +44,12 @@ describe(`options from cli`, () => {
 			bar: 1,
 		})
 	})
+	test(`happy: repeated options with mixed value separators`, () => {
+		const { inputs } = testCli([`--foo`, `one`, `--foo=two`])
+		expect(inputs.opts).toEqual({
+			foo: `one,two`,
+		})
+	})
 	test(`happy: flags with values without equals signs`, () => {
 		const { inputs } = testCli([`-f`, `hello`, `-b`, `1`])
 		expect(inputs.opts).toEqual({

--- a/packages/comline/__tests__/positional-args.test.ts
+++ b/packages/comline/__tests__/positional-args.test.ts
@@ -95,3 +95,43 @@ describe(`options and positional args from cli`, () => {
 		expect(inputs.path).toEqual([`yo`])
 	})
 })
+
+describe(`options without equals signs and positional args from cli`, () => {
+	const optionGroup = options(`blah`, type({ "with-option": `string` }), {
+		"with-option": {
+			description: `with option`,
+			example: `--with-option=so-and-so`,
+			parse: parseStringOption,
+			required: true,
+		},
+	})
+
+	const testCli = cli({
+		cliName: `my-cli`,
+		routes: required({ "do-thing": null }),
+		routeOptions: {
+			"do-thing": optionGroup,
+		},
+	})
+	test(`happy: positional args with option values separated by spaces`, () => {
+		const { inputs } = testCli([
+			`/some-random-path/my-cli`,
+			`do-thing`,
+			`--with-option`,
+			`so-and-so`,
+		])
+		expect(inputs.case).toEqual(`do-thing`)
+		expect(inputs.opts).toEqual({ "with-option": `so-and-so` })
+		expect(inputs.path).toEqual([`do-thing`])
+	})
+	test(`happy: positional args with option values separated by equals signs`, () => {
+		const { inputs } = testCli([
+			`/some-random-path/my-cli`,
+			`do-thing`,
+			`--with-option=so-and-so`,
+		])
+		expect(inputs.case).toEqual(`do-thing`)
+		expect(inputs.opts).toEqual({ "with-option": `so-and-so` })
+		expect(inputs.path).toEqual([`do-thing`])
+	})
+})

--- a/packages/comline/__tests__/positional-args.test.ts
+++ b/packages/comline/__tests__/positional-args.test.ts
@@ -1,5 +1,6 @@
 import { type } from "arktype"
 import { optional, required } from "treetrunks"
+import z from "zod"
 
 import { cli, options } from "../src/cli"
 import { parseBooleanOption, parseStringOption } from "../src/option-parsers"
@@ -283,5 +284,64 @@ describe(`options before positional args from cli`, () => {
 		expect(inputs.case).toEqual(`inspect/$target`)
 		expect(inputs.opts).toEqual({ name: `example` })
 		expect(inputs.path).toEqual([`inspect`, `service-a`])
+	})
+})
+
+describe(`zod boolean options before positional args from cli`, () => {
+	const makeTestCli = (
+		optionGroup: ReturnType<typeof options<{ "dry-run"?: boolean | undefined }>>,
+	) =>
+		cli({
+			cliName: `my-cli`,
+			routes: required({ set: required({ $enabled: null }) }),
+			routeOptions: {
+				"set/$enabled": optionGroup,
+			},
+		})
+
+	test(`happy: optional boolean switch before positional args`, () => {
+		const testCli = makeTestCli(
+			options(`blah`, z.object({ "dry-run": z.boolean().optional() }), {
+				"dry-run": {
+					description: `dry run`,
+					example: `--dry-run`,
+					flag: `d`,
+					parse: parseBooleanOption,
+					required: false,
+				},
+			}),
+		)
+		const { inputs } = testCli([
+			`/some-random-path/my-cli`,
+			`--dry-run`,
+			`set`,
+			`true`,
+		])
+		expect(inputs.case).toEqual(`set/$enabled`)
+		expect(inputs.opts).toEqual({ "dry-run": true })
+		expect(inputs.path).toEqual([`set`, `true`])
+	})
+
+	test(`happy: defaulted boolean switch before positional args`, () => {
+		const testCli = makeTestCli(
+			options(`blah`, z.object({ "dry-run": z.boolean().default(false) }), {
+				"dry-run": {
+					description: `dry run`,
+					example: `--dry-run`,
+					flag: `d`,
+					parse: parseBooleanOption,
+					required: false,
+				},
+			}),
+		)
+		const { inputs } = testCli([
+			`/some-random-path/my-cli`,
+			`--dry-run`,
+			`set`,
+			`true`,
+		])
+		expect(inputs.case).toEqual(`set/$enabled`)
+		expect(inputs.opts).toEqual({ "dry-run": true })
+		expect(inputs.path).toEqual([`set`, `true`])
 	})
 })

--- a/packages/comline/__tests__/positional-args.test.ts
+++ b/packages/comline/__tests__/positional-args.test.ts
@@ -211,6 +211,26 @@ describe(`options before positional args from cli`, () => {
 		expect(inputs.path).toEqual([`set`, `true`])
 	})
 
+	test(`happy: boolean switch value without equals before positional args`, () => {
+		const testCli = cli({
+			cliName: `my-cli`,
+			routes: required({ set: required({ $enabled: null }) }),
+			routeOptions: {
+				"set/$enabled": switchOptionGroup,
+			},
+		})
+		const { inputs } = testCli([
+			`/some-random-path/my-cli`,
+			`--dry-run`,
+			`false`,
+			`set`,
+			`true`,
+		])
+		expect(inputs.case).toEqual(`set/$enabled`)
+		expect(inputs.opts).toEqual({ "dry-run": false })
+		expect(inputs.path).toEqual([`set`, `true`])
+	})
+
 	test(`happy: bare boolean flag before positional args`, () => {
 		const testCli = cli({
 			cliName: `my-cli`,
@@ -222,6 +242,26 @@ describe(`options before positional args from cli`, () => {
 		const { inputs } = testCli([`/some-random-path/my-cli`, `-d`, `set`, `true`])
 		expect(inputs.case).toEqual(`set/$enabled`)
 		expect(inputs.opts).toEqual({ "dry-run": true })
+		expect(inputs.path).toEqual([`set`, `true`])
+	})
+
+	test(`happy: boolean flag value without equals before positional args`, () => {
+		const testCli = cli({
+			cliName: `my-cli`,
+			routes: required({ set: required({ $enabled: null }) }),
+			routeOptions: {
+				"set/$enabled": switchOptionGroup,
+			},
+		})
+		const { inputs } = testCli([
+			`/some-random-path/my-cli`,
+			`-d`,
+			`false`,
+			`set`,
+			`true`,
+		])
+		expect(inputs.case).toEqual(`set/$enabled`)
+		expect(inputs.opts).toEqual({ "dry-run": false })
 		expect(inputs.path).toEqual([`set`, `true`])
 	})
 

--- a/packages/comline/__tests__/positional-args.test.ts
+++ b/packages/comline/__tests__/positional-args.test.ts
@@ -289,7 +289,9 @@ describe(`options before positional args from cli`, () => {
 
 describe(`zod boolean options before positional args from cli`, () => {
 	const makeTestCli = (
-		optionGroup: ReturnType<typeof options<{ "dry-run"?: boolean | undefined }>>,
+		optionGroup: ReturnType<
+			typeof options<Partial<Record<`dry-run`, boolean | undefined>>>
+		>,
 	) =>
 		cli({
 			cliName: `my-cli`,

--- a/packages/comline/__tests__/positional-args.test.ts
+++ b/packages/comline/__tests__/positional-args.test.ts
@@ -2,7 +2,7 @@ import { type } from "arktype"
 import { optional, required } from "treetrunks"
 
 import { cli, options } from "../src/cli"
-import { parseStringOption } from "../src/option-parsers"
+import { parseBooleanOption, parseStringOption } from "../src/option-parsers"
 
 describe(`positional args from cli`, () => {
 	const testCli = cli({
@@ -108,8 +108,12 @@ describe(`options without equals signs and positional args from cli`, () => {
 
 	const testCli = cli({
 		cliName: `my-cli`,
-		routes: required({ "do-thing": null }),
+		routes: required({
+			deploy: required({ $target: required({ $environment: null }) }),
+			"do-thing": null,
+		}),
 		routeOptions: {
+			"deploy/$target/$environment": optionGroup,
 			"do-thing": optionGroup,
 		},
 	})
@@ -124,6 +128,19 @@ describe(`options without equals signs and positional args from cli`, () => {
 		expect(inputs.opts).toEqual({ "with-option": `so-and-so` })
 		expect(inputs.path).toEqual([`do-thing`])
 	})
+	test(`happy: more positional args with option values separated by spaces`, () => {
+		const { inputs } = testCli([
+			`/some-random-path/my-cli`,
+			`deploy`,
+			`my-app`,
+			`production`,
+			`--with-option`,
+			`so-and-so`,
+		])
+		expect(inputs.case).toEqual(`deploy/$target/$environment`)
+		expect(inputs.opts).toEqual({ "with-option": `so-and-so` })
+		expect(inputs.path).toEqual([`deploy`, `my-app`, `production`])
+	})
 	test(`happy: positional args with option values separated by equals signs`, () => {
 		const { inputs } = testCli([
 			`/some-random-path/my-cli`,
@@ -133,5 +150,65 @@ describe(`options without equals signs and positional args from cli`, () => {
 		expect(inputs.case).toEqual(`do-thing`)
 		expect(inputs.opts).toEqual({ "with-option": `so-and-so` })
 		expect(inputs.path).toEqual([`do-thing`])
+	})
+})
+
+describe(`options before positional args from cli`, () => {
+	const switchOptionGroup = options(`blah`, type({ "dry-run?": `boolean` }), {
+		"dry-run": {
+			description: `dry run`,
+			example: `--dry-run`,
+			flag: `d`,
+			parse: parseBooleanOption,
+			required: false,
+		},
+	})
+	const flagOptionGroup = options(`blah`, type({ "name?": `string` }), {
+		name: {
+			description: `name`,
+			example: `--name=example`,
+			flag: `n`,
+			parse: parseStringOption,
+			required: false,
+		},
+	})
+
+	test(`happy: bare boolean switch before positional args`, () => {
+		const testCli = cli({
+			cliName: `my-cli`,
+			routes: required({ set: required({ $enabled: null }) }),
+			routeOptions: {
+				"set/$enabled": switchOptionGroup,
+			},
+		})
+		const { inputs } = testCli([
+			`/some-random-path/my-cli`,
+			`--dry-run`,
+			`set`,
+			`true`,
+		])
+		expect(inputs.case).toEqual(`set/$enabled`)
+		expect(inputs.opts).toEqual({ "dry-run": true })
+		expect(inputs.path).toEqual([`set`, `true`])
+	})
+
+	test(`happy: flag value before non-boolean positional args`, () => {
+		const testCli = cli({
+			cliName: `my-cli`,
+			routes: required({ inspect: required({ $target: null }) }),
+			routeOptions: {
+				"inspect/$target": flagOptionGroup,
+			},
+		})
+		const { inputs } = testCli([
+			`/some-random-path/my-cli`,
+			`-n`,
+			`example`,
+			`inspect`,
+			`service-a`,
+		])
+		expect(inputs.case).toEqual(`inspect/$target`)
+		expect(inputs.opts).toEqual({ name: `example` })
+		expect(inputs.path).toEqual([`inspect`, `service-a`])
 	})
 })

--- a/packages/comline/__tests__/positional-args.test.ts
+++ b/packages/comline/__tests__/positional-args.test.ts
@@ -192,6 +192,39 @@ describe(`options before positional args from cli`, () => {
 		expect(inputs.path).toEqual([`set`, `true`])
 	})
 
+	test(`happy: boolean switch value before positional args`, () => {
+		const testCli = cli({
+			cliName: `my-cli`,
+			routes: required({ set: required({ $enabled: null }) }),
+			routeOptions: {
+				"set/$enabled": switchOptionGroup,
+			},
+		})
+		const { inputs } = testCli([
+			`/some-random-path/my-cli`,
+			`--dry-run=false`,
+			`set`,
+			`true`,
+		])
+		expect(inputs.case).toEqual(`set/$enabled`)
+		expect(inputs.opts).toEqual({ "dry-run": false })
+		expect(inputs.path).toEqual([`set`, `true`])
+	})
+
+	test(`happy: bare boolean flag before positional args`, () => {
+		const testCli = cli({
+			cliName: `my-cli`,
+			routes: required({ set: required({ $enabled: null }) }),
+			routeOptions: {
+				"set/$enabled": switchOptionGroup,
+			},
+		})
+		const { inputs } = testCli([`/some-random-path/my-cli`, `-d`, `set`, `true`])
+		expect(inputs.case).toEqual(`set/$enabled`)
+		expect(inputs.opts).toEqual({ "dry-run": true })
+		expect(inputs.path).toEqual([`set`, `true`])
+	})
+
 	test(`happy: flag value before non-boolean positional args`, () => {
 		const testCli = cli({
 			cliName: `my-cli`,

--- a/packages/comline/package.json
+++ b/packages/comline/package.json
@@ -22,8 +22,8 @@
 	"main": "dist/cli.js",
 	"types": "dist/cli.d.ts",
 	"peerDependencies": {
-		"arktype": "^2.1.25",
-		"zod": "^4.1.12"
+		"arktype": "^2.1.28",
+		"zod": "^4.2.0"
 	},
 	"peerDependenciesMeta": {
 		"arktype": {

--- a/packages/comline/package.json
+++ b/packages/comline/package.json
@@ -34,6 +34,7 @@
 		}
 	},
 	"dependencies": {
+		"@standard-schema/spec": "1.1.0",
 		"treetrunks": "workspace:*"
 	},
 	"scripts": {

--- a/packages/comline/src/cli.ts
+++ b/packages/comline/src/cli.ts
@@ -1,7 +1,6 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
 
-import type { JsonSchema, Type } from "arktype"
 import type {
 	Flatten,
 	Join,
@@ -10,21 +9,23 @@ import type {
 	TreePath,
 	TreePathName,
 } from "treetrunks"
-import type { ZodObject, ZodType } from "zod"
 
 import type { Flag } from "./flag"
 import { parseStringOption } from "./option-parsers"
 import { retrievePositionalArgs } from "./retrieve-positional-args"
-import { ark, schemaPkg, zod } from "./schema"
+import {
+	emptySchema,
+	type JsonSchema,
+	type OptionsSchema,
+	retrieveInputJsonSchema,
+	validateOptionsSchema,
+} from "./schema"
 
 export * from "./encapsulate"
 export type * from "./flag"
 export * from "./help"
 export * from "./option-parsers"
 export * from "treetrunks"
-
-const emptySchema =
-	`type` in schemaPkg ? schemaPkg.type({}) : schemaPkg.z.object({})
 
 export type CliOptionValue =
 	| Readonly<{ [key: string]: CliOptionValue }>
@@ -46,7 +47,7 @@ export type CliOption<T extends CliOptionValue> = (T extends string
 				parse: (arg: string) => T
 			}) & {
 	flag?: Flag
-	required: T extends undefined ? false : true
+	required: boolean
 	description: string
 	example: string
 }
@@ -69,7 +70,7 @@ export type OptionsGroup<Options extends Record<string, CliOptionValue> | null> 
 	Options extends Record<string, CliOptionValue>
 		? {
 				description: string
-				optionsSchema: Type<Options> | ZodType<Options>
+				optionsSchema: OptionsSchema<Options>
 				optionConfigs: {
 					[K in keyof Options]-?: CliOption<Options[K]>
 				}
@@ -78,7 +79,7 @@ export type OptionsGroup<Options extends Record<string, CliOptionValue> | null> 
 
 export function options<Options extends Record<string, CliOptionValue>>(
 	description: string,
-	optionsSchema: Type<Options> | ZodType<Options>,
+	optionsSchema: OptionsSchema<Options>,
 	optionConfigs: {
 		[K in keyof Options]-?: CliOption<Options[K]>
 	},
@@ -229,17 +230,6 @@ function retrieveArgumentInstances(
 	return instances
 }
 
-function retrieveZodOptionType(
-	optionsSchema: ZodType<any>,
-	key: string,
-): string | undefined {
-	const optionDef = (optionsSchema as ZodObject<any>).shape[key]?._def
-	if (optionDef?.type === `optional`) {
-		return optionDef.innerType._def.type
-	}
-	return optionDef?.type
-}
-
 function jsonSchemaTypeIsBoolean(jsonSchema: JsonSchema | undefined): boolean {
 	if (jsonSchema === undefined || !(`type` in jsonSchema)) {
 		return false
@@ -255,17 +245,12 @@ function optionSchemaIsBoolean(
 	optionsGroup: Exclude<OptionsGroup<any>, null>,
 	key: string,
 ): boolean {
-	const optionsSchema = optionsGroup.optionsSchema
-	if (zod && optionsSchema instanceof zod.ZodType) {
-		return retrieveZodOptionType(optionsSchema, key) === `boolean`
-	}
-	if (ark && optionsSchema instanceof ark.Type) {
-		const jsonSchema = optionsSchema.toJsonSchema() as JsonSchema.Object & {
-			properties?: Record<string, JsonSchema>
-		}
+	try {
+		const jsonSchema = retrieveInputJsonSchema(optionsGroup.optionsSchema)
 		return jsonSchemaTypeIsBoolean(jsonSchema.properties?.[key])
+	} catch {
+		return false
 	}
-	return false
 }
 
 function retrieveOptionValueKind(
@@ -416,15 +401,10 @@ export function cli<
 						cliLogger.info?.(`config file was found`)
 						const configText = fs.readFileSync(configFilePath, `utf-8`)
 						const optionsFromConfigJson = JSON.parse(configText)
-						if (zod && optionsSchema instanceof zod.ZodType) {
-							optionsFromConfig = optionsSchema.parse(
-								optionsFromConfigJson,
-							) as Options
-						} else if (ark && optionsSchema instanceof ark.Type) {
-							optionsFromConfig = optionsSchema.assert(
-								optionsFromConfigJson,
-							) as Options
-						}
+						optionsFromConfig = validateOptionsSchema(
+							optionsSchema,
+							optionsFromConfigJson,
+						) as Options
 					}
 				}
 			}
@@ -482,16 +462,10 @@ export function cli<
 				optionsFromCommandLine,
 			)
 			cliLogger.info?.(`options from command line:`, optionsFromCommandLine)
-			let suppliedOptions: Options
-			if (zod && optionsSchema instanceof zod.ZodType) {
-				suppliedOptions = optionsSchema.parse(suppliedOptionsUnparsed) as Options
-			} else if (ark && optionsSchema instanceof ark.Type) {
-				suppliedOptions = optionsSchema.assert(
-					suppliedOptionsUnparsed,
-				) as Options
-			} else {
-				throw new Error(`Unreachable? Indicates no install of arktype or zod.`)
-			}
+			const suppliedOptions = validateOptionsSchema(
+				optionsSchema,
+				suppliedOptionsUnparsed,
+			) as Options
 			cliLogger.info?.(`final options parsed:`, suppliedOptions)
 			return {
 				inputs: {
@@ -507,19 +481,9 @@ export function cli<
 							continue
 						}
 						const safeRoute = unsafeRoute.replaceAll(`/`, `.`)
-						let jsonSchema: object
-						if (zod && optionsGroup.optionsSchema instanceof zod.ZodType) {
-							jsonSchema = zod.z.toJSONSchema(optionsGroup.optionsSchema)
-						} else if (ark && optionsGroup.optionsSchema instanceof ark.Type) {
-							const arktypeJsonSchema =
-								optionsGroup.optionsSchema.toJsonSchema() as JsonSchema.Object
-							arktypeJsonSchema.additionalProperties = false
-							jsonSchema = arktypeJsonSchema
-						} else {
-							throw new Error(
-								`Unreachable? Indicates no install of arktype or zod.`,
-							)
-						}
+						const jsonSchema = retrieveInputJsonSchema(
+							optionsGroup.optionsSchema,
+						)
 						const filepath = path.resolve(
 							outdir,
 							`${cliName}.${safeRoute || `main`}.schema.json`,

--- a/packages/comline/src/cli.ts
+++ b/packages/comline/src/cli.ts
@@ -98,7 +98,7 @@ export type CommandLineInterface<Routes extends Tree> = {
 type CliOptionConfigEntry = readonly [
 	key: string,
 	config: CliOption<any>,
-	consumesNextArg: boolean,
+	valueKind: OptionValueKind,
 ]
 
 type ArgumentInstance = {
@@ -106,8 +106,16 @@ type ArgumentInstance = {
 	valueIndex?: number
 }
 
+type OptionValueKind = `boolean` | `value`
+
+type KnownOptionTokens = {
+	flags: ReadonlySet<string>
+	switches: ReadonlySet<string>
+}
+
 type RetrieveArgumentInstancesOptions = {
-	consumesNextArg?: boolean
+	knownOptionTokens?: KnownOptionTokens
+	valueKind?: OptionValueKind
 }
 
 function splitOptionValue(
@@ -120,8 +128,39 @@ function splitOptionValue(
 	return [argument.slice(0, equalsIndex), argument.slice(equalsIndex + 1)]
 }
 
-function shouldConsumeNextArg(arg: string | undefined): arg is string {
-	return arg !== undefined && arg !== `--` && !arg.startsWith(`-`)
+function isBooleanLiteral(arg: string): boolean {
+	return arg === `true` || arg === `false` || arg === `0` || arg === `1`
+}
+
+function isKnownOptionToken(
+	arg: string,
+	knownOptionTokens: KnownOptionTokens,
+): boolean {
+	if (!arg.startsWith(`-`)) {
+		return false
+	}
+	const [optionName] = splitOptionValue(arg)
+	if (optionName.startsWith(`--`)) {
+		return knownOptionTokens.switches.has(optionName)
+	}
+	return optionName
+		.slice(1)
+		.split(``)
+		.some((flag) => knownOptionTokens.flags.has(flag))
+}
+
+function shouldConsumeNextArg(
+	arg: string | undefined,
+	valueKind: OptionValueKind,
+	knownOptionTokens: KnownOptionTokens,
+): arg is string {
+	if (arg === undefined || arg === `--`) {
+		return false
+	}
+	if (valueKind === `boolean`) {
+		return isBooleanLiteral(arg)
+	}
+	return !isKnownOptionToken(arg, knownOptionTokens)
 }
 
 function retrieveRepeatedFlagValue(argument: string, flag: string): string {
@@ -139,14 +178,20 @@ function retrieveArgumentInstances(
 	flag?: string,
 	retrieveOptions: RetrieveArgumentInstancesOptions = {},
 ): ArgumentInstance[] {
-	const { consumesNextArg = true } = retrieveOptions
+	const {
+		knownOptionTokens = {
+			flags: new Set<string>(),
+			switches: new Set<string>(),
+		},
+		valueKind = `value`,
+	} = retrieveOptions
 	const instances: ArgumentInstance[] = []
 	const switchName = `--${key}`
 	const switchNameWithValue = `${switchName}=`
 	for (const [index, argument] of passed.entries()) {
 		if (argument === switchName) {
 			const nextArg = passed[index + 1]
-			if (consumesNextArg && shouldConsumeNextArg(nextArg)) {
+			if (shouldConsumeNextArg(nextArg, valueKind, knownOptionTokens)) {
 				instances.push({ value: nextArg, valueIndex: index + 1 })
 			} else {
 				instances.push({ value: `` })
@@ -172,9 +217,9 @@ function retrieveArgumentInstances(
 			instances.push({ value })
 			continue
 		}
-		if (consumesNextArg && flagGroup === `-${flag}`) {
+		if (flagGroup === `-${flag}`) {
 			const nextArg = passed[index + 1]
-			if (shouldConsumeNextArg(nextArg)) {
+			if (shouldConsumeNextArg(nextArg, valueKind, knownOptionTokens)) {
 				instances.push({ value: nextArg, valueIndex: index + 1 })
 				continue
 			}
@@ -223,6 +268,13 @@ function optionSchemaIsBoolean(
 	return false
 }
 
+function retrieveOptionValueKind(
+	optionsGroup: Exclude<OptionsGroup<any>, null>,
+	key: string,
+): OptionValueKind {
+	return optionSchemaIsBoolean(optionsGroup, key) ? `boolean` : `value`
+}
+
 function retrieveOptionConfigEntries(
 	routeOptions: Record<string, OptionsGroup<any> | null>,
 ): CliOptionConfigEntry[] {
@@ -233,16 +285,30 @@ function retrieveOptionConfigEntries(
 			continue
 		}
 		for (const [key, config] of Object.entries(optionsGroup.optionConfigs)) {
-			const consumesNextArg = !optionSchemaIsBoolean(optionsGroup, key)
-			const signature = `${key}\0${config.flag ?? ``}\0${consumesNextArg}`
+			const valueKind = retrieveOptionValueKind(optionsGroup, key)
+			const signature = `${key}\0${config.flag ?? ``}\0${valueKind}`
 			if (seenOptions.has(signature)) {
 				continue
 			}
 			seenOptions.add(signature)
-			entries.push([key, config, consumesNextArg])
+			entries.push([key, config, valueKind])
 		}
 	}
 	return entries
+}
+
+function retrieveKnownOptionTokens(
+	optionConfigEntries: CliOptionConfigEntry[],
+): KnownOptionTokens {
+	const flags = new Set<string>()
+	const switches = new Set<string>()
+	for (const [key, config] of optionConfigEntries) {
+		switches.add(`--${key}`)
+		if (config.flag) {
+			flags.add(config.flag)
+		}
+	}
+	return { flags, switches }
 }
 
 function retrieveConsumedValueIndexes(
@@ -250,12 +316,13 @@ function retrieveConsumedValueIndexes(
 	optionConfigEntries: CliOptionConfigEntry[],
 ): Set<number> {
 	const indexes = new Set<number>()
-	for (const [key, config, consumesNextArg] of optionConfigEntries) {
+	const knownOptionTokens = retrieveKnownOptionTokens(optionConfigEntries)
+	for (const [key, config, valueKind] of optionConfigEntries) {
 		for (const argumentInstance of retrieveArgumentInstances(
 			passed,
 			key,
 			config.flag,
-			{ consumesNextArg },
+			{ knownOptionTokens, valueKind },
 		)) {
 			if (argumentInstance.valueIndex !== undefined) {
 				indexes.add(argumentInstance.valueIndex)
@@ -320,6 +387,7 @@ export function cli<
 				passed,
 				allOptionConfigEntries,
 			)
+			const knownOptionTokens = retrieveKnownOptionTokens(allOptionConfigEntries)
 			if (routes) {
 				positionalArgs = retrievePositionalArgs(
 					cliName,
@@ -372,8 +440,9 @@ export function cli<
 						key,
 						flag,
 						{
-							consumesNextArg:
-								route === null ? true : !optionSchemaIsBoolean(route, key),
+							knownOptionTokens,
+							valueKind:
+								route === null ? `value` : retrieveOptionValueKind(route, key),
 						},
 					)
 					switch (argumentInstances.length) {

--- a/packages/comline/src/cli.ts
+++ b/packages/comline/src/cli.ts
@@ -10,7 +10,7 @@ import type {
 	TreePath,
 	TreePathName,
 } from "treetrunks"
-import type { ZodType } from "zod"
+import type { ZodObject, ZodType } from "zod"
 
 import type { Flag } from "./flag"
 import { parseStringOption } from "./option-parsers"
@@ -95,11 +95,19 @@ export type CommandLineInterface<Routes extends Tree> = {
 	discoverConfigPath?: (positionalArgs: TreePath<Routes>) => string | undefined
 }
 
-type CliOptionConfigEntry = readonly [key: string, config: CliOption<any>]
+type CliOptionConfigEntry = readonly [
+	key: string,
+	config: CliOption<any>,
+	consumesNextArg: boolean,
+]
 
 type ArgumentInstance = {
 	value: string
 	valueIndex?: number
+}
+
+type RetrieveArgumentInstancesOptions = {
+	consumesNextArg?: boolean
 }
 
 function splitOptionValue(
@@ -129,14 +137,16 @@ function retrieveArgumentInstances(
 	passed: string[],
 	key: string,
 	flag?: string,
+	retrieveOptions: RetrieveArgumentInstancesOptions = {},
 ): ArgumentInstance[] {
+	const { consumesNextArg = true } = retrieveOptions
 	const instances: ArgumentInstance[] = []
 	const switchName = `--${key}`
 	const switchNameWithValue = `${switchName}=`
 	for (const [index, argument] of passed.entries()) {
 		if (argument === switchName) {
 			const nextArg = passed[index + 1]
-			if (shouldConsumeNextArg(nextArg)) {
+			if (consumesNextArg && shouldConsumeNextArg(nextArg)) {
 				instances.push({ value: nextArg, valueIndex: index + 1 })
 			} else {
 				instances.push({ value: `` })
@@ -162,7 +172,7 @@ function retrieveArgumentInstances(
 			instances.push({ value })
 			continue
 		}
-		if (flagGroup === `-${flag}`) {
+		if (consumesNextArg && flagGroup === `-${flag}`) {
 			const nextArg = passed[index + 1]
 			if (shouldConsumeNextArg(nextArg)) {
 				instances.push({ value: nextArg, valueIndex: index + 1 })
@@ -172,6 +182,45 @@ function retrieveArgumentInstances(
 		instances.push({ value: retrieveRepeatedFlagValue(flagGroup, flag) })
 	}
 	return instances
+}
+
+function retrieveZodOptionType(
+	optionsSchema: ZodType<any>,
+	key: string,
+): string | undefined {
+	const optionDef = (optionsSchema as ZodObject<any>).shape[key]?._def
+	if (optionDef?.type === `optional`) {
+		return optionDef.innerType._def.type
+	}
+	return optionDef?.type
+}
+
+function jsonSchemaTypeIsBoolean(jsonSchema: JsonSchema | undefined): boolean {
+	if (jsonSchema === undefined || !(`type` in jsonSchema)) {
+		return false
+	}
+	const { type } = jsonSchema
+	if (typeof type === `string`) {
+		return type === `boolean`
+	}
+	return type.length > 0 && type.every((t) => t === `boolean`)
+}
+
+function optionSchemaIsBoolean(
+	optionsGroup: Exclude<OptionsGroup<any>, null>,
+	key: string,
+): boolean {
+	const optionsSchema = optionsGroup.optionsSchema
+	if (zod && optionsSchema instanceof zod.ZodType) {
+		return retrieveZodOptionType(optionsSchema, key) === `boolean`
+	}
+	if (ark && optionsSchema instanceof ark.Type) {
+		const jsonSchema = optionsSchema.toJsonSchema() as JsonSchema.Object & {
+			properties?: Record<string, JsonSchema>
+		}
+		return jsonSchemaTypeIsBoolean(jsonSchema.properties?.[key])
+	}
+	return false
 }
 
 function retrieveOptionConfigEntries(
@@ -184,12 +233,13 @@ function retrieveOptionConfigEntries(
 			continue
 		}
 		for (const [key, config] of Object.entries(optionsGroup.optionConfigs)) {
-			const signature = `${key}\0${config.flag ?? ``}`
+			const consumesNextArg = !optionSchemaIsBoolean(optionsGroup, key)
+			const signature = `${key}\0${config.flag ?? ``}\0${consumesNextArg}`
 			if (seenOptions.has(signature)) {
 				continue
 			}
 			seenOptions.add(signature)
-			entries.push([key, config])
+			entries.push([key, config, consumesNextArg])
 		}
 	}
 	return entries
@@ -200,11 +250,12 @@ function retrieveConsumedValueIndexes(
 	optionConfigEntries: CliOptionConfigEntry[],
 ): Set<number> {
 	const indexes = new Set<number>()
-	for (const [key, config] of optionConfigEntries) {
+	for (const [key, config, consumesNextArg] of optionConfigEntries) {
 		for (const argumentInstance of retrieveArgumentInstances(
 			passed,
 			key,
 			config.flag,
+			{ consumesNextArg },
 		)) {
 			if (argumentInstance.valueIndex !== undefined) {
 				indexes.add(argumentInstance.valueIndex)
@@ -316,7 +367,15 @@ export function cli<
 					const [key, config] = entry
 					const { flag, required, description, example } = config
 					const parse = `parse` in config ? config.parse : parseStringOption
-					const argumentInstances = retrieveArgumentInstances(passed, key, flag)
+					const argumentInstances = retrieveArgumentInstances(
+						passed,
+						key,
+						flag,
+						{
+							consumesNextArg:
+								route === null ? true : !optionSchemaIsBoolean(route, key),
+						},
+					)
 					switch (argumentInstances.length) {
 						case 0:
 							if (required && !optionsFromConfig) {

--- a/packages/comline/src/cli.ts
+++ b/packages/comline/src/cli.ts
@@ -95,23 +95,123 @@ export type CommandLineInterface<Routes extends Tree> = {
 	discoverConfigPath?: (positionalArgs: TreePath<Routes>) => string | undefined
 }
 
-function retrieveArgValue(argument: string, flag?: string): string {
-	const isSwitch = argument.startsWith(`--`)
-	const [key, value] = argument.split(`=`)
-	let retrievedValue = value
-	if (retrievedValue === undefined) {
-		if (isSwitch) {
-			retrievedValue = ``
-		} else if (flag) {
-			retrievedValue = key
-				.split(``)
-				.filter((s) => s === flag)
-				.map(() => `,`)
-				.join(``)
-				.substring(1)
+type CliOptionConfigEntry = readonly [key: string, config: CliOption<any>]
+
+type ArgumentInstance = {
+	value: string
+	valueIndex?: number
+}
+
+function splitOptionValue(
+	argument: string,
+): [optionName: string, value?: string] {
+	const equalsIndex = argument.indexOf(`=`)
+	if (equalsIndex === -1) {
+		return [argument]
+	}
+	return [argument.slice(0, equalsIndex), argument.slice(equalsIndex + 1)]
+}
+
+function shouldConsumeNextArg(arg: string | undefined): arg is string {
+	return arg !== undefined && arg !== `--` && !arg.startsWith(`-`)
+}
+
+function retrieveRepeatedFlagValue(argument: string, flag: string): string {
+	return argument
+		.split(``)
+		.filter((s) => s === flag)
+		.map(() => `,`)
+		.join(``)
+		.substring(1)
+}
+
+function retrieveArgumentInstances(
+	passed: string[],
+	key: string,
+	flag?: string,
+): ArgumentInstance[] {
+	const instances: ArgumentInstance[] = []
+	const switchName = `--${key}`
+	const switchNameWithValue = `${switchName}=`
+	for (const [index, argument] of passed.entries()) {
+		if (argument === switchName) {
+			const nextArg = passed[index + 1]
+			if (shouldConsumeNextArg(nextArg)) {
+				instances.push({ value: nextArg, valueIndex: index + 1 })
+			} else {
+				instances.push({ value: `` })
+			}
+			continue
+		}
+		if (argument.startsWith(switchNameWithValue)) {
+			instances.push({ value: argument.slice(switchNameWithValue.length) })
+			continue
+		}
+		if (
+			flag === undefined ||
+			!argument.startsWith(`-`) ||
+			argument.startsWith(`--`)
+		) {
+			continue
+		}
+		const [flagGroup, value] = splitOptionValue(argument)
+		if (!flagGroup.includes(flag)) {
+			continue
+		}
+		if (value !== undefined) {
+			instances.push({ value })
+			continue
+		}
+		if (flagGroup === `-${flag}`) {
+			const nextArg = passed[index + 1]
+			if (shouldConsumeNextArg(nextArg)) {
+				instances.push({ value: nextArg, valueIndex: index + 1 })
+				continue
+			}
+		}
+		instances.push({ value: retrieveRepeatedFlagValue(flagGroup, flag) })
+	}
+	return instances
+}
+
+function retrieveOptionConfigEntries(
+	routeOptions: Record<string, OptionsGroup<any> | null>,
+): CliOptionConfigEntry[] {
+	const seenOptions = new Set<string>()
+	const entries: CliOptionConfigEntry[] = []
+	for (const optionsGroup of Object.values(routeOptions)) {
+		if (optionsGroup === null) {
+			continue
+		}
+		for (const [key, config] of Object.entries(optionsGroup.optionConfigs)) {
+			const signature = `${key}\0${config.flag ?? ``}`
+			if (seenOptions.has(signature)) {
+				continue
+			}
+			seenOptions.add(signature)
+			entries.push([key, config])
 		}
 	}
-	return retrievedValue
+	return entries
+}
+
+function retrieveConsumedValueIndexes(
+	passed: string[],
+	optionConfigEntries: CliOptionConfigEntry[],
+): Set<number> {
+	const indexes = new Set<number>()
+	for (const [key, config] of optionConfigEntries) {
+		for (const argumentInstance of retrieveArgumentInstances(
+			passed,
+			key,
+			config.flag,
+		)) {
+			if (argumentInstance.valueIndex !== undefined) {
+				indexes.add(argumentInstance.valueIndex)
+			}
+		}
+	}
+	return indexes
 }
 
 export type CliRoutes<CLI extends CommandLineInterface<any>> = CLI[`routes`]
@@ -162,8 +262,20 @@ export function cli<
 				path: [] as TreePath<Routes>,
 				route: `` as Join<TreePathName<Routes>>,
 			}
+			const allOptionConfigEntries = retrieveOptionConfigEntries(
+				routeOptions as Record<string, OptionsGroup<any> | null>,
+			)
+			const consumedValueIndexes = retrieveConsumedValueIndexes(
+				passed,
+				allOptionConfigEntries,
+			)
 			if (routes) {
-				positionalArgs = retrievePositionalArgs(cliName, routes, passed)
+				positionalArgs = retrievePositionalArgs(
+					cliName,
+					routes,
+					passed,
+					consumedValueIndexes,
+				)
 			}
 
 			const route: OptionsGroup<any> = routeOptions[positionalArgs.route]
@@ -204,14 +316,7 @@ export function cli<
 					const [key, config] = entry
 					const { flag, required, description, example } = config
 					const parse = `parse` in config ? config.parse : parseStringOption
-					const argumentInstances = passed.filter(
-						(arg) =>
-							arg.startsWith(`--${key}`) ||
-							(arg.startsWith(`-`) &&
-								!arg.startsWith(`--`) &&
-								flag &&
-								arg.split(`=`)[0].includes(flag)),
-					)
+					const argumentInstances = retrieveArgumentInstances(passed, key, flag)
 					switch (argumentInstances.length) {
 						case 0:
 							if (required && !optionsFromConfig) {
@@ -224,12 +329,12 @@ export function cli<
 							}
 							return [key, undefined]
 						case 1: {
-							const retrievedValue = retrieveArgValue(argumentInstances[0], flag)
+							const retrievedValue = argumentInstances[0].value
 							return [key, parse(retrievedValue)]
 						}
 						default: {
 							const retrievedValues = argumentInstances
-								.map((arg) => retrieveArgValue(arg, flag))
+								.map((arg) => arg.value)
 								.join(`,`)
 							return [key, parse(retrievedValues)]
 						}

--- a/packages/comline/src/help.ts
+++ b/packages/comline/src/help.ts
@@ -1,17 +1,15 @@
 import { styleText } from "node:util"
 
-import type { JsonSchema } from "arktype"
-import { type } from "arktype"
-import type { ZodObject } from "zod"
-
 import { type CommandLineInterface, options, type OptionsGroup } from "./cli"
 import { parseBooleanOption } from "./option-parsers"
+import {
+	type JsonSchema,
+	type OptionsSchema,
+	retrieveInputJsonSchema,
+} from "./schema"
 
 const capitalize = <T extends string>(str: T): Capitalize<T> =>
 	(str[0].toUpperCase() + str.slice(1)) as Capitalize<T>
-
-const lower = <T extends string>(str: T): Lowercase<T> =>
-	(str[0].toLowerCase() + str.slice(1)) as Lowercase<T>
 
 export type TerminalColor =
 	| `black`
@@ -148,7 +146,12 @@ export type HelpOptions = {
 	forceColor?: boolean
 }
 
-function shallowlyStringifyJsonSchema(jsonSchema: JsonSchema): string {
+function shallowlyStringifyJsonSchema(
+	jsonSchema: JsonSchema | undefined,
+): string {
+	if (jsonSchema === undefined) {
+		return `unknown`
+	}
 	if (`type` in jsonSchema) {
 		if (typeof jsonSchema.type === `string`) {
 			return jsonSchema.type
@@ -197,30 +200,13 @@ export function help(
 							const optionsSchema = value.optionsSchema
 
 							let typeString = `unknown`
-							if (`_def` in optionsSchema) {
-								const optionDef = (optionsSchema as ZodObject<any>).shape[key]
-									._def
-								console.log(optionDef)
-								typeString = optionDef.type as string
-
-								if (typeString === `optional`) {
-									typeString = optionDef.innerType._def.type as string
-								}
-								typeString = lower(typeString.replaceAll(`Zod`, ``))
-								if (option.required) {
-									typeString = `${typeString} (required)`
-								}
-							} else {
-								const jsonSchema = optionsSchema.toJsonSchema()
-								const propertySchema = (
-									jsonSchema as JsonSchema.Object & {
-										properties: Record<string, JsonSchema>
-									}
-								).properties[key]
+							try {
+								const jsonSchema = retrieveInputJsonSchema(optionsSchema)
+								const propertySchema = jsonSchema.properties?.[key]
 								typeString = shallowlyStringifyJsonSchema(propertySchema)
-								if (option.required) {
-									typeString = `${typeString} (required)`
-								}
+							} catch {}
+							if (option.required) {
+								typeString = `${typeString} (required)`
 							}
 
 							return [
@@ -260,10 +246,44 @@ function assemble<T extends Object>(
 		.reduce((acc, [, ext]) => Object.assign(acc, ext), base)
 }
 
+const helpOptionsJsonSchema: JsonSchema = {
+	$schema: `https://json-schema.org/draft/2020-12/schema`,
+	additionalProperties: false,
+	type: `object`,
+	properties: {
+		help: {
+			type: `boolean`,
+		},
+	},
+}
+
+const helpOptionsSchema: OptionsSchema<{ help?: boolean | undefined }> = {
+	"~standard": {
+		version: 1,
+		vendor: `comline`,
+		validate: (value) => {
+			if (typeof value !== `object` || value === null || Array.isArray(value)) {
+				return { issues: [{ message: `Expected an object.` }] }
+			}
+			const helpValue = (value as { help?: unknown }).help
+			if (helpValue !== undefined && typeof helpValue !== `boolean`) {
+				return {
+					issues: [{ message: `Expected a boolean.`, path: [`help`] }],
+				}
+			}
+			return { value: helpValue === undefined ? {} : { help: helpValue } }
+		},
+		jsonSchema: {
+			input: () => helpOptionsJsonSchema,
+			output: () => helpOptionsJsonSchema,
+		},
+	},
+}
+
 export function helpOption(
 	description = ``,
 ): OptionsGroup<{ help?: boolean | undefined }> {
-	return options(description, type({ "help?": `boolean` }), {
+	return options(description, helpOptionsSchema, {
 		help: {
 			description: `show this help text`,
 			example: `--help`,

--- a/packages/comline/src/retrieve-positional-args.ts
+++ b/packages/comline/src/retrieve-positional-args.ts
@@ -4,6 +4,7 @@ export function retrievePositionalArgs<PositionalArgTree extends Tree>(
 	cliName: string,
 	positionalArgTree: PositionalArgTree,
 	passed: string[],
+	ignoredArgIndexes: ReadonlySet<number> = new Set<number>(),
 ): {
 	path: TreePath<PositionalArgTree>
 	route: Join<TreePathName<PositionalArgTree>>
@@ -14,7 +15,10 @@ export function retrievePositionalArgs<PositionalArgTree extends Tree>(
 	if (endOfOptionsDelimiterIndex === -1) {
 		if (cliInvocationIndex !== -1) {
 			const allArgs = passed.slice(cliInvocationIndex + 1)
-			positionalArgs = allArgs.filter((arg) => !arg.startsWith(`-`))
+			positionalArgs = allArgs.filter((arg, index) => {
+				const passedIndex = cliInvocationIndex + 1 + index
+				return !ignoredArgIndexes.has(passedIndex) && !arg.startsWith(`-`)
+			})
 		}
 	} else {
 		positionalArgs = passed.slice(endOfOptionsDelimiterIndex + 1)

--- a/packages/comline/src/schema.ts
+++ b/packages/comline/src/schema.ts
@@ -1,13 +1,119 @@
-/* eslint-disable quotes */
-/* oxlint-disable typescript/consistent-type-imports */
+import type {
+	StandardJSONSchemaV1,
+	StandardSchemaV1,
+} from "@standard-schema/spec"
 
-export let ark: typeof import("arktype") | undefined
-export let zod: typeof import("zod") | undefined
-try {
-	ark = await import(`arktype`)
-} catch (_) {}
-try {
-	zod = await import(`zod`)
-} catch (_) {}
-export const schemaPkg: typeof import("arktype") | typeof import("zod") =
-	ark ?? zod!
+export type JsonSchema = Record<string, unknown> & {
+	$schema?: string
+	additionalProperties?: boolean | JsonSchema
+	allOf?: readonly JsonSchema[]
+	anyOf?: readonly JsonSchema[]
+	const?: unknown
+	enum?: readonly unknown[]
+	oneOf?: readonly JsonSchema[]
+	properties?: Record<string, JsonSchema>
+	required?: readonly string[]
+	type?: string | readonly string[]
+}
+
+export type OptionsSchema<Options> = StandardSchemaV1<unknown, Options> &
+	StandardJSONSchemaV1<unknown, Options>
+
+const jsonSchemaOptions: StandardJSONSchemaV1.Options = {
+	target: `draft-2020-12`,
+}
+
+const emptyObjectJsonSchema = {
+	$schema: `https://json-schema.org/draft/2020-12/schema`,
+	additionalProperties: false,
+	type: `object`,
+	properties: {},
+} satisfies JsonSchema
+
+export const emptySchema: OptionsSchema<Record<never, never>> = {
+	"~standard": {
+		version: 1,
+		vendor: `comline`,
+		validate: (): StandardSchemaV1.Result<Record<never, never>> => ({
+			value: {},
+		}),
+		jsonSchema: {
+			input: (): JsonSchema => emptyObjectJsonSchema,
+			output: (): JsonSchema => emptyObjectJsonSchema,
+		},
+	},
+}
+
+function isObjectJsonSchema(jsonSchema: JsonSchema): boolean {
+	const { type } = jsonSchema
+	return type === `object` || (Array.isArray(type) && type.includes(`object`))
+}
+
+function disallowAdditionalProperties(jsonSchema: JsonSchema): JsonSchema {
+	if (!isObjectJsonSchema(jsonSchema) || `additionalProperties` in jsonSchema) {
+		return jsonSchema
+	}
+	const { $schema, ...rest } = jsonSchema
+	return {
+		...($schema === undefined ? {} : { $schema }),
+		additionalProperties: false,
+		...rest,
+	}
+}
+
+export function retrieveInputJsonSchema(
+	optionsSchema: OptionsSchema<any>,
+): JsonSchema {
+	return disallowAdditionalProperties(
+		optionsSchema[`~standard`].jsonSchema.input(jsonSchemaOptions) as JsonSchema,
+	)
+}
+
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+	return (
+		typeof value === `object` &&
+		value !== null &&
+		`then` in value &&
+		typeof value.then === `function`
+	)
+}
+
+function stringifyIssuePath(
+	path: StandardSchemaV1.Issue[`path`],
+): string | undefined {
+	return path
+		?.map((segment) => (typeof segment === `object` ? segment.key : segment))
+		.map(String)
+		.join(`.`)
+}
+
+function formatSchemaValidationIssues(
+	issues: ReadonlyArray<StandardSchemaV1.Issue>,
+): string {
+	if (issues.length === 0) {
+		return `Options failed validation.`
+	}
+	return (
+		`Options failed validation:` +
+		issues
+			.map((issue) => {
+				const path = stringifyIssuePath(issue.path)
+				return `\n\t- ${path ? `${path}: ` : ``}${issue.message}`
+			})
+			.join(``)
+	)
+}
+
+export function validateOptionsSchema<Options>(
+	optionsSchema: OptionsSchema<Options>,
+	value: unknown,
+): Options {
+	const result = optionsSchema[`~standard`].validate(value)
+	if (isPromiseLike(result)) {
+		throw new Error(`comline does not support async Standard Schema validation.`)
+	}
+	if (result.issues) {
+		throw new Error(formatSchemaValidationIssues(result.issues))
+	}
+	return result.value
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,9 @@ importers:
 
   packages/comline:
     dependencies:
+      '@standard-schema/spec':
+        specifier: 1.1.0
+        version: 1.1.0
       treetrunks:
         specifier: workspace:*
         version: link:../treetrunks


### PR DESCRIPTION
- **🔧 draft equals-less switches and flags**
- **✅ add special consume-next-arg handling**
- **🦋 add changeset**
- **✅ cover more test cases**
