### PR TITLE
Add configurable takua log sinks

### DIFF
--- a/.changeset/quiet-servers-log.md
+++ b/.changeset/quiet-servers-log.md
@@ -1,0 +1,5 @@
+---
+"takua": patch
+---
+
+Add configurable log sinks so integrations like LSPs can route formatted output without writing to process stdout.

--- a/packages/takua/README.md
+++ b/packages/takua/README.md
@@ -5,3 +5,21 @@ npm i takua
 ```
 
 Takua is a chronicler. A nice logger with colors and timestamps.
+
+```ts
+import { Logger } from "takua"
+
+const logger = new Logger({
+	colorEnabled: false,
+	sink: {
+		error: (message) => connection.console.error(message),
+		info: (message) => connection.console.info(message),
+		log: (message) => connection.console.log(message),
+		warn: (message) => connection.console.warn(message),
+	},
+})
+```
+
+Use a sink when stdout is reserved for another transport, such as an LSP,
+JSON-RPC process, worker runtime, or test harness. Chronicle output uses the
+same sink.

--- a/packages/takua/__tests__/takua.test.ts
+++ b/packages/takua/__tests__/takua.test.ts
@@ -1,4 +1,8 @@
-import { Logger } from "../src/takua"
+import { Logger, type LogSink } from "../src/takua"
+
+afterEach(() => {
+	vi.restoreAllMocks()
+})
 
 test(`takua`, () => {
 	const logger = new Logger({ colorEnabled: true })
@@ -41,4 +45,56 @@ test(`takua`, () => {
 			},
 		},
 	})
+})
+
+test(`logger writes through a configured sink`, () => {
+	const log = vi.spyOn(console, `log`).mockImplementation(() => undefined)
+	const entries: [level: string, message: string][] = []
+	const sink: LogSink = {
+		error: (message) => entries.push([`error`, message]),
+		info: (message) => entries.push([`info`, message]),
+		warn: (message) => entries.push([`warn`, message]),
+	}
+	const logger = new Logger({ colorEnabled: false, sink })
+
+	logger.info(`hi`, `there`)
+	logger.warn(`heads`, `up`, `careful`)
+	logger.error(`oh`, `no`)
+
+	expect(entries).toEqual([
+		[`info`, `info hi there `],
+		[`warn`, `warn heads up careful`],
+		[`error`, `ERR! oh no `],
+	])
+	expect(log).not.toHaveBeenCalled()
+})
+
+test(`chronicle writes every line through the configured sink`, () => {
+	const log = vi.spyOn(console, `log`).mockImplementation(() => undefined)
+	const entries: [level: string, message: string][] = []
+	const sink: LogSink = {
+		error: (message) => entries.push([`error`, message]),
+		info: (message) => entries.push([`info`, message]),
+		log: (message) => entries.push([`log`, message]),
+		warn: (message) => entries.push([`warn`, message]),
+	}
+	const logger = new Logger({ colorEnabled: false, sink })
+	const chronicle = logger.makeChronicle()
+
+	chronicle.mark(`start`)
+	chronicle.mark(`step`)
+	chronicle.logMarks()
+
+	expect(
+		entries.some(([level, message]) => {
+			return level === `info` && message.startsWith(`info step `)
+		}),
+	).toBe(true)
+	expect(
+		entries.some(([level, message]) => {
+			return level === `info` && message.startsWith(`info TOTAL TIME `)
+		}),
+	).toBe(true)
+	expect(entries.at(-1)).toEqual([`log`, ``])
+	expect(log).not.toHaveBeenCalled()
 })

--- a/packages/takua/src/takua.ts
+++ b/packages/takua/src/takua.ts
@@ -12,6 +12,14 @@ export type LogFn = (
 
 export type LogLevel = `error` | `info` | `warn`
 
+export type LogSink = {
+	debug?: (message: string) => void
+	error: (message: string) => void
+	info: (message: string) => void
+	log?: (message: string) => void
+	warn: (message: string) => void
+}
+
 export interface Chronicle {
 	mark: (text: string) => void
 	logMarks: () => void
@@ -25,15 +33,44 @@ export interface LoggerInterface extends Pick<Console, LogLevel> {
 }
 
 export type LoggerConfig = {
-	colorEnabled: boolean
+	colorEnabled?: boolean
+	sink?: LogSink
+}
+
+const defaultLogSink: LogSink = {
+	debug: (message: string) => {
+		console.log(message)
+	},
+	error: (message: string) => {
+		console.log(message)
+	},
+	info: (message: string) => {
+		console.log(message)
+	},
+	log: (message: string) => {
+		console.log(message)
+	},
+	warn: (message: string) => {
+		console.log(message)
+	},
 }
 
 export class Logger implements LoggerInterface {
 	public chronicle: Chronicle | undefined
 	public readonly colorEnabled: boolean
+	protected readonly sink: LogSink
 
-	public constructor({ colorEnabled }: LoggerConfig) {
+	public constructor({
+		colorEnabled = true,
+		sink = defaultLogSink,
+	}: LoggerConfig = {}) {
 		this.colorEnabled = colorEnabled
+		this.sink = sink
+	}
+
+	protected write(level: LogLevel | `log`, message: string): void {
+		const write = this.sink[level] ?? this.sink.log ?? this.sink.info
+		write(message)
 	}
 
 	protected log(
@@ -90,9 +127,9 @@ export class Logger implements LoggerInterface {
 			output += `${wheatpaste} ${datumString}`
 		}
 		if (output) {
-			console.log(output)
+			this.write(level, output)
 		} else {
-			console.log(wheatpaste)
+			this.write(level, wheatpaste)
 		}
 	}
 	public info(prefix: string, message: number | string, datum?: unknown): void {
@@ -147,7 +184,7 @@ export class Logger implements LoggerInterface {
 				}
 			}
 			logMark(`TOTAL TIME`, overall.duration)
-			console.log()
+			this.write(`log`, ``)
 			this.chronicle = undefined
 		}
 		const chronicle = (this.chronicle = { mark, logMarks })


### PR DESCRIPTION
## Summary

- add a configurable `LogSink` to `LoggerConfig`
- route regular logger output and chronicle output through the configured sink
- document the LSP-style sink usage and add a patch changeset

## Verification

- `pnpm --filter takua test:once`
- `pnpm --filter takua lint:types`
- `pnpm --filter takua lint:eslint`
- `pnpm --filter takua lint:oxlint`
- `pnpm exec dprint check packages/takua/src/takua.ts packages/takua/__tests__/takua.test.ts packages/takua/README.md`
- `pnpm --filter takua build`
