### PR TITLE
Improve comline help output

### DIFF
--- a/.changeset/neat-options-help.md
+++ b/.changeset/neat-options-help.md
@@ -1,0 +1,5 @@
+---
+"comline": patch
+---
+
+Improve the appearance of help output for options without short flags.

--- a/packages/comline/src/help.ts
+++ b/packages/comline/src/help.ts
@@ -196,7 +196,7 @@ export function help(
 				if (value?.optionConfigs) {
 					rows.push(
 						...Object.entries(value.optionConfigs).map(([key, option]) => {
-							const flag = option.flag ? `-${option.flag}` : ` . `
+							const flag = option.flag ? `-${option.flag}` : `  `
 							const optionsSchema = value.optionsSchema
 
 							let typeString = `unknown`


### PR DESCRIPTION
## Summary
- remove the visible placeholder dot for comline options without short flags
- add a patch changeset for comline

## Test
- pnpm --filter comline exec vitest run __tests__/help.test.ts

Note: an initial broader package test invocation also ran the help tests successfully, but the unrelated exec test hit sandboxed /bin/sh with EPERM.