### PR TITLE
Improve Varmint fixture safety and flushing

### DIFF
--- a/.changeset/kind-varmints-remember.md
+++ b/.changeset/kind-varmints-remember.md
@@ -1,0 +1,5 @@
+---
+"varmint": patch
+---
+
+Preserve every touched fixture case when flushing a collection.

--- a/.changeset/wise-varmints-record.md
+++ b/.changeset/wise-varmints-record.md
@@ -1,0 +1,5 @@
+---
+"varmint": patch
+---
+
+Expand the agent guide with safe recording and fixture-lifecycle practices.

--- a/packages/varmint/AGENTS.md
+++ b/packages/varmint/AGENTS.md
@@ -86,8 +86,21 @@ export const VARMINT_MODE: CacheMode = process.env[`CI`]
 - Avoid manually editing fixtures in normal use. Their job is to document and
   cache real calls, so regenerate them from the wrapped interaction when the
   underlying behavior changes.
-- Use `flush` after a suite to remove fixture cases that were not touched by the
-  current test run.
+
+## Fixture cleanup and concurrency
+
+- `flush` removes fixture cases that were not touched through the current
+  `Squirrel` or `Ferret` instance. Use it only when the run authoritatively
+  enumerates the entire collection.
+- Do not flush after a filtered or partial test run. Cases omitted by that run
+  would be treated as stale.
+- Instance `flush` only examines collection keys touched by that instance. It
+  does not discover or remove an entirely orphaned collection directory.
+- Do not let concurrent writers or flushers share a mutable fixture directory.
+  Give parallel agents and test processes isolated cache roots. Sharing is safe
+  only when every participant is read-only.
+- Run deliberate recording and cleanup jobs in isolation, and review deletions
+  before committing them.
 
 ## Failure model
 

--- a/packages/varmint/AGENTS.md
+++ b/packages/varmint/AGENTS.md
@@ -14,10 +14,14 @@ the real dependency every time.
   `for`.
 - Varmint records the exact call arguments beside the captured result, then
   requires those arguments to match when replaying.
+- Varmint cannot see configuration captured by a closure or read elsewhere.
+  Callers are responsible for making every result-affecting input part of the
+  fixture contract.
 - The cache is intentionally visible on disk; fixture diffs are reviewable test
   artifacts, not hidden mocks.
-- Prefer stable, human-readable keys and subKeys because they become filenames
-  after sanitization.
+- Prefer stable, human-readable keys and subKeys because they shape fixture
+  paths. SubKeys are sanitized, so distinct labels containing unsupported
+  characters can collapse to the same filename.
 
 ## Core APIs
 
@@ -34,6 +38,20 @@ Use `Ferret` for functions that return `AsyncIterable` streams.
 
 - Input fixture: `<baseDir>/<key>/<subKey>.input.json`
 - Stream fixture: `<baseDir>/<key>/<subKey>.stream.txt`
+
+### Input format
+
+The `.input.json` file contains the wrapped function's positional argument
+list. A one-argument call therefore records an array:
+
+```json
+[
+	"the prompt"
+]
+```
+
+Do not add an unnecessary wrapper such as `{ "input": value }` solely to change
+fixture formatting.
 
 ## Cache modes
 
@@ -59,33 +77,122 @@ export const VARMINT_MODE: CacheMode = process.env[`CI`]
 	? `read`
 	: process.env[`NODE_ENV`] === `production`
 		? `off`
