### PR TITLE
Use react-router directly in hamr

### DIFF
--- a/.changeset/calm-routers-listen.md
+++ b/.changeset/calm-routers-listen.md
@@ -1,0 +1,5 @@
+---
+"hamr": patch
+---
+
+Use `react-router` directly for route parameters and exclude versions affected by GHSA-qwww-vcr4-c8h2 from the peer dependency range.

--- a/packages/hamr/package.json
+++ b/packages/hamr/package.json
@@ -45,7 +45,7 @@
 		"corners": "^0.1.0 || ^0.2.0",
 		"motion": "^10.15.1 || ^11.0.0 || ^12.0.0",
 		"react": "^18.2.0 || ^19.0.0",
-		"react-router-dom": "^6.8.1 || ^7.0.0"
+		"react-router": "^6.8.1 || >=7.0.0 <7.12.0 || ^8.3.0"
 	},
 	"devDependencies": {
 		"@testing-library/dom": "10.4.1",
@@ -64,7 +64,7 @@
 		"preact": "10.29.7",
 		"react": "19.2.8",
 		"react-dom": "19.2.8",
-		"react-router-dom": "7.18.2",
+		"react-router": "8.3.0",
 		"takua": "workspace:*",
 		"tsdown": "0.22.14",
 		"vite-plugin-dts": "5.0.3",

--- a/packages/hamr/src/atom.io-tools/AtomEditor.tsx
+++ b/packages/hamr/src/atom.io-tools/AtomEditor.tsx
@@ -1,6 +1,6 @@
 import type { WritableFamilyToken } from "atom.io"
 import type { FC, ReactElement } from "react"
-import { useParams } from "react-router-dom"
+import { useParams } from "react-router"
 
 import type { AtomListItemProps } from "./AtomList"
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,9 +463,9 @@ importers:
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
-      react-router-dom:
-        specifier: 7.18.2
-        version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-router:
+        specifier: 8.3.0
+        version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       takua:
         specifier: workspace:*
         version: link:../takua
@@ -3510,13 +3510,12 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
-
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
 
   corners@0.2.0:
     resolution: {integrity: sha512-O5hzhQ8bxP86gF9xIZ0aNQuPV3WKqIo1WGSJpsJqWTZvIT6LMi0hvh40o+3pF8s4gE43aLgp8m6xUidipIwlNg==}
@@ -4911,19 +4910,12 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react-router-dom@7.18.2:
-    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
-    engines: {node: '>=20.0.0'}
+  react-router@8.3.0:
+    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
+    engines: {node: '>=22.22.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  react-router@7.18.2:
-    resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -5039,9 +5031,6 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -7874,9 +7863,9 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie@0.7.2: {}
+  cookie-es@3.1.1: {}
 
-  cookie@1.1.1: {}
+  cookie@0.7.2: {}
 
   corners@0.2.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -9140,17 +9129,10 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-router-dom@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
+      cookie-es: 3.1.1
       react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-router: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-
-  react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.8
-      set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.8(react@19.2.8)
 
@@ -9305,8 +9287,6 @@ snapshots:
   semver@7.8.4: {}
 
   semver@7.8.5: {}
-
-  set-cookie-parser@2.7.2: {}
 
   sharp@0.34.5:
     dependencies:


### PR DESCRIPTION
## Summary

- import `useParams` from `react-router` instead of `react-router-dom`
- peer on safe React Router ranges, excluding versions affected by GHSA-qwww-vcr4-c8h2
- update Hamr’s development graph to `react-router@8.3.0` and add a patch changeset

This should let a newly published Hamr release resolve the patched core router directly and gives us a concrete check that vigilance no longer proposes the stale `react-router-dom@7.18.1` graph.

## Verification

- `pnpm --filter hamr lint:types`
- `pnpm --filter hamr test:once`
- `pnpm --filter hamr build`
- `pnpm --filter hamr lint:eslint`
- `pnpm --filter hamr lint:oxlint`
- `pnpm fmt`
- `pnpm lint:deps`