### PR TITLE
Pin published versions in Vigilance testbeds

### DIFF
--- a/scripts/vigilance-bot.bun.ts
+++ b/scripts/vigilance-bot.bun.ts
@@ -415,7 +415,7 @@ async function prepareTestbed(
 	await fs.rm(testbedPath, { force: true, recursive: true })
 	await fs.mkdir(testbedPath, { recursive: true })
 	const dependencies = Object.fromEntries(
-		publishedPackages.map((pkg) => [pkg.name, `latest`]),
+		publishedPackages.map((pkg) => [pkg.name, pkg.latestPublishedVersion]),
 	)
 	const packageJson = {
 		name: `wayforge-vigilance-testbed`,


### PR DESCRIPTION
## Summary

Pin each Vigilance testbed dependency to the exact version already returned by `pnpm view`, instead of independently resolving the `latest` tag again.

The post-release Vigilance run queried `hamr@4.0.1`, but the testbed install resolved stale `hamr@4.0.0` metadata and regenerated PR #7197. Reusing `latestPublishedVersion` ensures the installed graph matches the version Vigilance reports auditing and turns registry propagation inconsistencies into an explicit install failure instead of a false finding.

## Verification

- `pnpm fmt`
- `pnpm lint:deps`
- type-aware Oxlint on `scripts/vigilance-bot.bun.ts`
- Bun bundle check