-		: `read-write`
+		: process.env[`RECORD_FIXTURES`] === `1`
+			? `write`
+			: `read`
 ```
 
-- Use `read` in CI so fixture misses are visible failures.
+- Use `read` for ordinary local tests and CI so fixture misses are visible
+  failures and routine test runs cannot make live calls.
 - Use `off` in production builds or runtime code so Varmint never records or
   replays test fixtures there.
-- Use `read-write` for local development so new scenarios can be captured
-  naturally.
-- Prefer an explicit override only for intentional maintenance tasks, such as
-  regenerating fixtures with `write`.
+- Expose `write` or `read-write` only through an explicitly named fixture
+  recording command.
+- Use `write` when the selected run should authoritatively regenerate every
+  exercised fixture.
+- Use `read-write` for deliberate incremental recording only when a cache miss
+  making a silent live call is cheap, side-effect free, and otherwise
+  acceptable.
 
 ## Basic workflow
 
 - Wrap the boundary you want to stabilize with
   `new Squirrel(mode).add(key, fn)` or
   `new Ferret(mode).add(key, streamFn)`.
-- In local development, use `read-write` to keep existing fixtures fast while
-  allowing new scenarios to be captured.
-- In CI, use `read` so tests prove all external behavior is represented by
-  committed fixtures.
-- When behavior intentionally changes, run in `write` or delete the affected
-  fixture and rerun in `read-write`.
+- Run ordinary local and CI tests in `read`.
+- When behavior intentionally changes, use the explicit recording command to
+  run the affected scenarios in `write`. An explicit `read-write` recording
+  command can be used when incremental live capture is intentional.
 - Commit the updated `.varmint` fixture files with the test change so future runs
   replay the same behavior.
 - Avoid manually editing fixtures in normal use. Their job is to document and
   cache real calls, so regenerate them from the wrapped interaction when the
   underlying behavior changes.
+
+## Choosing the wrapper boundary
+
+Record the stable, safe value that actually crosses the external boundary, not
+an upstream application object that will later be transformed into that value.
+
+```ts
+// Avoid: the fixture captures a large internal object.
+await cachedGenerateTurn.for(caseName).get(gameState)
+
+// Prefer: the fixture captures the dependency-facing request.
+await cachedModelCall.for(caseName).get({
+	model,
+	systemPrompt,
+	userPrompt: renderPrompt(gameState),
+	outputSchemaVersion,
+	reasoning,
+})
+```
+
+If fixture diffs are unexpectedly large, dominated by internal state, or
+difficult to interpret, the wrapper is probably too high in the stack.
+
+For model calls, the reviewable input is usually a safe representation of the
+outbound generation request. Do not include authorization headers or other
+transport credentials.
+
+## Semantic identity
+
+- Explicit arguments are the primary fixture identity. Include every safe input
+  that can change the result, such as model identity, system instructions,
+  output-contract versions, provider settings, endpoint or API versions,
+  feature flags, and prompt-template or parser versions.
+- Configuration captured by a closure is invisible to Varmint. Prefer adapting
+  the wrapped function to accept a safe request object containing the complete
+  semantic contract.
+- Use readable behavioral keys and subKeys for navigation. When relevant
+  contract information cannot reasonably be explicit, add a deterministic
+  fingerprint to the case identity, for example
+  `round-2-trick-4-play-3-P1--a701b47efab7`.
+- A fingerprint supplements explicit arguments; it does not replace them.
+  Document what it covers, compute it deterministically, and exclude secrets and
+  secret-derived values.
+- Because filename sanitization can make distinct labels collide, use an
+  explicit disambiguator or fingerprint when labels differ only by characters
+  that sanitize the same way.
+
+## Secrets and private data
+
+- Varmint writes exact arguments and results to disk. Never record credentials,
+  authorization headers, secrets, or unnecessary personal or private data.
+- Hashing a secret is not safe redaction, particularly for low-entropy values.
+  Semantic fingerprints must exclude secrets and secret-derived values.
+- Define a minimal safe request at the wrapper boundary and inspect generated
+  fixture files before staging them.
+
+## Replay layering
+
+- Usually cache the raw external result, then run parsing, schema validation,
+  legality checks, retries, and deterministic fallbacks outside the cache. This
+  lets replay exercise the application's handling of malformed or invalid
+  dependency behavior.
+- Do not edit a fixture merely because the external result is poor. Invalid
+  outputs are often valuable regression cases.
+- A cached result does not imply that the application accepted it. When the
+  distinction matters, assert the raw result, guarded decision, fallback, and
+  committed action separately.
+- If a retry sends a different outbound request, give the attempt a stable case
+  identity so its fixture remains independently reviewable.
+
+## Source control and provenance
+
+- If CI uses `read`, verify that every required input and output fixture is
+  tracked rather than merely present locally. Check ignore rules, staged fixture
+  counts, and final committed paths.
+- Track durable replay evidence. Keep transient reports, costs, timestamps, and
+  local diagnostics ignored unless the project explicitly treats them as golden
+  data.
+- Scenario labels describe intended provenance; they do not prove that a live
+  dependency call occurred. When provenance matters, instrument recording runs
+  to count live calls, cached replays, invalid results, fallbacks, and committed
+  actions.
+- For expensive recording jobs, persist useful diagnostics before enforcing
+  quality assertions. Fixture validity and model quality are separate concerns;
+  a faithfully replayed fallback can be a valid fixture.
 
 ## Fixture cleanup and concurrency
 
@@ -115,8 +222,10 @@ export const VARMINT_MODE: CacheMode = process.env[`CI`]
 
 - Keep wrappers at process or service boundaries such as network calls, model
   calls, or expensive async helpers.
-- Also reach for Varmint around inherently unpredictable values such as random
-  generation, dates, clocks, or Temporal values.
+- Prefer seeded randomness, injected clocks, and deterministic identifiers for
+  nondeterminism owned by the application.
+- Use Varmint for nondeterministic values when they genuinely cross an external
+  or otherwise difficult-to-control boundary.
 - More generally, use Varmint anywhere your code has an unpredictable
   interaction with the outside world and you want that interaction to become
   predictable in tests.

--- a/packages/varmint/__tests__/flush.test.ts
+++ b/packages/varmint/__tests__/flush.test.ts
@@ -3,6 +3,8 @@ import * as fs from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
 
+import { Ferret, Squirrel } from "../src"
+
 let tempDir: string
 const utils = { put: (..._: unknown[]) => undefined }
 
@@ -55,6 +57,61 @@ describe(`flushing with workspace manager`, () => {
 		expect(fs.readdirSync(path.join(tempDir, `myStreamer`))).toEqual([
 			`myAsyncIterable.input.json`,
 			`myAsyncIterable.stream.txt`,
+		])
+	})
+})
+
+describe(`instance flush`, () => {
+	test(`Squirrel preserves every touched case in a collection`, async () => {
+		const squirrel = new Squirrel(`write`, tempDir)
+		const values = squirrel.add(`values`, (value: string) =>
+			Promise.resolve(value),
+		)
+
+		for (const value of [`first`, `second`, `third`]) {
+			await values.for(value).get(value)
+		}
+
+		fs.writeFileSync(path.join(tempDir, `values/stale.input.json`), `[]`)
+		fs.writeFileSync(path.join(tempDir, `values/stale.output.json`), `null`)
+
+		values.flush()
+
+		expect(fs.readdirSync(path.join(tempDir, `values`))).toEqual([
+			`first.input.json`,
+			`first.output.json`,
+			`second.input.json`,
+			`second.output.json`,
+			`third.input.json`,
+			`third.output.json`,
+		])
+	})
+
+	test(`Ferret preserves every touched case in a collection`, async () => {
+		const ferret = new Ferret(`write`, tempDir)
+		const values = ferret.add(`values`, async function* (value: string) {
+			await Promise.resolve()
+			yield value
+		})
+
+		for (const value of [`first`, `second`, `third`]) {
+			for await (const _ of await values.for(value).get(value)) {
+				// Consume the stream so Ferret writes the complete fixture.
+			}
+		}
+
+		fs.writeFileSync(path.join(tempDir, `values/stale.input.json`), `[]`)
+		fs.writeFileSync(path.join(tempDir, `values/stale.stream.txt`), ``)
+
+		values.flush()
+
+		expect(fs.readdirSync(path.join(tempDir, `values`))).toEqual([
+			`first.input.json`,
+			`first.stream.txt`,
+			`second.input.json`,
+			`second.stream.txt`,
+			`third.input.json`,
+			`third.stream.txt`,
 		])
 	})
 })

--- a/packages/varmint/src/ferret.ts
+++ b/packages/varmint/src/ferret.ts
@@ -235,7 +235,9 @@ export class Ferret {
 			},
 			for: (unSafeSubKey: string) => {
 				if (this.mode !== `off`) {
-					this.filesTouched.set(key, new Set())
+					if (!this.filesTouched.has(key)) {
+						this.filesTouched.set(key, new Set())
+					}
 					if (
 						mgr.storage.initialized &&
 						!mgr.storage.getItem(`list${SBS}${listName}`)

--- a/packages/varmint/src/squirrel.ts
+++ b/packages/varmint/src/squirrel.ts
@@ -203,7 +203,9 @@ export class Squirrel {
 			},
 			for: (unSafeSubKey: string) => {
 				if (this.mode !== `off`) {
-					this.filesTouched.set(key, new Set())
+					if (!this.filesTouched.has(key)) {
+						this.filesTouched.set(key, new Set())
+					}
 					if (
 						mgr.storage.initialized &&
 						!mgr.storage.getItem(`list${SBS}${listName}`)
@@ -260,7 +262,6 @@ export class Squirrel {
 	}
 
 	public flush(...args: string[]): void {
-		console.log(this.filesTouched)
 		for (const [key, filesTouched] of this.filesTouched.entries()) {
 			if (args.length === 0 || args.includes(key)) {
 				const subDir = path.join(this.baseDir, key)


### PR DESCRIPTION
## Summary

- accumulate touched fixture cases across repeated .for() calls
- add Squirrel and Ferret regressions covering retained and stale cases
- replace permissive local recording defaults with strict replay and explicit recording guidance
- document safe wrapper boundaries, semantic identity, supplemental fingerprints, secrets, replay layering, source-control provenance, deterministic injection, cleanup scope, and concurrent-writer isolation
- include separate patch Changesets for the flush fix and agent-guide expansion

## Testing

- focused Vitest flush suite
- TypeScript
- ESLint
- type-aware Oxlint
- dprint
- Changesets status validation
- git diff --check
- all pull-request CI checks